### PR TITLE
Dispute is only available on fiatsent or active

### DIFF
--- a/.specify/v1-reference/ORDER_STATES.md
+++ b/.specify/v1-reference/ORDER_STATES.md
@@ -478,12 +478,10 @@ The trade detail screen shows different action buttons based on the current stat
 ### WAITING_BUYER_INVOICE (as Buyer)
 - **Add Invoice** - Primary button
 - **Cancel** - Destructive
-- **Dispute** - Warning
 
 ### WAITING_PAYMENT (as Seller)
 - **Pay Hold Invoice** - Primary button (shows QR/invoice)
 - **Cancel** - Destructive
-- **Dispute** - Warning
 
 ### PAYMENT_FAILED (as Seller)
 - **Retry Payment** - Primary button


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * The Dispute action button has been removed from availability during specific order stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->