### PR TITLE
fix(order-book): subscribe to all orders so status changes are receiv…

### DIFF
--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -705,7 +705,10 @@ async fn _run_order_subscription() {
     // events that arrive between the subscribe call and receiver creation.
     let mut rx = client.notifications();
 
-    let filter = crate::nostr::order_events::pending_orders_filter(&mostro_pubkey);
+    // Subscribe to ALL orders (no status restriction) so we receive status-change
+    // events (e.g. pending → canceled) and can remove them from the order book.
+    // Display-level filtering (show only pending) is handled in the Dart layer.
+    let filter = crate::nostr::order_events::all_orders_filter(&mostro_pubkey);
     if let Err(e) = client.subscribe(filter, None).await {
         log::error!("[orders] subscribe failed: {e}");
         return;

--- a/rust/src/nostr/order_events.rs
+++ b/rust/src/nostr/order_events.rs
@@ -144,6 +144,19 @@ pub fn pending_orders_filter(mostro_pubkey: &PublicKey) -> Filter {
         .custom_tag(SingleLetterTag::lowercase(Alphabet::S), "pending")
 }
 
+/// Build a Nostr filter for **all** Kind 38383 orders from a specific Mostro node,
+/// regardless of status.
+///
+/// Use this for the global order-book subscription so that status transitions
+/// (e.g. `pending` → `canceled` / `in-progress`) are received and the order
+/// is removed from or updated in the order book in real time.
+/// Display-level filtering (show only `pending`) is done in the Dart layer.
+pub fn all_orders_filter(mostro_pubkey: &PublicKey) -> Filter {
+    Filter::new()
+        .kind(Kind::from(KIND_ORDER))
+        .author(*mostro_pubkey)
+}
+
 /// Build a Nostr filter for a **single** Kind 38383 order by `d`-tag (order ID).
 ///
 /// Unlike `pending_orders_filter`, this filter has **no status restriction** —


### PR DESCRIPTION
…ed in real time

The global subscription used pending_orders_filter (s=pending tag), so when an order transitioned to canceled/taken the relay published a new event with s=canceled but we never received it — the canceled order stayed visible until the app restarted.

Add all_orders_filter (no s-tag constraint) and use it for the order-book subscription so every status-change event is delivered. The existing filteredOrdersProvider (o.status != pending → hide) handles display filtering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Order book now displays real-time updates for all order status changes and transitions, providing complete visibility into the full order lifecycle including cancellations and status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->