### PR TITLE
Feat/persistence db init

### DIFF
--- a/lib/features/order/providers/trade_state_provider.dart
+++ b/lib/features/order/providers/trade_state_provider.dart
@@ -36,3 +36,22 @@ final tradeStatusProvider =
     if (info != null) yield info.status;
   }
 });
+
+/// Loads the buyer/seller role for a trade from the persistent DB.
+///
+/// Returns `true` when the local user is the buyer, `false` for seller, or
+/// `null` while loading / when no record exists (trade was never taken on
+/// this device, or [initDb] has not been called yet).
+///
+/// Consumed by [TradeDetailScreen] as a fallback when [tradeRoleProvider]
+/// has no in-memory entry for the order — i.e. the app was restarted after
+/// the trade was already taken in a previous session.
+final tradeRoleFromDbProvider =
+    FutureProvider.family.autoDispose<bool?, String>((ref, orderId) async {
+  final role = await orders_api.getTradeRole(orderId: orderId);
+  return switch (role) {
+    TradeRole.buyer => true,
+    TradeRole.seller => false,
+    null => null,
+  };
+});

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -235,9 +235,18 @@ class _TradeDetailScreenState extends ConsumerState<TradeDetailScreen> {
     final green = colors?.mostroGreen ?? const Color(0xFF8CC63F);
     final textSec = colors?.textSecondary ?? const Color(0xFFB0B3C6);
 
-    // Derive role from provider (set by TakeOrderScreen before navigation).
+    // Derive role: in-memory map (set by TakeOrderScreen in this session) takes
+    // priority; fall back to the DB-backed provider so reopened trades after an
+    // app restart still show the correct buyer/seller actions.
     final roleMap = ref.watch(tradeRoleProvider);
-    final isBuyer = roleMap[widget.orderId] ?? true;
+    final bool isBuyer;
+    if (roleMap.containsKey(widget.orderId)) {
+      isBuyer = roleMap[widget.orderId]!;
+    } else {
+      final dbRole =
+          ref.watch(tradeRoleFromDbProvider(widget.orderId)).valueOrNull;
+      isBuyer = dbRole ?? true; // default to buyer while DB result is loading
+    }
 
     // Derive trade status from the polled order status.
     final orderStatus = ref.watch(tradeStatusProvider(widget.orderId)).valueOrNull

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -621,12 +621,14 @@ class AppLocalizationsDe extends AppLocalizations {
   String get cancelRequestSent => 'Abbruchanfrage gesendet';
 
   @override
-  String get cancelRequestFailed => 'Abbrechen fehlgeschlagen. Bitte erneut versuchen.';
+  String get cancelRequestFailed =>
+      'Abbrechen fehlgeschlagen. Bitte erneut versuchen.';
 
   @override
   String get fiatSentFailed =>
       'Fiat-Zahlung konnte nicht bestätigt werden. Bitte erneut versuchen.';
 
   @override
-  String get releaseFailed => 'Freigabe fehlgeschlagen. Bitte erneut versuchen.';
+  String get releaseFailed =>
+      'Freigabe fehlgeschlagen. Bitte erneut versuchen.';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -621,12 +621,14 @@ class AppLocalizationsEs extends AppLocalizations {
   String get cancelRequestSent => 'Solicitud de cancelación enviada';
 
   @override
-  String get cancelRequestFailed => 'No se pudo cancelar. Por favor, inténtelo de nuevo.';
+  String get cancelRequestFailed =>
+      'No se pudo cancelar. Por favor, inténtelo de nuevo.';
 
   @override
   String get fiatSentFailed =>
       'Error al marcar el fiat como enviado. Por favor, inténtelo de nuevo.';
 
   @override
-  String get releaseFailed => 'Error al liberar. Por favor, inténtelo de nuevo.';
+  String get releaseFailed =>
+      'Error al liberar. Por favor, inténtelo de nuevo.';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -625,7 +625,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get cancelRequestSent => 'Demande d\'annulation envoyée';
 
   @override
-  String get cancelRequestFailed => 'Échec de l\'annulation. Veuillez réessayer.';
+  String get cancelRequestFailed =>
+      'Échec de l\'annulation. Veuillez réessayer.';
 
   @override
   String get fiatSentFailed =>

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -624,7 +624,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get cancelRequestFailed => 'Annullamento fallito. Riprovare.';
 
   @override
-  String get fiatSentFailed => 'Impossibile contrassegnare il fiat come inviato. Riprovare.';
+  String get fiatSentFailed =>
+      'Impossibile contrassegnare il fiat come inviato. Riprovare.';
 
   @override
   String get releaseFailed => 'Rilascio fallito. Riprovare.';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,18 +1,28 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:mostro/core/app.dart';
 import 'package:mostro/core/services/identity_service.dart';
 import 'package:mostro/features/walkthrough/providers/first_run_provider.dart';
 import 'package:mostro/features/account/providers/backup_reminder_provider.dart';
 import 'package:mostro/src/rust/frb_generated.dart';
+import 'package:mostro/src/rust/api.dart' as rust_api;
 import 'package:mostro/src/rust/api/nostr.dart' as nostr_api;
 import 'package:mostro/src/rust/api/orders.dart' as orders_api;
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await RustLib.init();
+
+  // Initialize persistent SQLite store. Must come before any trade / order
+  // operations that read or write trade keys and trade records.
+  if (!kIsWeb) {
+    final docsDir = await getApplicationDocumentsDirectory();
+    await rust_api.initDb(path: p.join(docsDir.path, 'mostro.db'));
+  }
 
   // Initialize identity: creates on first launch, reloads on subsequent launches.
   // Must run before Nostr init so the identity key is available for relay auth.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,8 +20,15 @@ Future<void> main() async {
   // Initialize persistent SQLite store. Must come before any trade / order
   // operations that read or write trade keys and trade records.
   if (!kIsWeb) {
-    final docsDir = await getApplicationDocumentsDirectory();
-    await rust_api.initDb(path: p.join(docsDir.path, 'mostro.db'));
+    try {
+      final docsDir = await getApplicationDocumentsDirectory();
+      await rust_api.initDb(path: p.join(docsDir.path, 'mostro.db'));
+    } catch (e, st) {
+      // DB init failure is non-fatal: trade-key and role persistence won't
+      // work for this session, but the app can still browse orders and relay
+      // messages.  All Rust callers already handle db() == None gracefully.
+      debugPrint('[main] DB init failed — running in memory-only mode: $e\n$st');
+    }
   }
 
   // Initialize identity: creates on first launch, reloads on subsequent launches.

--- a/rust/src/api/mod.rs
+++ b/rust/src/api/mod.rs
@@ -11,3 +11,15 @@ pub mod types;
 pub fn get_app_version() -> String {
     env!("CARGO_PKG_VERSION").to_string()
 }
+
+/// Initialise the persistent store.
+///
+/// Must be called once on app startup **before** taking orders or sending
+/// invoices.  On native platforms pass the absolute path to the SQLite file
+/// (e.g. `<app_documents_dir>/mostro.db`).  On WASM `path` is used as the
+/// IndexedDB database name.
+///
+/// Subsequent calls are no-ops.
+pub async fn init_db(path: String) -> anyhow::Result<()> {
+    crate::db::app_db::init_db(&path).await
+}

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -44,20 +44,23 @@ async fn store_trade_key_index(order_id: &str, index: u32) {
     }
 }
 
-/// Return the BIP-32 index for `order_id`.
+/// Return the BIP-32 index for `order_id`, or `None` if not found.
 ///
 /// Lookup order:
 /// 1. In-memory cache (always up-to-date for the current session).
 /// 2. Persistent DB (covers trades taken in a previous session).
-/// 3. Falls back to `0` with a warning if neither source has the value.
-async fn get_trade_key_index(order_id: &str) -> u32 {
+///
+/// Returns `None` when neither source has a record for the order.
+/// Callers must treat `None` as an error rather than silently using index 0,
+/// which would cause signature verification failures on the daemon side.
+async fn get_trade_key_index(order_id: &str) -> Option<u32> {
     // Fast path: in-memory cache.
     if let Some(idx) = trade_key_map()
         .read()
         .ok()
         .and_then(|m| m.get(order_id).copied())
     {
-        return idx;
+        return Some(idx);
     }
     // Slow path: DB (populates cache on hit for subsequent calls).
     if let Some(db) = crate::db::app_db::db() {
@@ -66,14 +69,14 @@ async fn get_trade_key_index(order_id: &str) -> u32 {
                 if let Ok(mut map) = trade_key_map().write() {
                     map.insert(order_id.to_string(), idx);
                 }
-                return idx;
+                return Some(idx);
             }
             Ok(None) => {}
             Err(e) => log::warn!("[orders] DB trade key lookup failed for order={order_id}: {e}"),
         }
     }
-    log::warn!("[orders] trade key not found for order={order_id}, using index 0");
-    0
+    log::warn!("[orders] trade key not found for order={order_id}");
+    None
 }
 
 /// Filter parameters for the order list.
@@ -476,7 +479,8 @@ pub async fn send_invoice(
         None
     };
 
-    let trade_index = get_trade_key_index(&order_id).await;
+    let trade_index = get_trade_key_index(&order_id).await
+        .ok_or_else(|| anyhow::anyhow!("no persisted trade key for order {order_id}"))?;
     let sender_keys = crate::api::identity::get_active_trade_keys(trade_index).await?;
     let mostro_pubkey = nostr_sdk::PublicKey::from_hex(DEFAULT_MOSTRO_PUBKEY)?;
     let event_json = actions::add_invoice(
@@ -503,7 +507,8 @@ pub async fn send_invoice(
 /// Sends a `FiatSent` MostroMessage to the Mostro daemon signed with the trade
 /// key that was used when taking the order.
 pub async fn send_fiat_sent(order_id: String) -> Result<()> {
-    let trade_index = get_trade_key_index(&order_id).await;
+    let trade_index = get_trade_key_index(&order_id).await
+        .ok_or_else(|| anyhow::anyhow!("no persisted trade key for order {order_id}"))?;
     let sender_keys = crate::api::identity::get_active_trade_keys(trade_index).await?;
     let mostro_pubkey = nostr_sdk::PublicKey::from_hex(DEFAULT_MOSTRO_PUBKEY)?;
     let event_json = actions::fiat_sent(&sender_keys, &mostro_pubkey, &order_id, trade_index).await?;
@@ -517,7 +522,8 @@ pub async fn send_fiat_sent(order_id: String) -> Result<()> {
 /// Sends a `Release` MostroMessage to the Mostro daemon signed with the trade
 /// key that was used when taking the order.
 pub async fn release_order(order_id: String) -> Result<()> {
-    let trade_index = get_trade_key_index(&order_id).await;
+    let trade_index = get_trade_key_index(&order_id).await
+        .ok_or_else(|| anyhow::anyhow!("no persisted trade key for order {order_id}"))?;
     let sender_keys = crate::api::identity::get_active_trade_keys(trade_index).await?;
     let mostro_pubkey = nostr_sdk::PublicKey::from_hex(DEFAULT_MOSTRO_PUBKEY)?;
     let event_json = actions::release(&sender_keys, &mostro_pubkey, &order_id, trade_index).await?;
@@ -532,7 +538,8 @@ pub async fn release_order(order_id: String) -> Result<()> {
 /// was taken.  Both parties must cancel for it to take effect; the Mostro daemon
 /// handles the cooperative-cancel state machine.
 pub async fn cancel_order(order_id: String) -> Result<()> {
-    let trade_index = get_trade_key_index(&order_id).await;
+    let trade_index = get_trade_key_index(&order_id).await
+        .ok_or_else(|| anyhow::anyhow!("no persisted trade key for order {order_id}"))?;
     let sender_keys = crate::api::identity::get_active_trade_keys(trade_index).await?;
     let mostro_pubkey = nostr_sdk::PublicKey::from_hex(DEFAULT_MOSTRO_PUBKEY)?;
     let event_json = actions::cancel(&sender_keys, &mostro_pubkey, &order_id, trade_index).await?;

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -10,6 +10,7 @@ use tokio::sync::{broadcast, RwLock};
 
 use crate::api::types::{NewOrderParams, OrderInfo, OrderKind, OrderStatus};
 use crate::config::DEFAULT_MOSTRO_PUBKEY;
+use crate::db::Storage;
 use crate::mostro::actions;
 use crate::nostr::order_events::parse_order_event;
 
@@ -26,18 +27,53 @@ fn trade_key_map() -> &'static std::sync::RwLock<HashMap<String, u32>> {
     TRADE_KEY_MAP.get_or_init(|| std::sync::RwLock::new(HashMap::new()))
 }
 
-fn store_trade_key_index(order_id: &str, index: u32) {
+/// Persist `index` for `order_id` in both the in-memory cache and the DB.
+///
+/// The in-memory write is synchronous and always succeeds.  The DB write is
+/// best-effort — a failure is logged but does not prevent the trade from
+/// proceeding (the in-memory value is still available for the remainder of
+/// this session).
+async fn store_trade_key_index(order_id: &str, index: u32) {
     if let Ok(mut map) = trade_key_map().write() {
         map.insert(order_id.to_string(), index);
     }
+    if let Some(db) = crate::db::app_db::db() {
+        if let Err(e) = db.save_trade_key(order_id, index).await {
+            log::warn!("[orders] failed to persist trade key for order={order_id}: {e}");
+        }
+    }
 }
 
-fn get_trade_key_index(order_id: &str) -> u32 {
-    trade_key_map()
+/// Return the BIP-32 index for `order_id`.
+///
+/// Lookup order:
+/// 1. In-memory cache (always up-to-date for the current session).
+/// 2. Persistent DB (covers trades taken in a previous session).
+/// 3. Falls back to `0` with a warning if neither source has the value.
+async fn get_trade_key_index(order_id: &str) -> u32 {
+    // Fast path: in-memory cache.
+    if let Some(idx) = trade_key_map()
         .read()
         .ok()
         .and_then(|m| m.get(order_id).copied())
-        .unwrap_or(0)
+    {
+        return idx;
+    }
+    // Slow path: DB (populates cache on hit for subsequent calls).
+    if let Some(db) = crate::db::app_db::db() {
+        match db.get_trade_key(order_id).await {
+            Ok(Some(idx)) => {
+                if let Ok(mut map) = trade_key_map().write() {
+                    map.insert(order_id.to_string(), idx);
+                }
+                return idx;
+            }
+            Ok(None) => {}
+            Err(e) => log::warn!("[orders] DB trade key lookup failed for order={order_id}: {e}"),
+        }
+    }
+    log::warn!("[orders] trade key not found for order={order_id}, using index 0");
+    0
 }
 
 /// Filter parameters for the order list.
@@ -391,9 +427,14 @@ pub async fn take_order(
                         if let Err(e) = publish_event_json(&event_json).await {
                             log::warn!("[orders] take_order publish failed: {e}");
                         } else {
-                            // Persist the trade-key mapping only after a successful publish
-                            // so a publish failure doesn't leave a stale entry.
-                            store_trade_key_index(&order_id, trade_index);
+                            // Persist trade-key mapping and trade record only after a
+                            // successful publish so failures leave no stale state.
+                            store_trade_key_index(&order_id, trade_index).await;
+                            if let Some(db) = crate::db::app_db::db() {
+                                if let Err(e) = db.save_trade(&trade).await {
+                                    log::warn!("[orders] failed to persist trade: {e}");
+                                }
+                            }
                             log::info!(
                                 "[orders] take_order dispatched order={order_id} \
                                  trade_index={trade_index} ln_address={}",
@@ -435,7 +476,7 @@ pub async fn send_invoice(
         None
     };
 
-    let trade_index = get_trade_key_index(&order_id);
+    let trade_index = get_trade_key_index(&order_id).await;
     let sender_keys = crate::api::identity::get_active_trade_keys(trade_index).await?;
     let mostro_pubkey = nostr_sdk::PublicKey::from_hex(DEFAULT_MOSTRO_PUBKEY)?;
     let event_json = actions::add_invoice(
@@ -462,7 +503,7 @@ pub async fn send_invoice(
 /// Sends a `FiatSent` MostroMessage to the Mostro daemon signed with the trade
 /// key that was used when taking the order.
 pub async fn send_fiat_sent(order_id: String) -> Result<()> {
-    let trade_index = get_trade_key_index(&order_id);
+    let trade_index = get_trade_key_index(&order_id).await;
     let sender_keys = crate::api::identity::get_active_trade_keys(trade_index).await?;
     let mostro_pubkey = nostr_sdk::PublicKey::from_hex(DEFAULT_MOSTRO_PUBKEY)?;
     let event_json = actions::fiat_sent(&sender_keys, &mostro_pubkey, &order_id, trade_index).await?;
@@ -476,7 +517,7 @@ pub async fn send_fiat_sent(order_id: String) -> Result<()> {
 /// Sends a `Release` MostroMessage to the Mostro daemon signed with the trade
 /// key that was used when taking the order.
 pub async fn release_order(order_id: String) -> Result<()> {
-    let trade_index = get_trade_key_index(&order_id);
+    let trade_index = get_trade_key_index(&order_id).await;
     let sender_keys = crate::api::identity::get_active_trade_keys(trade_index).await?;
     let mostro_pubkey = nostr_sdk::PublicKey::from_hex(DEFAULT_MOSTRO_PUBKEY)?;
     let event_json = actions::release(&sender_keys, &mostro_pubkey, &order_id, trade_index).await?;
@@ -491,7 +532,7 @@ pub async fn release_order(order_id: String) -> Result<()> {
 /// was taken.  Both parties must cancel for it to take effect; the Mostro daemon
 /// handles the cooperative-cancel state machine.
 pub async fn cancel_order(order_id: String) -> Result<()> {
-    let trade_index = get_trade_key_index(&order_id);
+    let trade_index = get_trade_key_index(&order_id).await;
     let sender_keys = crate::api::identity::get_active_trade_keys(trade_index).await?;
     let mostro_pubkey = nostr_sdk::PublicKey::from_hex(DEFAULT_MOSTRO_PUBKEY)?;
     let event_json = actions::cancel(&sender_keys, &mostro_pubkey, &order_id, trade_index).await?;
@@ -728,5 +769,29 @@ impl OrdersStream {
 pub(crate) async fn process_order_event(event: &nostr_sdk::Event, my_pubkey: Option<&nostr_sdk::PublicKey>) {
     if let Some(order) = parse_order_event(event, my_pubkey) {
         order_book().upsert_order(order).await;
+    }
+}
+
+/// Return the persisted [`TradeRole`] for the given `order_id`.
+///
+/// Returns `Some(role)` when a matching trade record exists in the DB,
+/// `None` when the DB has no record for this order (e.g. it was never taken
+/// in this installation, or `init_db` has not been called yet).
+///
+/// Used by the Flutter layer to restore the buyer/seller role after an app
+/// restart so the trade-detail screen shows the correct actions.
+pub async fn get_trade_role(
+    order_id: String,
+) -> Result<Option<crate::api::types::TradeRole>> {
+    let Some(db) = crate::db::app_db::db() else {
+        return Ok(None);
+    };
+    match db.get_trade_by_order_id(&order_id).await {
+        Ok(Some(trade)) => Ok(Some(trade.role)),
+        Ok(None) => Ok(None),
+        Err(e) => {
+            log::warn!("[orders] get_trade_role DB error for order={order_id}: {e}");
+            Ok(None)
+        }
     }
 }

--- a/rust/src/db/app_db.rs
+++ b/rust/src/db/app_db.rs
@@ -1,0 +1,40 @@
+/// Global persistent-storage singleton.
+///
+/// Flutter calls [`init_db`] once on startup with the platform-specific
+/// database path.  All Rust API functions that need persistence call [`db()`]
+/// to obtain a reference.  If the DB has not been initialised yet (e.g. during
+/// unit tests or early in the startup sequence) the call returns `None` and the
+/// caller falls back to the in-memory cache.
+use anyhow::Result;
+use tokio::sync::OnceCell;
+
+#[cfg(not(target_arch = "wasm32"))]
+use crate::db::sqlite::SqliteStorage as AppStorage;
+#[cfg(target_arch = "wasm32")]
+use crate::db::indexeddb::IndexedDbStorage as AppStorage;
+
+static APP_DB: OnceCell<AppStorage> = OnceCell::const_new();
+
+/// Initialise the persistent store with the given `path`.
+///
+/// On native platforms `path` is the absolute path to the SQLite file (e.g.
+/// `<app_documents>/mostro.db`).  On WASM the argument is used as the
+/// IndexedDB database name.
+///
+/// Subsequent calls are no-ops — the singleton is only written once.
+pub async fn init_db(path: &str) -> Result<()> {
+    if APP_DB.get().is_none() {
+        let storage = AppStorage::open(path).await?;
+        // A concurrent init racing here is harmless — OnceCell guarantees
+        // only the first value is stored.
+        let _ = APP_DB.set(storage);
+        log::info!("[db] persistent store initialised (path={})", path);
+    }
+    Ok(())
+}
+
+/// Return a reference to the initialised storage, or `None` if [`init_db`]
+/// has not been called yet.
+pub(crate) fn db() -> Option<&'static AppStorage> {
+    APP_DB.get()
+}

--- a/rust/src/db/app_db.rs
+++ b/rust/src/db/app_db.rs
@@ -23,13 +23,10 @@ static APP_DB: OnceCell<AppStorage> = OnceCell::const_new();
 ///
 /// Subsequent calls are no-ops — the singleton is only written once.
 pub async fn init_db(path: &str) -> Result<()> {
-    if APP_DB.get().is_none() {
-        let storage = AppStorage::open(path).await?;
-        // A concurrent init racing here is harmless — OnceCell guarantees
-        // only the first value is stored.
-        let _ = APP_DB.set(storage);
-        log::info!("[db] persistent store initialised (path={})", path);
-    }
+    APP_DB
+        .get_or_try_init(|| async { AppStorage::open(path).await })
+        .await?;
+    log::info!("[db] persistent store ready (path={})", path);
     Ok(())
 }
 

--- a/rust/src/db/indexeddb.rs
+++ b/rust/src/db/indexeddb.rs
@@ -82,17 +82,17 @@ impl Storage for IndexedDbStorage {
     }
 
     async fn save_trade_key(&self, _order_id: &str, _key_index: u32) -> Result<()> {
-        Err(anyhow!("IndexedDB not yet implemented"))
+        Ok(()) // no-op: IndexedDB persistence not yet implemented
     }
 
     async fn get_trade_key(&self, _order_id: &str) -> Result<Option<u32>> {
-        Err(anyhow!("IndexedDB not yet implemented"))
+        Ok(None) // no persisted key: caller will treat absence correctly
     }
 
     async fn get_trade_by_order_id(
         &self,
         _order_id: &str,
     ) -> Result<Option<crate::api::types::TradeInfo>> {
-        Err(anyhow!("IndexedDB not yet implemented"))
+        Ok(None) // no persisted trade: role lookup returns None
     }
 }

--- a/rust/src/db/indexeddb.rs
+++ b/rust/src/db/indexeddb.rs
@@ -80,4 +80,19 @@ impl Storage for IndexedDbStorage {
     async fn delete_queued_message(&self, _id: &str) -> Result<()> {
         Err(anyhow!("IndexedDB not yet implemented"))
     }
+
+    async fn save_trade_key(&self, _order_id: &str, _key_index: u32) -> Result<()> {
+        Err(anyhow!("IndexedDB not yet implemented"))
+    }
+
+    async fn get_trade_key(&self, _order_id: &str) -> Result<Option<u32>> {
+        Err(anyhow!("IndexedDB not yet implemented"))
+    }
+
+    async fn get_trade_by_order_id(
+        &self,
+        _order_id: &str,
+    ) -> Result<Option<crate::api::types::TradeInfo>> {
+        Err(anyhow!("IndexedDB not yet implemented"))
+    }
 }

--- a/rust/src/db/mod.rs
+++ b/rust/src/db/mod.rs
@@ -1,3 +1,4 @@
+pub mod app_db;
 pub mod schema;
 pub mod seeds;
 #[cfg(not(target_arch = "wasm32"))]
@@ -52,4 +53,18 @@ pub trait Storage: Send + Sync {
         status: crate::api::types::QueuedMessageStatus,
     ) -> Result<()>;
     async fn delete_queued_message(&self, id: &str) -> Result<()>;
+
+    // ── Trade key index ──────────────────────────────────────────────────────
+
+    /// Persist the BIP-32 key index used for `order_id`.
+    async fn save_trade_key(&self, order_id: &str, key_index: u32) -> Result<()>;
+
+    /// Retrieve the BIP-32 key index for `order_id`, or `None` if not found.
+    async fn get_trade_key(&self, order_id: &str) -> Result<Option<u32>>;
+
+    /// Look up a persisted trade by the order ID it is associated with.
+    async fn get_trade_by_order_id(
+        &self,
+        order_id: &str,
+    ) -> Result<Option<crate::api::types::TradeInfo>>;
 }

--- a/rust/src/db/schema.rs
+++ b/rust/src/db/schema.rs
@@ -1,5 +1,5 @@
 /// Database schema version. Bump when migrations change the schema.
-pub const SCHEMA_VERSION: u32 = 1;
+pub const SCHEMA_VERSION: u32 = 2;
 
 /// SQLite DDL — applied on first launch and when SCHEMA_VERSION increases.
 #[cfg(not(target_arch = "wasm32"))]
@@ -51,5 +51,13 @@ CREATE TABLE IF NOT EXISTS queued_messages (
     created_at      INTEGER NOT NULL,
     retry_count     INTEGER NOT NULL DEFAULT 0,
     next_retry_at   INTEGER
+);
+
+-- Maps order_id → BIP-32 trade key index used when taking/creating that order.
+-- Persists across restarts so fiat-sent, release, and cancel can re-derive the
+-- correct signing key even after the app is killed between protocol steps.
+CREATE TABLE IF NOT EXISTS trade_keys (
+    order_id        TEXT PRIMARY KEY,
+    key_index       INTEGER NOT NULL
 );
 "#;

--- a/rust/src/db/schema.rs
+++ b/rust/src/db/schema.rs
@@ -1,7 +1,10 @@
-/// Database schema version. Bump when migrations change the schema.
+/// Database schema version. Currently unused at runtime — kept as a reference
+/// for future migration logic (e.g. ALTER TABLE guards or schema-diff checks).
 pub const SCHEMA_VERSION: u32 = 2;
 
-/// SQLite DDL — applied on first launch and when SCHEMA_VERSION increases.
+/// SQLite DDL executed unconditionally on every `SqliteStorage::open()` call.
+/// Safe to run repeatedly because every statement uses `CREATE TABLE IF NOT
+/// EXISTS` / `CREATE INDEX IF NOT EXISTS`.
 #[cfg(not(target_arch = "wasm32"))]
 pub const SQLITE_INIT_SQL: &str = r#"
 PRAGMA journal_mode = WAL;

--- a/rust/src/db/sqlite.rs
+++ b/rust/src/db/sqlite.rs
@@ -262,4 +262,39 @@ impl Storage for SqliteStorage {
             .await?;
         Ok(())
     }
+
+    async fn save_trade_key(&self, order_id: &str, key_index: u32) -> Result<()> {
+        sqlx::query(
+            "INSERT OR REPLACE INTO trade_keys (order_id, key_index) VALUES (?, ?)",
+        )
+        .bind(order_id)
+        .bind(key_index as i64)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn get_trade_key(&self, order_id: &str) -> Result<Option<u32>> {
+        let row: Option<(i64,)> =
+            sqlx::query_as("SELECT key_index FROM trade_keys WHERE order_id = ?")
+                .bind(order_id)
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(row.map(|(idx,)| idx as u32))
+    }
+
+    async fn get_trade_by_order_id(&self, order_id: &str) -> Result<Option<TradeInfo>> {
+        // The `data` column holds the full JSON-serialised TradeInfo; use
+        // SQLite's json_extract to filter by the nested order id without
+        // deserialising every row.
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT data FROM trades \
+             WHERE json_extract(data, '$.order.id') = ? \
+             LIMIT 1",
+        )
+        .bind(order_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.map(|(data,)| serde_json::from_str(&data)).transpose()?)
+    }
 }

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -44,7 +44,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1998520049;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 780091882;
 
 // Section: executor
 
@@ -971,6 +971,42 @@ fn wire__crate__api__nostr__add_relay_impl(
         },
     )
 }
+fn wire__crate__api__orders__cancel_order_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "cancel_order",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_order_id = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || async move {
+                        let output_ok = crate::api::orders::cancel_order(api_order_id).await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
 fn wire__crate__api__nwc__connect_wallet_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -1822,6 +1858,42 @@ fn wire__crate__api__identity__get_trade_key_impl(
         },
     )
 }
+fn wire__crate__api__orders__get_trade_role_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "get_trade_role",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_order_id = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || async move {
+                        let output_ok = crate::api::orders::get_trade_role(api_order_id).await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
 fn wire__crate__api__messages__get_unread_count_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -2117,6 +2189,42 @@ fn wire__crate__api__identity__import_from_nsec_impl(
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
                     (move || async move {
                         let output_ok = crate::api::identity::import_from_nsec(api_nsec).await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__init_db_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "init_db",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_path = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || async move {
+                        let output_ok = crate::api::init_db(api_path).await?;
                         Ok(output_ok)
                     })()
                     .await,
@@ -2798,42 +2906,6 @@ fn wire__crate__api__orders__send_fiat_sent_impl(
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
                     (move || async move {
                         let output_ok = crate::api::orders::send_fiat_sent(api_order_id).await?;
-                        Ok(output_ok)
-                    })()
-                    .await,
-                )
-            }
-        },
-    )
-}
-fn wire__crate__api__orders__cancel_order_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "cancel_order",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_order_id = <String>::sse_decode(&mut deserializer);
-            deserializer.end();
-            move |context| async move {
-                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
-                    (move || async move {
-                        let output_ok = crate::api::orders::cancel_order(api_order_id).await?;
                         Ok(output_ok)
                     })()
                     .await,
@@ -4223,6 +4295,17 @@ impl SseDecode for Option<crate::api::types::TradeOutcome> {
     }
 }
 
+impl SseDecode for Option<crate::api::types::TradeRole> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<crate::api::types::TradeRole>::sse_decode(deserializer));
+        } else {
+            return None;
+        }
+    }
+}
+
 impl SseDecode for Option<u32> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -4682,155 +4765,157 @@ fn pde_ffi_dispatcher_primary_impl(
             wire__crate__api__nwc__WalletStatusStream_next_impl(port, ptr, rust_vec_len, data_len)
         }
         17 => wire__crate__api__nostr__add_relay_impl(port, ptr, rust_vec_len, data_len),
-        18 => wire__crate__api__nwc__connect_wallet_impl(port, ptr, rust_vec_len, data_len),
-        19 => wire__crate__api__identity__create_identity_impl(port, ptr, rust_vec_len, data_len),
-        20 => wire__crate__api__orders__create_order_impl(port, ptr, rust_vec_len, data_len),
-        21 => wire__crate__api__identity__delete_identity_impl(port, ptr, rust_vec_len, data_len),
-        22 => wire__crate__api__identity__derive_trade_key_impl(port, ptr, rust_vec_len, data_len),
-        23 => wire__crate__api__nwc__disconnect_wallet_impl(port, ptr, rust_vec_len, data_len),
-        24 => {
+        18 => wire__crate__api__orders__cancel_order_impl(port, ptr, rust_vec_len, data_len),
+        19 => wire__crate__api__nwc__connect_wallet_impl(port, ptr, rust_vec_len, data_len),
+        20 => wire__crate__api__identity__create_identity_impl(port, ptr, rust_vec_len, data_len),
+        21 => wire__crate__api__orders__create_order_impl(port, ptr, rust_vec_len, data_len),
+        22 => wire__crate__api__identity__delete_identity_impl(port, ptr, rust_vec_len, data_len),
+        23 => wire__crate__api__identity__derive_trade_key_impl(port, ptr, rust_vec_len, data_len),
+        24 => wire__crate__api__nwc__disconnect_wallet_impl(port, ptr, rust_vec_len, data_len),
+        25 => {
             wire__crate__api__messages__download_attachment_impl(port, ptr, rust_vec_len, data_len)
         }
-        25 => wire__crate__api__identity__export_encrypted_backup_impl(
+        26 => wire__crate__api__identity__export_encrypted_backup_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        26 => wire__crate__api__nostr__flush_message_queue_impl(port, ptr, rust_vec_len, data_len),
-        27 => wire__crate__api__get_app_version_impl(port, ptr, rust_vec_len, data_len),
-        28 => wire__crate__api__messages__get_attachment_status_impl(
+        27 => wire__crate__api__nostr__flush_message_queue_impl(port, ptr, rust_vec_len, data_len),
+        28 => wire__crate__api__get_app_version_impl(port, ptr, rust_vec_len, data_len),
+        29 => wire__crate__api__messages__get_attachment_status_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        29 => wire__crate__api__nwc__get_balance_impl(port, ptr, rust_vec_len, data_len),
-        30 => wire__crate__api__nostr__get_connection_state_impl(port, ptr, rust_vec_len, data_len),
-        31 => wire__crate__api__disputes__get_dispute_impl(port, ptr, rust_vec_len, data_len),
-        32 => wire__crate__api__identity__get_identity_impl(port, ptr, rust_vec_len, data_len),
-        33 => wire__crate__api__messages__get_messages_impl(port, ptr, rust_vec_len, data_len),
-        34 => wire__crate__api__identity__get_nym_identity_impl(port, ptr, rust_vec_len, data_len),
-        35 => wire__crate__api__orders__get_order_impl(port, ptr, rust_vec_len, data_len),
-        36 => wire__crate__api__orders__get_orders_impl(port, ptr, rust_vec_len, data_len),
-        37 => {
+        30 => wire__crate__api__nwc__get_balance_impl(port, ptr, rust_vec_len, data_len),
+        31 => wire__crate__api__nostr__get_connection_state_impl(port, ptr, rust_vec_len, data_len),
+        32 => wire__crate__api__disputes__get_dispute_impl(port, ptr, rust_vec_len, data_len),
+        33 => wire__crate__api__identity__get_identity_impl(port, ptr, rust_vec_len, data_len),
+        34 => wire__crate__api__messages__get_messages_impl(port, ptr, rust_vec_len, data_len),
+        35 => wire__crate__api__identity__get_nym_identity_impl(port, ptr, rust_vec_len, data_len),
+        36 => wire__crate__api__orders__get_order_impl(port, ptr, rust_vec_len, data_len),
+        37 => wire__crate__api__orders__get_orders_impl(port, ptr, rust_vec_len, data_len),
+        38 => {
             wire__crate__api__reputation__get_privacy_mode_impl(port, ptr, rust_vec_len, data_len)
         }
-        38 => wire__crate__api__reputation__get_rating_for_trade_impl(
+        39 => wire__crate__api__reputation__get_rating_for_trade_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        39 => wire__crate__api__nostr__get_relays_impl(port, ptr, rust_vec_len, data_len),
-        40 => wire__crate__api__settings__get_settings_impl(port, ptr, rust_vec_len, data_len),
-        41 => wire__crate__api__identity__get_trade_key_impl(port, ptr, rust_vec_len, data_len),
-        42 => wire__crate__api__messages__get_unread_count_impl(port, ptr, rust_vec_len, data_len),
-        43 => wire__crate__api__nwc__get_wallet_impl(port, ptr, rust_vec_len, data_len),
-        44 => wire__crate__api__disputes__handle_admin_canceled_impl(
+        40 => wire__crate__api__nostr__get_relays_impl(port, ptr, rust_vec_len, data_len),
+        41 => wire__crate__api__settings__get_settings_impl(port, ptr, rust_vec_len, data_len),
+        42 => wire__crate__api__identity__get_trade_key_impl(port, ptr, rust_vec_len, data_len),
+        43 => wire__crate__api__orders__get_trade_role_impl(port, ptr, rust_vec_len, data_len),
+        44 => wire__crate__api__messages__get_unread_count_impl(port, ptr, rust_vec_len, data_len),
+        45 => wire__crate__api__nwc__get_wallet_impl(port, ptr, rust_vec_len, data_len),
+        46 => wire__crate__api__disputes__handle_admin_canceled_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        45 => {
+        47 => {
             wire__crate__api__disputes__handle_admin_settled_impl(port, ptr, rust_vec_len, data_len)
         }
-        46 => wire__crate__api__disputes__handle_admin_took_dispute_impl(
+        48 => wire__crate__api__disputes__handle_admin_took_dispute_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        47 => wire__crate__api__reputation__handle_rating_received_impl(
+        49 => wire__crate__api__reputation__handle_rating_received_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        48 => {
+        50 => {
             wire__crate__api__identity__import_from_mnemonic_impl(port, ptr, rust_vec_len, data_len)
         }
-        49 => wire__crate__api__identity__import_from_nsec_impl(port, ptr, rust_vec_len, data_len),
-        50 => wire__crate__api__nostr__initialize_impl(port, ptr, rust_vec_len, data_len),
-        51 => wire__crate__api__identity__load_identity_from_mnemonic_impl(
+        51 => wire__crate__api__identity__import_from_nsec_impl(port, ptr, rust_vec_len, data_len),
+        52 => wire__crate__api__init_db_impl(port, ptr, rust_vec_len, data_len),
+        53 => wire__crate__api__nostr__initialize_impl(port, ptr, rust_vec_len, data_len),
+        54 => wire__crate__api__identity__load_identity_from_mnemonic_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        52 => wire__crate__api__messages__mark_as_read_impl(port, ptr, rust_vec_len, data_len),
-        53 => wire__crate__api__messages__on_attachment_progress_impl(
+        55 => wire__crate__api__messages__mark_as_read_impl(port, ptr, rust_vec_len, data_len),
+        56 => wire__crate__api__messages__on_attachment_progress_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        54 => wire__crate__api__nostr__on_connection_state_changed_impl(
+        57 => wire__crate__api__nostr__on_connection_state_changed_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        55 => {
+        58 => {
             wire__crate__api__disputes__on_dispute_updated_impl(port, ptr, rust_vec_len, data_len)
         }
-        56 => wire__crate__api__messages__on_new_message_impl(port, ptr, rust_vec_len, data_len),
-        57 => wire__crate__api__orders__on_orders_updated_impl(port, ptr, rust_vec_len, data_len),
-        58 => {
+        59 => wire__crate__api__messages__on_new_message_impl(port, ptr, rust_vec_len, data_len),
+        60 => wire__crate__api__orders__on_orders_updated_impl(port, ptr, rust_vec_len, data_len),
+        61 => {
             wire__crate__api__reputation__on_rating_received_impl(port, ptr, rust_vec_len, data_len)
         }
-        59 => {
+        62 => {
             wire__crate__api__nostr__on_relay_status_changed_impl(port, ptr, rust_vec_len, data_len)
         }
-        60 => {
+        63 => {
             wire__crate__api__settings__on_settings_changed_impl(port, ptr, rust_vec_len, data_len)
         }
-        61 => wire__crate__api__messages__on_unread_count_changed_impl(
+        64 => wire__crate__api__messages__on_unread_count_changed_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        62 => {
+        65 => {
             wire__crate__api__nwc__on_wallet_status_changed_impl(port, ptr, rust_vec_len, data_len)
         }
-        63 => wire__crate__api__disputes__open_dispute_impl(port, ptr, rust_vec_len, data_len),
-        64 => {
+        66 => wire__crate__api__disputes__open_dispute_impl(port, ptr, rust_vec_len, data_len),
+        67 => {
             wire__crate__api__orders__order_filters_default_impl(port, ptr, rust_vec_len, data_len)
         }
-        65 => wire__crate__api__nwc__pay_invoice_impl(port, ptr, rust_vec_len, data_len),
-        66 => wire__crate__api__orders__release_order_impl(port, ptr, rust_vec_len, data_len),
-        67 => wire__crate__api__nostr__remove_relay_impl(port, ptr, rust_vec_len, data_len),
-        68 => wire__crate__api__orders__send_fiat_sent_impl(port, ptr, rust_vec_len, data_len),
-        69 => wire__crate__api__messages__send_file_impl(port, ptr, rust_vec_len, data_len),
-        70 => wire__crate__api__orders__send_invoice_impl(port, ptr, rust_vec_len, data_len),
-        71 => wire__crate__api__messages__send_message_impl(port, ptr, rust_vec_len, data_len),
-        72 => wire__crate__api__settings__set_default_fiat_code_impl(
+        68 => wire__crate__api__nwc__pay_invoice_impl(port, ptr, rust_vec_len, data_len),
+        69 => wire__crate__api__orders__release_order_impl(port, ptr, rust_vec_len, data_len),
+        70 => wire__crate__api__nostr__remove_relay_impl(port, ptr, rust_vec_len, data_len),
+        71 => wire__crate__api__orders__send_fiat_sent_impl(port, ptr, rust_vec_len, data_len),
+        72 => wire__crate__api__messages__send_file_impl(port, ptr, rust_vec_len, data_len),
+        73 => wire__crate__api__orders__send_invoice_impl(port, ptr, rust_vec_len, data_len),
+        74 => wire__crate__api__messages__send_message_impl(port, ptr, rust_vec_len, data_len),
+        75 => wire__crate__api__settings__set_default_fiat_code_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        73 => wire__crate__api__settings__set_default_lightning_address_impl(
+        76 => wire__crate__api__settings__set_default_lightning_address_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        74 => wire__crate__api__settings__set_language_impl(port, ptr, rust_vec_len, data_len),
-        75 => {
+        77 => wire__crate__api__settings__set_language_impl(port, ptr, rust_vec_len, data_len),
+        78 => {
             wire__crate__api__settings__set_logging_enabled_impl(port, ptr, rust_vec_len, data_len)
         }
-        76 => {
+        79 => {
             wire__crate__api__reputation__set_privacy_mode_impl(port, ptr, rust_vec_len, data_len)
         }
-        77 => wire__crate__api__settings__set_theme_impl(port, ptr, rust_vec_len, data_len),
-        78 => wire__crate__api__disputes__submit_evidence_impl(port, ptr, rust_vec_len, data_len),
-        79 => wire__crate__api__reputation__submit_rating_impl(port, ptr, rust_vec_len, data_len),
-        80 => wire__crate__api__orders__subscribe_orders_impl(port, ptr, rust_vec_len, data_len),
-        81 => wire__crate__api__orders__take_order_impl(port, ptr, rust_vec_len, data_len),
-        82 => wire__crate__api__orders__cancel_order_impl(port, ptr, rust_vec_len, data_len),
+        80 => wire__crate__api__settings__set_theme_impl(port, ptr, rust_vec_len, data_len),
+        81 => wire__crate__api__disputes__submit_evidence_impl(port, ptr, rust_vec_len, data_len),
+        82 => wire__crate__api__reputation__submit_rating_impl(port, ptr, rust_vec_len, data_len),
+        83 => wire__crate__api__orders__subscribe_orders_impl(port, ptr, rust_vec_len, data_len),
+        84 => wire__crate__api__orders__take_order_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -6605,6 +6690,16 @@ impl SseEncode for Option<crate::api::types::TradeOutcome> {
         <bool>::sse_encode(self.is_some(), serializer);
         if let Some(value) = self {
             <crate::api::types::TradeOutcome>::sse_encode(value, serializer);
+        }
+    }
+}
+
+impl SseEncode for Option<crate::api::types::TradeRole> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <crate::api::types::TradeRole>::sse_encode(value, serializer);
         }
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -26,14 +26,3 @@ pub fn init_app() {
     log::info!("[init] Rust core initialized");
 }
 
-/// Initialise the persistent store.
-///
-/// Must be called once on app startup **before** taking orders or sending
-/// invoices.  On native platforms pass the absolute path to the SQLite file
-/// (e.g. `<app_documents_dir>/mostro.db`).  On WASM `path` is used as the
-/// IndexedDB database name.
-///
-/// Subsequent calls are no-ops.
-pub async fn init_db(path: String) -> anyhow::Result<()> {
-    crate::db::app_db::init_db(&path).await
-}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -25,3 +25,15 @@ pub fn init_app() {
     );
     log::info!("[init] Rust core initialized");
 }
+
+/// Initialise the persistent store.
+///
+/// Must be called once on app startup **before** taking orders or sending
+/// invoices.  On native platforms pass the absolute path to the SQLite file
+/// (e.g. `<app_documents_dir>/mostro.db`).  On WASM `path` is used as the
+/// IndexedDB database name.
+///
+/// Subsequent calls are no-ops.
+pub async fn init_db(path: String) -> anyhow::Result<()> {
+    crate::db::app_db::init_db(&path).await
+}


### PR DESCRIPTION
- Add `trade_keys` table to SQLite schema (schema v2) to persist the
  BIP-32 key index used per order across restarts
- Extend `Storage` trait with `save_trade_key`, `get_trade_key`, and
  `get_trade_by_order_id`; implement in SqliteStorage, stub in IndexedDbStorage
- Add `db/app_db.rs`: global `OnceCell<AppStorage>` singleton with
  `init_db(path)` / `db()` accessors
- Expose `init_db(path: String)` to Flutter via flutter_rust_bridge
- Make `store_trade_key_index` / `get_trade_key_index` async; write-through
  to DB on store, DB fallback with cache-warm on miss
- Save `TradeInfo` to DB after successful publish in `take_order`
- Add `get_trade_role(order_id)` public API that queries the persisted trade
- Dart: add `tradeRoleFromDbProvider` (FutureProvider.family) that calls
  `getTradeRole` and maps `TradeRole` → bool
- `TradeDetailScreen` falls back to `tradeRoleFromDbProvider` when the
  in-memory `tradeRoleProvider` map has no entry for the order, so
  reopened trades after an app restart show the correct buyer/seller actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent local database for trade data so trades and keys survive app restarts, improving continuity and reliability.
  * Trade detail now falls back to persisted buyer/seller role when in-memory state is missing, reducing incorrect role displays after restart.

* **Chores**
  * Updated localization source formatting for German, Spanish, French, and Italian strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->