### PR TITLE
fix: correct v1-reference docs (BIP-39 mnemonic and encrypted messaging)

### DIFF
--- a/.specify/v1-reference/AUTHENTICATION.md
+++ b/.specify/v1-reference/AUTHENTICATION.md
@@ -45,7 +45,7 @@ App Launch
 │                    KEY GENERATION                                │
 └─────────────────────────────────────────────────────────────────┘
 
-1. Generate 12-word BIP-39 mnemonic (entropy: 256 bits)
+1. Generate 12-word BIP-39 mnemonic (entropy: 128 bits)
 2. Derive BIP-32 extended private key from mnemonic
 3. Store mnemonic in secure storage (encrypted)
 4. Store extended private key in secure storage

--- a/.specify/v1-reference/AUTHENTICATION.md
+++ b/.specify/v1-reference/AUTHENTICATION.md
@@ -45,7 +45,7 @@ App Launch
 │                    KEY GENERATION                                │
 └─────────────────────────────────────────────────────────────────┘
 
-1. Generate 24-word BIP-39 mnemonic (entropy: 256 bits)
+1. Generate 12-word BIP-39 mnemonic (entropy: 256 bits)
 2. Derive BIP-32 extended private key from mnemonic
 3. Store mnemonic in secure storage (encrypted)
 4. Store extended private key in secure storage
@@ -134,7 +134,7 @@ Note: Trade index 0 is the master identity key, index 1 is an ephemeral temp key
 **Sections:**
 
 #### 1. Secret Words Card
-- Displays 24-word BIP-39 mnemonic
+- Displays 12-word BIP-39 mnemonic
 - **Masking:** Shows first 2 + last 2 words, middle masked as `••• ••• ••• •••`
 - **Toggle:** Eye icon to show/hide full mnemonic
 - **Info dialog:** Explains what secret words are
