### PR TITLE
docs: clarify dispute status taxonomy in DISPUTE_SYSTEM.md

### DIFF
--- a/.specify/v1-reference/DISPUTE_SYSTEM.md
+++ b/.specify/v1-reference/DISPUTE_SYSTEM.md
@@ -230,7 +230,7 @@ Four independent status systems coexist during a dispute. Confusing them causes 
 
 ---
 
-## 9) Cross references
+## 9) Cross-references
 
 | Topic | Document |
 |-------|----------|

--- a/.specify/v1-reference/DISPUTE_SYSTEM.md
+++ b/.specify/v1-reference/DISPUTE_SYSTEM.md
@@ -44,17 +44,40 @@
 
 ### Trade Detail → Dispute button
 - `TradeDetailScreen` surfaces a **Dispute** button whenever the action set contains `actions.Action.dispute` and no dispute is already in progress.
-- Tapping Dispute prompts a confirmation dialog; if confirmed, it calls `DisputeRepository.createDispute(orderId)` (see §2) and shows a snackbar on success/failure.
+- Tapping Dispute prompts a confirmation dialog; if confirmed, it calls `DisputeRepository.createDispute(orderId)` (see §3) and shows a snackbar on success/failure.
 - Once a dispute exists (`tradeState.dispute?.disputeId != null`), the CTA switches to **View dispute** which links to `/dispute_details/:disputeId`.
 
 ### Automatic navigation via Mostro events
 - `AbstractMostroNotifier` listens to Mostro DM actions:
   - `disputeInitiatedByYou`, `disputeInitiatedByPeer`, `adminTookDispute`, `adminSettled`, `adminCanceled` all push `/trade_detail/:orderId` to keep both parties on the trade screen when a dispute state changes.
-  - Admin assignment (`adminTookDispute`) also updates the session's admin shared key (see §3), enabling the dispute chat to decrypt admin messages.
+  - Admin assignment (`adminTookDispute`) also updates the session's admin shared key (see §4), enabling the dispute chat to decrypt admin messages.
 
 ---
 
-## 2) Repository, data model, and dispute creation
+## 2) Status taxonomy
+
+Four independent status systems coexist during a dispute. Confusing them causes implementation bugs.
+
+| Layer | Where it lives | Values during dispute lifecycle | Notes |
+|---|---|---|---|
+| **Order status (public)** | Kind 38383 event, tag `s` | **Does not change** when a dispute opens. Updates to `success` (admin-settle) or `canceled` (admin-cancel) only at resolution. | The public order book never shows `dispute`. |
+| **Order status (internal + DMs)** | Mostrod database + gift-wrapped DMs to users | Changes to `dispute` when a dispute is opened (`setup_dispute()` in mostro-core). Then to `success` or `canceled` at resolution. | This is a real protocol order status — mostrod checks `Status::Dispute` before allowing admin-settle or admin-cancel. It reaches clients via gift wraps but is never published in kind 38383 events. |
+| **Dispute status (protocol)** | Kind 38386 event, tag `s` | `initiated` → `in-progress` → `settled` \| `seller-refunded` | Authoritative source: `mostro-core::dispute::Status` enum. |
+| **Local UX dispute status (v1 app)** | `Dispute.status` string field set by `OrderState.updateWith()` | `in-progress`, `resolved`, `seller-refunded`, `closed` | **Never sent to Mostro.** Client-side labels for UI rendering. `resolved` and `closed` do not exist in the protocol. |
+
+**Mapping between protocol and v1 UX statuses:**
+
+| Protocol trigger | Protocol dispute status (kind 38386) | Protocol order status (DM) | V1 local UX `Dispute.status` |
+|---|---|---|---|
+| User opens dispute | `initiated` | `dispute` | *(not overwritten — keeps value from action)* |
+| Admin takes dispute | `in-progress` | `dispute` (unchanged) | `in-progress` |
+| Admin settles | `settled` | `success` | `resolved` |
+| Admin cancels | `seller-refunded` | `canceled` | `seller-refunded` |
+| User completes trade / cooperative cancel | *(no protocol update to kind 38386 from client — mostrod calls `close_dispute_after_user_resolution()` server-side)* | `success` / `canceled` | `closed` |
+
+---
+
+## 3) Repository, data model, and dispute creation
 
 ### `DisputeRepository`
 - `createDispute(orderId)` builds a `MostroMessage(action: Action.dispute, id: orderId)` and wraps it using NIP-59 gift wrap with the user's `tradeKey` and the configured Mostro pubkey (`settingsProvider.mostroPublicKey`).
@@ -63,22 +86,25 @@
 - `getUserDisputes()` and `getDispute(disputeId)` never hit a remote endpoint. They walk all `sessionNotifierProvider` sessions, read each `orderNotifierProvider(orderId)` and collect `OrderState.dispute` objects.
 
 ### Data types
