### PR TITLE
feat(l10n): add backupConfirmCheckbox key to all 5 locales

### DIFF
--- a/lib/features/account/screens/account_screen.dart
+++ b/lib/features/account/screens/account_screen.dart
@@ -8,6 +8,7 @@ import 'package:mostro/core/app_theme.dart';
 import 'package:mostro/core/services/identity_service.dart';
 import 'package:mostro/features/account/providers/backup_reminder_provider.dart';
 import 'package:mostro/features/account/providers/privacy_mode_provider.dart';
+import 'package:mostro/l10n/app_localizations.dart';
 
 /// Account screen — Route `/key_management`.
 ///
@@ -559,7 +560,7 @@ class _BackupConfirmRowState extends State<_BackupConfirmRow> {
             const SizedBox(width: AppSpacing.sm),
             Expanded(
               child: Text(
-                'I have written down my words and backed them up securely',
+                AppLocalizations.of(context).backupConfirmCheckbox,
                 style: Theme.of(context).textTheme.bodySmall,
               ),
             ),

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -195,5 +195,6 @@
   "retry": "Erneut versuchen",
   "disableRelayLabel": "Relay {url} deaktivieren",
   "enableRelayLabel": "Relay {url} aktivieren",
-  "removeRelayTooltip": "Relay entfernen"
+  "removeRelayTooltip": "Relay entfernen",
+  "backupConfirmCheckbox": "Ich habe meine Wörter aufgeschrieben und sicher gespeichert"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -409,5 +409,7 @@
     "placeholders": {"url": {"type": "String"}}
   },
   "removeRelayTooltip": "Remove relay",
-  "@removeRelayTooltip": {"description": "Tooltip for the remove-relay icon button"}
+  "@removeRelayTooltip": {"description": "Tooltip for the remove-relay icon button"},
+  "backupConfirmCheckbox": "I have written down my words and backed them up securely",
+  "@backupConfirmCheckbox": {"description": "Label for the backup confirmation checkbox on the Account screen"}
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -195,5 +195,6 @@
   "retry": "Reintentar",
   "disableRelayLabel": "Desactivar relay {url}",
   "enableRelayLabel": "Activar relay {url}",
-  "removeRelayTooltip": "Eliminar relay"
+  "removeRelayTooltip": "Eliminar relay",
+  "backupConfirmCheckbox": "He anotado mis palabras y las he guardado de forma segura"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -195,5 +195,6 @@
   "retry": "Réessayer",
   "disableRelayLabel": "Désactiver le relais {url}",
   "enableRelayLabel": "Activer le relais {url}",
-  "removeRelayTooltip": "Supprimer le relais"
+  "removeRelayTooltip": "Supprimer le relais",
+  "backupConfirmCheckbox": "J'ai noté mes mots et les ai sauvegardés en lieu sûr"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -195,5 +195,6 @@
   "retry": "Riprova",
   "disableRelayLabel": "Disabilita relay {url}",
   "enableRelayLabel": "Abilita relay {url}",
-  "removeRelayTooltip": "Rimuovi relay"
+  "removeRelayTooltip": "Rimuovi relay",
+  "backupConfirmCheckbox": "Ho annotato le mie parole e le ho salvate in modo sicuro"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1189,6 +1189,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Remove relay'**
   String get removeRelayTooltip;
+
+  /// Label for the backup confirmation checkbox on the Account screen
+  ///
+  /// In en, this message translates to:
+  /// **'I have written down my words and backed them up securely'**
+  String get backupConfirmCheckbox;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -599,4 +599,8 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get removeRelayTooltip => 'Relay entfernen';
+
+  @override
+  String get backupConfirmCheckbox =>
+      'Ich habe meine Wörter aufgeschrieben und sicher gespeichert';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -591,4 +591,8 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get removeRelayTooltip => 'Remove relay';
+
+  @override
+  String get backupConfirmCheckbox =>
+      'I have written down my words and backed them up securely';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -599,4 +599,8 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get removeRelayTooltip => 'Eliminar relay';
+
+  @override
+  String get backupConfirmCheckbox =>
+      'He anotado mis palabras y las he guardado de forma segura';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -603,4 +603,8 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get removeRelayTooltip => 'Supprimer le relais';
+
+  @override
+  String get backupConfirmCheckbox =>
+      'J\'ai noté mes mots et les ai sauvegardés en lieu sûr';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -599,4 +599,8 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get removeRelayTooltip => 'Rimuovi relay';
+
+  @override
+  String get backupConfirmCheckbox =>
+      'Ho annotato le mie parole e le ho salvate in modo sicuro';
 }


### PR DESCRIPTION
Add the backup confirmation checkbox label to app_en/es/de/fr/it.arb
and update _BackupConfirmRow to use AppLocalizations instead of the
hardcoded English string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added multi-language support for the backup confirmation checkbox with translations in German, English, Spanish, French, and Italian.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->