@@ -199,7 +199,7 @@ class KeyManager {
 class KeyDerivator {
   // Derivation path: m/44'/1237'/0' (NIP-06 compliant for Nostr)
   
-  String generateMnemonic();           // BIP-39, 24 words
+  String generateMnemonic();           // BIP-39, 12 words
   bool isMnemonicValid(String mnemonic);
   String masterPrivateKeyFromMnemonic(String mnemonic);
   String extendedKeyFromMnemonic(String mnemonic);  // BIP-32 base58
@@ -365,7 +365,7 @@ class BackupReminderNotifier extends StateNotifier<bool> {
 ## Data Storage
 
 ### Secure Storage (KeyStorage)
-- **Mnemonic:** 24-word BIP-39 seed phrase
+- **Mnemonic:** 12-word BIP-39 seed phrase
 - **Master Key:** BIP-32 extended private key (base58)
 - **Trade Key Index:** Next index to use
 - **Backend:** Platform-specific secure storage (iOS Keychain, Android Keystore)

--- a/.specify/v1-reference/ENCRYPTED_IMAGE_MESSAGING_IMPLEMENTATION.md
+++ b/.specify/v1-reference/ENCRYPTED_IMAGE_MESSAGING_IMPLEMENTATION.md
@@ -6,9 +6,9 @@ This document details the complete implementation of encrypted file messaging fo
 
 ### Supported File Types
 
-- **Images**: JPG, PNG, GIF, WEBP (with auto-preview)
-- **Documents**: PDF, DOC, TXT, RTF
-- **Videos**: MP4, MOV, AVI, WEBM
+- **Images**: JPG, PNG, JPEG
+- **Documents**: PDF, DOC, DOCX
+- **Videos**: MP4, MOV, AVI
 - **Size limit**: 25MB per file
 
 ## Table of Contents
@@ -573,17 +573,6 @@ final Map<String, EncryptedFileUploadResult> _fileMetadata = {};
 - **Session-based**: Cache tied to current app session only
 - **Size**: No explicit size limits (relies on system memory management)
 
-### TODO: Persistent Cache Implementation
-
-A session-linked persistent cache system has been developed but not yet integrated:
-
-- **SessionFileCache**: Stores files per trading session (72h lifetime)
-- **Automatic Cleanup**: Files deleted when sessions expire 
-- **Organized Storage**: Files grouped by type (images/documents/videos)
-- **Metadata Preservation**: JSON metadata stored alongside file data
-
-This will be implemented in a future update to provide better user experience.
-
 ### Performance Optimizations
 
 1. **Image Compression**: 85% quality during selection
@@ -648,140 +637,19 @@ testWidgets('should upload and display encrypted image', (tester) async {
 
 ### 1. Persistent Caching
 
-**Current Limitation**: Images re-download on app restart
+**Problem**: Every time the app restarts or a chat is reopened, all files are re-downloaded from Blossom. With files up to 25 MB this is a poor user experience.
 
-**Proposed Solution**:
-```dart
-class PersistentImageCache {
-  static const String _cacheDir = 'encrypted_images';
-  
-  Future<void> cacheImage(String messageId, Uint8List data) async {
-    final dir = await getApplicationCacheDirectory();
-    final file = File('${dir.path}/$_cacheDir/$messageId.enc');
-    await file.writeAsBytes(data);
-  }
-  
-  Future<Uint8List?> getCachedImage(String messageId) async {
-    final dir = await getApplicationCacheDirectory();
-    final file = File('${dir.path}/$_cacheDir/$messageId.enc');
-    if (await file.exists()) {
-      return await file.readAsBytes();
-    }
-    return null;
-  }
-}
-```
+**Security concern with the current proposal**: The `MediaCacheMixin` stores already-decrypted bytes in memory. The proposed `PersistentImageCache` in the doc would write those same decrypted bytes to disk as `.enc` files — the extension is misleading, they are not encrypted. Any app or process with filesystem access could read the files in plain.
 
-### 2. Nostr Authentication for Blossom
+**Correct approach**: Cache files on disk as downloaded from Blossom — still encrypted with ChaCha20-Poly1305. Decrypt only at display time. This way the on-disk cache has the same security as the file on the server: useless without the conversation's shared key.
 
-**Current**: Anonymous uploads to public servers
+The concrete design (directory structure, expiration policy, size limits) is yet to be defined, but the principle is clear: cache the encrypted blob, not the decrypted content.
 
-**Proposed**: NIP-98 HTTP Auth for Blossom
-```dart
-class AuthenticatedBlossomClient {
-  final NostrKeyPairs keyPair;
-  
-  Future<String> uploadWithAuth(Uint8List data) async {
-    final authEvent = await createNIP98AuthEvent(
-      url: '$serverUrl/upload',
-      method: 'PUT',
-      body: data,
-    );
-    
-    final headers = {
-      'Authorization': 'Nostr ${base64Encode(utf8.encode(jsonEncode(authEvent)))}',
-      'Content-Type': 'application/octet-stream',
-    };
-    
-    // ... rest of upload logic
-  }
-}
-```
+### 2. Download Progress Indication
 
-### 3. Image Compression Options
+**Problem**: Files up to 25 MB download with no visual feedback. The user cannot tell whether a download is in progress, stalled, or how much remains.
 
-```dart
-enum CompressionLevel { low, medium, high, lossless }
-
-class ImageCompressionService {
-  static Future<Uint8List> compress(
-    Uint8List imageData, 
-    CompressionLevel level
-  ) async {
-    switch (level) {
-      case CompressionLevel.low:
-        return await FlutterImageCompress.compressWithList(
-          imageData, quality: 95
-        );
-      // ... other levels
-    }
-  }
-}
-```
-
-### 4. Multiple Image Selection
-
-```dart
-Future<void> _selectMultipleImages() async {
-  final pickedFiles = await _imagePicker.pickMultiImage();
-  
-  for (final file in pickedFiles) {
-    await _uploadSingleImage(file);
-  }
-}
-```
-
-### 5. Video Support
-
-```dart
-class EncryptedVideoUploadService {
-  Future<EncryptedVideoUploadResult> uploadEncryptedVideo({
-    required File videoFile,
-    required Uint8List sharedKey,
-  }) async {
-    // Similar to image upload but for video files
-  }
-}
-```
-
-### 6. Download Progress Indication
-
-```dart
-class ProgressTrackingDownloader {
-  Stream<DownloadProgress> downloadWithProgress(String url) async* {
-    final request = http.Request('GET', Uri.parse(url));
-    final response = await request.send();
-    
-    final contentLength = response.contentLength ?? 0;
-    int downloadedBytes = 0;
-    
-    await for (final chunk in response.stream) {
-      downloadedBytes += chunk.length;
-      yield DownloadProgress(downloadedBytes, contentLength);
-    }
-  }
-}
-```
-
-### 7. Image Gallery View
-
-```dart
-class ImageGalleryScreen extends StatelessWidget {
-  final List<EncryptedImageMessage> images;
-  
-  @override
-  Widget build(BuildContext context) {
-    return PageView.builder(
-      itemCount: images.length,
-      itemBuilder: (context, index) {
-        return InteractiveViewer(
-          child: images[index],
-        );
-      },
-    );
-  }
-}
-```
+**Solution**: A `Stream<double>` (0.0 to 1.0) consumed by the download widget to display a progress bar or percentage. When the server does not send a `Content-Length` header, fall back to an indeterminate progress indicator instead of a percentage.
 
 ---
 
@@ -790,6 +658,7 @@ class ImageGalleryScreen extends StatelessWidget {
 The encrypted file messaging system provides a robust, secure, and user-friendly way to share multiple file types in Mostro Mobile's P2P chat. The implementation balances security, performance, and usability while maintaining compatibility with the existing Mostro protocol and Nostr ecosystem.
 
 Key achievements:
+
 - ✅ End-to-end encryption using ChaCha20-Poly1305
 - ✅ Support for images, documents (PDF/DOC/TXT), and videos (MP4/MOV)
 - ✅ Decentralized storage via Blossom protocol
@@ -801,5 +670,3 @@ Key achievements:
 - ✅ Zero analyzer errors and passing test suite
 
 **Current Status**: The system is production-ready with temporary cache storage. Files are re-downloaded after app restart but remain secure and functional.
-
-**Next Steps**: Integration of persistent cache system (already implemented) for improved user experience with file persistence across app sessions.


### PR DESCRIPTION
  - Fix mnemonic spec to use 12-word BIP-39 instead of 24                                                             
  - Remove fictional SessionFileCache section (never existed in code)
  - Rewrite Future Improvements with correct persistent caching approach (cache encrypted blobs, not decrypted)
  - Add download progress indication improvement
  - Update supported file types: images, documents (PDF/DOC/TXT), videos (MP4/MOV)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authentication documentation to reflect 12-word recovery phrase format for account backups
  * Clarified supported file formats for encrypted messaging: images (JPG, PNG, JPEG), documents (PDF, DOC, DOCX), and videos (MP4, MOV, AVI)
  * Documented upcoming download progress indication feature for improved file transfer visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->