-- `Dispute` carries protocol-level fields (IDs, status, admin pubkey, timestamps, action) and implements `Payload` so Mostro DMs can embed it.
+- `Dispute` implements `Payload` so Mostro DMs can embed it. Its `status` field is a free-form `String?` — **not** a protocol enum. When a `Dispute` arrives from Mostro (e.g., inside a `dispute-initiated-by-you` DM), the status reflects the protocol dispute status (e.g., `initiated`). However, `OrderState.updateWith()` later overwrites this field with local UX values (`resolved`, `closed`) that do not exist in the protocol. See §2 Status taxonomy for the full mapping.
 - `DisputeData` is the UI view model (order ID, counterparty, user role, `DisputeDescriptionKey`, etc.). It derives `descriptionKey` from normalized statuses and stores whether the current user initiated the dispute.
 - `DisputeDescriptionKey` drives localized copy ("You opened a dispute", "Waiting for admin assignment", "Admin closed the dispute"...).
 
 ### Status & action normalization (from `OrderState`)
-- Actions `disputeInitiatedByYou`, `disputeInitiatedByPeer`, `dispute`, `adminTakeDispute`, `adminTookDispute` map to `Status.dispute`.
-- `OrderState.updateWith()` enriches disputes:
-  - Stamps `createdAt` from the DM timestamp for sorting.
-  - `adminTookDispute` sets `status: in-progress`, saves `adminPubkey`, and triggers `Session.setAdminPeer`.
-  - `adminSettled` ⇒ `status: resolved`, `action: admin-settled`.
-  - `adminCanceled` ⇒ `status: seller-refunded`, `action: admin-canceled`.
-  - User-completed or cooperative-cancel terminal states auto-close the dispute (`status: closed`, `action: user-completed` or `cooperative-cancel`).
+
+**Order status mapping:**
+- Actions `disputeInitiatedByYou`, `disputeInitiatedByPeer`, `dispute`, `adminTakeDispute`, `adminTookDispute` set the **order status** to `Status.dispute` in the v1 app. This mirrors the real protocol behavior: mostrod sets the internal order status to `dispute` via `setup_dispute()`, though this status is never published in kind 38383 public events.
+
+**Local UX dispute status mapping** (via `OrderState.updateWith()` writing to `Dispute.status`):
+- Stamps `createdAt` from the DM timestamp for sorting.
+- `adminTookDispute` → local `Dispute.status = 'in-progress'`, saves `adminPubkey`, triggers `Session.setAdminPeer`. *(Matches protocol dispute status `in-progress`.)*
+- `adminSettled` → local `Dispute.status = 'resolved'`, `action = 'admin-settled'`. *(Protocol dispute status is `settled`, not `resolved`. `resolved` is a v1 UX-only label.)*
+- `adminCanceled` → local `Dispute.status = 'seller-refunded'`, `action = 'admin-canceled'`. *(Matches protocol dispute status `seller-refunded`.)*
+- User-completed or cooperative-cancel terminal order states → local `Dispute.status = 'closed'`, `action = 'user-completed'` or `'cooperative-cancel'`. *(`closed` does not exist in the protocol. The kind 38386 dispute event is updated by mostrod via `close_dispute_after_user_resolution()` with status `settled` or `seller-refunded`, but the v1 app does not read that event — it uses its own local label.)*
 
 ---
 
-## 3) Session & admin shared key handshake
+## 4) Session & admin shared key handshake
 
 - Sessions (`lib/data/models/session.dart`) store both the counterparty shared key (`peer`) and an optional `adminSharedKey`.
 - When `adminTookDispute` arrives, `AbstractMostroNotifier` extracts the admin pubkey from the event payload (`Peer`) or existing `Dispute.adminPubkey`, calls `sessionNotifier.updateSession(orderId, setAdminPeer)` and recomputes the shared key via ECDH.
@@ -87,7 +113,7 @@
 
 ---
 
-## 4) Dispute list UX & unread state
+## 5) Dispute list UX & unread state
 
 ### `DisputesList`
 - Driven by `userDisputeDataProvider`, which memoizes `DisputeData` list, sorts by `createdAt` DESC, and rebuilds whenever sessions or order states change.
@@ -108,7 +134,7 @@
 
 ---
 
-## 5) Dispute detail & chat screen
+## 6) Dispute detail & chat screen
 
 ### `DisputeChatScreen`
 - Receives `disputeId` from GoRouter, `watch(disputeDetailsProvider(disputeId))` to load the latest `Dispute` (or show "not found").
@@ -116,14 +142,14 @@
 - Converts the domain model (`Dispute`) into `DisputeData` using both `sessionNotifierProvider` and `orderNotifierProvider` to pull role/counterparty data.
 - Layout:
   1. `DisputeCommunicationSection` → `DisputeMessagesList`
-  2. `DisputeMessageInput` rendered **only** when `DisputeData.status == 'in-progress'`. Initiated / resolved disputes become read-only logs.
+  2. `DisputeMessageInput` rendered **only** when the local UX `DisputeData.status == 'in-progress'`. Disputes with any other local status (`initiated`, `resolved`, `seller-refunded`, `closed`) become read-only logs.
 
 ### `DisputeMessagesList`
 - Combines informational UI and chat messages into a single scroll view:
   - `SliverToBoxAdapter` shows a blue "Admin assigned" card if status = `in-progress` and there are no messages yet.
   - First list item is always `DisputeInfoCard` (order ID, dispute ID, user role, counterparty nickname via `nickNameProvider`).
   - Remainder: `DisputeMessageBubble` entries sorted by timestamp, deduped by message ID.
-  - For resolved statuses (`resolved`, `seller-refunded`, `closed`), an extra "Chat closed" lock banner is appended.
+  - For terminal local UX statuses (`resolved`, `seller-refunded`, `closed`), an extra "Chat closed" lock banner is appended. These are all v1 app-local values; see §2 for protocol equivalents.
 - Handles empty chat gracefully: waiting-for-admin copy, no-messages-yet placeholders, etc.
 - Auto-scrolls to the bottom whenever new messages arrive and the user is near the bottom.
 
@@ -134,7 +160,7 @@
 
 ---
 
-## 6) Messaging pipeline & storage
+## 7) Messaging pipeline & storage
 
 ### Provider & state
 - `disputeChatNotifierProvider` is a `StateNotifierProvider.family<DisputeChatNotifier, DisputeChatState, String>`.
@@ -172,13 +198,13 @@
 
 ---
 
-## 7) Dispute lifecycle & order status integration
+## 8) Dispute lifecycle & order status integration
 
 ### Initiation
 1. User taps **Dispute** in Trade Detail.
 2. `DisputeRepository.createDispute` sends the gift wrap event.
 3. Mostro responds with `disputeInitiatedByYou` (for initiator) and `disputeInitiatedByPeer` (for the counterpart).
-4. `OrderState` stores the `Dispute` payload, `status` transitions to `Status.dispute`, and UI shows the red "Dispute" chip.
+4. `OrderState` stores the `Dispute` payload and transitions the **order status** to `Status.dispute`. This is a real protocol order status — mostrod also sets it internally via `setup_dispute()` — but it is only communicated via DMs, never in kind 38383 public events. The UI shows the red "Dispute" chip.
 
 ### Admin assignment
 1. When an admin takes the dispute, Mostro sends `adminTookDispute` with a `Peer` payload representing the admin.
@@ -187,9 +213,16 @@
 4. `DisputeMessagesList` shows the blue "Admin assigned" card until the first message arrives.
 
 ### Resolution paths
-- **Admin settled** (`adminSettled`): `Dispute.status = resolved`, `action = admin-settled`. `DisputeMessagesList` hides the input and shows the lock banner. `DisputeStatusContent` renders "Admin released the sats".
-- **Admin canceled** (`adminCanceled`): `status = seller-refunded`, `action = admin-canceled`.
-- **User completed** (Lightning payment succeeded) or **cooperative cancel**: auto-close logic in `OrderState` sets `status = closed`, `action = user-completed / cooperative-cancel`. No admin involvement required.
+- **Admin settled** (`adminSettled`):
+  - *Protocol*: dispute event (kind 38386) → `settled`; order event (kind 38383) → `success`; order DM status → `success`.
+  - *V1 app*: local `Dispute.status = 'resolved'` (UX-only, does not exist in protocol), `action = 'admin-settled'`.
+  - *UI effect*: `DisputeMessagesList` hides the input and shows the lock banner. `DisputeStatusContent` renders "Admin released the sats".
+- **Admin canceled** (`adminCanceled`):
+  - *Protocol*: dispute event (kind 38386) → `seller-refunded`; order event (kind 38383) → `canceled`; order DM status → `canceled`.
+  - *V1 app*: local `Dispute.status = 'seller-refunded'` (matches protocol), `action = 'admin-canceled'`.
+- **User completed / cooperative cancel** (trade resolves without admin):
+  - *Protocol*: mostrod calls `close_dispute_after_user_resolution()` updating the kind 38386 event to `settled` (release) or `seller-refunded` (cancel). Order events update normally.
+  - *V1 app*: local `Dispute.status = 'closed'` (UX-only, does not exist in protocol), `action = 'user-completed'` or `'cooperative-cancel'`. The app does not read the updated kind 38386 event.
 
 ### Unread + notification flows
 - Because `DisputeReadStatusService` works off timestamps, any new message (admin or user) increments the badge automatically until the user opens the chat.
@@ -197,7 +230,7 @@
 
 ---
 
-## 8) Cross references
+## 9) Cross references
 
 | Topic | Document |
 |-------|----------|


### PR DESCRIPTION
  - Add Status taxonomy distinguishing four status layers: order public (kind 38383), order internal/DMs, dispute protocol (kind 38386), and v1 local UX
  - Add protocol-to-UX mapping table showing resolved/closed are app-only labels
  - Clarify Dispute.status is a free-form string overwritten by OrderState.updateWith(), not a protocol enum
  - Split status normalization into order status mapping vs local UX dispute status mapping
  - Clarify Status.dispute is a real protocol order status sent via DMs but never published in kind 38383
  - Expand resolution paths to show protocol and v1 app effects separately

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Redesigned dispute status taxonomy and clarified mappings between protocol events and local UX labels.
  * Explained how local UX labels drive interface behavior (when message input appears and when chat shows a closed banner).
  * Expanded dispute lifecycle and resolution guidance to contrast protocol vs. app-local outcomes and updated cross-references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->