### PR TITLE
feat(desktop): add primary navigation to persistent sidebar

### DIFF
--- a/lib/features/chat/screens/chat_rooms_screen.dart
+++ b/lib/features/chat/screens/chat_rooms_screen.dart
@@ -7,6 +7,7 @@ import 'package:mostro/core/app_theme.dart';
 import 'package:mostro/features/chat/providers/chat_providers.dart';
 import 'package:mostro/features/chat/widgets/chat_list_item.dart';
 import 'package:mostro/features/disputes/widgets/disputes_list.dart';
+import 'package:mostro/features/drawer/screens/drawer_menu.dart';
 import 'package:mostro/shared/widgets/bottom_nav_bar.dart';
 
 /// Route: /chat_list
@@ -21,27 +22,48 @@ class ChatRoomsScreen extends ConsumerWidget {
     if (colors == null) throw StateError('AppColors theme extension must be registered');
     final textTheme = Theme.of(context).textTheme;
 
-    return DefaultTabController(
-      length: 2,
-      child: Scaffold(
-        appBar: AppBar(
-          title: const Text('Chat'),
-          bottom: TabBar(
-            indicatorColor: colors.mostroGreen,
-            labelColor: colors.mostroGreen,
-            unselectedLabelColor: colors.textSubtle,
-            tabs: const [
-              Tab(text: 'Messages'),
-              Tab(text: 'Disputes'),
+    final isDesktop =
+        MediaQuery.sizeOf(context).width >= AppBreakpoints.desktop;
+
+    final mainContent = Column(
+      children: [
+        TabBar(
+          indicatorColor: colors.mostroGreen,
+          labelColor: colors.mostroGreen,
+          unselectedLabelColor: colors.textSubtle,
+          tabs: const [
+            Tab(text: 'Messages'),
+            Tab(text: 'Disputes'),
+          ],
+        ),
+        Expanded(
+          child: TabBarView(
+            children: [
+              _MessagesTab(colors: colors, textTheme: textTheme),
+              _DisputesTab(colors: colors, textTheme: textTheme),
             ],
           ),
         ),
-        body: TabBarView(
-          children: [
-            _MessagesTab(colors: colors, textTheme: textTheme),
-            _DisputesTab(colors: colors, textTheme: textTheme),
-          ],
-        ),
+      ],
+    );
+
+    final body = isDesktop
+        ? Row(
+            children: [
+              const DrawerMenu(persistent: true),
+              const VerticalDivider(width: 1),
+              Expanded(child: mainContent),
+            ],
+          )
+        : mainContent;
+
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: isDesktop
+            ? null
+            : AppBar(title: const Text('Chat')),
+        body: body,
         bottomNavigationBar: const BottomNavBar(),
       ),
     );

--- a/lib/features/chat/screens/chat_rooms_screen.dart
+++ b/lib/features/chat/screens/chat_rooms_screen.dart
@@ -52,7 +52,7 @@ class ChatRoomsScreen extends ConsumerWidget {
             children: [
               const DrawerMenu(persistent: true),
               const VerticalDivider(width: 1),
-              Expanded(child: mainContent),
+              Expanded(child: SafeArea(child: mainContent)),
             ],
           )
         : mainContent;

--- a/lib/features/drawer/screens/drawer_menu.dart
+++ b/lib/features/drawer/screens/drawer_menu.dart
@@ -270,6 +270,7 @@ class _NavItem extends StatelessWidget {
       button: true,
       label: label,
       selected: isActive,
+      hint: badgeCount > 0 ? '$badgeCount new' : null,
       child: Material(
         color: Colors.transparent,
         child: InkWell(

--- a/lib/features/drawer/screens/drawer_menu.dart
+++ b/lib/features/drawer/screens/drawer_menu.dart
@@ -1,8 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:mostro/core/app_routes.dart';
 import 'package:mostro/core/app_theme.dart';
+import 'package:mostro/features/trades/providers/trades_providers.dart'
+    show orderBookNotificationCountProvider;
+import 'package:mostro/shared/widgets/bottom_nav_bar.dart'
+    show chatNotificationCountProvider;
 
 /// Drawer menu — overlay on mobile/tablet, persistent sidebar on desktop.
 ///
@@ -12,8 +17,9 @@ import 'package:mostro/core/app_theme.dart';
 /// [240 px] sidebar column, suitable for embedding in a [Row] on desktop.
 ///
 /// Header: Mostro mascot icon + "Beta" label + "MOSTRO" title.
-/// 3 menu items: Account, Settings, About.
-class DrawerMenu extends StatelessWidget {
+/// Desktop nav: Order Book, My Trades, Chat — active item highlighted.
+/// Account items: Account, Settings, About.
+class DrawerMenu extends ConsumerWidget {
   const DrawerMenu({
     super.key,
     this.onClose,
@@ -27,16 +33,26 @@ class DrawerMenu extends StatelessWidget {
   final bool persistent;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final colors = theme.extension<AppColors>();
     final green = colors?.mostroGreen ?? const Color(0xFF8CC63F);
     final cardBg = colors?.backgroundCard ?? const Color(0xFF1E2230);
 
+    final tradesCount = persistent
+        ? ref.watch(orderBookNotificationCountProvider)
+        : 0;
+    final chatCount = persistent
+        ? ref.watch(chatNotificationCountProvider)
+        : 0;
+
     final panel = _SidebarContent(
       green: green,
       cardBg: cardBg,
       theme: theme,
+      persistent: persistent,
+      tradesCount: tradesCount,
+      chatCount: chatCount,
       onNavigate: persistent ? null : onClose,
     );
 
@@ -70,25 +86,33 @@ class _SidebarContent extends StatelessWidget {
     required this.green,
     required this.cardBg,
     required this.theme,
+    required this.persistent,
+    required this.tradesCount,
+    required this.chatCount,
     required this.onNavigate,
   });
 
   final Color green;
   final Color cardBg;
   final ThemeData theme;
+  final bool persistent;
+  final int tradesCount;
+  final int chatCount;
 
   /// Called before each navigation push (closes overlay drawer if not null).
   final VoidCallback? onNavigate;
 
   @override
   Widget build(BuildContext context) {
+    final currentPath = GoRouterState.of(context).uri.path;
+
     return Container(
       color: cardBg,
       child: SafeArea(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // Header
+            // ── Header ───────────────────────────────────────────────────
             Padding(
               padding: const EdgeInsets.fromLTRB(
                 AppSpacing.xl,
@@ -139,9 +163,46 @@ class _SidebarContent extends StatelessWidget {
             ),
 
             const Divider(height: 1),
-            const SizedBox(height: AppSpacing.lg),
+            const SizedBox(height: AppSpacing.sm),
 
-            // Menu items
+            // ── Primary navigation (desktop persistent sidebar only) ─────
+            if (persistent) ...[
+              _NavItem(
+                icon: Icons.list_alt_outlined,
+                activeIcon: Icons.list_alt,
+                label: 'Order Book',
+                isActive: currentPath == AppRoute.home ||
+                    currentPath == '/',
+                badgeCount: 0,
+                green: green,
+                onTap: () => context.go(AppRoute.home),
+              ),
+              _NavItem(
+                icon: Icons.bolt_outlined,
+                activeIcon: Icons.bolt,
+                label: 'My Trades',
+                isActive: currentPath.startsWith(AppRoute.orderBook),
+                badgeCount: tradesCount,
+                green: green,
+                onTap: () => context.go(AppRoute.orderBook),
+              ),
+              _NavItem(
+                icon: Icons.chat_bubble_outline,
+                activeIcon: Icons.chat_bubble,
+                label: 'Chat',
+                isActive: currentPath.startsWith(AppRoute.chatList),
+                badgeCount: chatCount,
+                green: green,
+                onTap: () => context.go(AppRoute.chatList),
+              ),
+              const SizedBox(height: AppSpacing.sm),
+              const Divider(height: 1),
+              const SizedBox(height: AppSpacing.sm),
+            ] else ...[
+              const SizedBox(height: AppSpacing.lg),
+            ],
+
+            // ── Account / settings items ─────────────────────────────────
             _MenuItem(
               icon: Icons.key_outlined,
               label: 'Account',
@@ -174,6 +235,93 @@ class _SidebarContent extends StatelessWidget {
     );
   }
 }
+
+// ── Primary nav item (desktop sidebar) ───────────────────────────────────────
+
+class _NavItem extends StatelessWidget {
+  const _NavItem({
+    required this.icon,
+    required this.activeIcon,
+    required this.label,
+    required this.isActive,
+    required this.badgeCount,
+    required this.green,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final IconData activeIcon;
+  final String label;
+  final bool isActive;
+  final int badgeCount;
+  final Color green;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<AppColors>();
+    final activeBg = green.withValues(alpha: 0.12);
+    final iconColor = isActive ? green : Colors.white;
+    final textColor = isActive ? green : Colors.white;
+    final fontWeight =
+        isActive ? FontWeight.w600 : FontWeight.w500;
+
+    return Semantics(
+      button: true,
+      label: label,
+      selected: isActive,
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: onTap,
+          child: Container(
+            margin: const EdgeInsets.symmetric(
+              horizontal: AppSpacing.md,
+              vertical: 2,
+            ),
+            decoration: BoxDecoration(
+              color: isActive ? activeBg : Colors.transparent,
+              borderRadius: BorderRadius.circular(AppRadius.chip),
+            ),
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSpacing.md,
+              vertical: AppSpacing.md,
+            ),
+            child: Row(
+              children: [
+                Icon(isActive ? activeIcon : icon,
+                    color: iconColor, size: 22),
+                const SizedBox(width: AppSpacing.lg),
+                Expanded(
+                  child: Text(
+                    label,
+                    style: TextStyle(
+                      color: textColor,
+                      fontSize: 16,
+                      fontWeight: fontWeight,
+                    ),
+                  ),
+                ),
+                if (badgeCount > 0)
+                  Container(
+                    width: 8,
+                    height: 8,
+                    decoration: BoxDecoration(
+                      color: colors?.destructiveRed ??
+                          const Color(0xFFD84D4D),
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ── Account menu item ─────────────────────────────────────────────────────────
 
 class _MenuItem extends StatelessWidget {
   const _MenuItem({

--- a/lib/features/trades/screens/trades_screen.dart
+++ b/lib/features/trades/screens/trades_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:mostro/core/app_routes.dart';
 import 'package:mostro/core/app_theme.dart';
+import 'package:mostro/features/drawer/screens/drawer_menu.dart';
 import 'package:mostro/features/trades/providers/trades_providers.dart';
 import 'package:mostro/features/trades/widgets/trades_list_item.dart';
 import 'package:mostro/shared/widgets/bottom_nav_bar.dart' show BottomNavBar;
@@ -28,95 +29,112 @@ class TradesScreen extends ConsumerWidget {
       next.whenData((_) => resetTradeNotifications(ref));
     });
 
-    return Scaffold(
-      appBar: AppBar(
-        leading: Builder(
-          builder: (context) => IconButton(
-            icon: const Icon(Icons.menu),
-            onPressed: () => Scaffold.of(context).openDrawer(),
-            tooltip: 'Menu',
-          ),
-        ),
-        title: Image.asset(
-          'assets/images/mostro_logo.png',
-          height: 28,
-          errorBuilder: (_, __, ___) => Text(
-            'Mostro',
-            style: Theme.of(context).textTheme.headlineMedium,
-          ),
-        ),
-        centerTitle: true,
-        actions: const [NotificationBell()],
-      ),
-      body: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // ── Sub-header ──────────────────────────────────────────────────
-          Padding(
-            padding: const EdgeInsets.fromLTRB(
-              AppSpacing.lg,
-              AppSpacing.md,
-              AppSpacing.lg,
-              0,
-            ),
-            child: Row(
-              children: [
-                Expanded(
-                  child: Text(
-                    'My Trades',
-                    style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                          color: colors.textPrimary,
-                          fontWeight: FontWeight.bold,
-                        ),
-                  ),
-                ),
+    final isDesktop =
+        MediaQuery.sizeOf(context).width >= AppBreakpoints.desktop;
 
-                // ── Status filter dropdown ──────────────────────────────
-                _StatusFilterButton(
-                  selected: selectedFilter,
-                  colors: colors,
-                  onChanged: (filter) {
-                    if (filter != null) {
-                      ref.read(selectedStatusFilterProvider.notifier).state =
-                          filter;
-                    }
-                  },
-                ),
-              ],
-            ),
+    final mainContent = Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // ── Sub-header ──────────────────────────────────────────────────
+        Padding(
+          padding: const EdgeInsets.fromLTRB(
+            AppSpacing.lg,
+            AppSpacing.md,
+            AppSpacing.lg,
+            0,
           ),
-          const SizedBox(height: AppSpacing.sm),
-
-          // ── Trade list / loading / empty / error ─────────────────────
-          Expanded(
-            child: tradesAsync.when(
-              data: (trades) => RefreshIndicator(
-                  onRefresh: () {
-                    refreshTrades(ref);
-                    return ref.refresh(filteredTradesWithOrderStateProvider.future);
-                  },
-                  child: trades.isEmpty
-                      ? _EmptyState(colors: colors)
-                      : ListView.builder(
-                          padding: const EdgeInsets.only(
-                            top: AppSpacing.xs,
-                            bottom: AppSpacing.lg,
-                          ),
-                          itemCount: trades.length,
-                          itemBuilder: (context, index) =>
-                              TradesListItem(trade: trades[index]),
-                        ),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  'My Trades',
+                  style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                        color: colors.textPrimary,
+                        fontWeight: FontWeight.bold,
+                      ),
                 ),
-              loading: () => const Center(child: CircularProgressIndicator()),
-              error: (e, _) => _ErrorState(
-                colors: colors,
-                onRetry: () =>
-                    ref.invalidate(filteredTradesWithOrderStateProvider),
               ),
+
+              // ── Status filter dropdown ────────────────────────────────
+              _StatusFilterButton(
+                selected: selectedFilter,
+                colors: colors,
+                onChanged: (filter) {
+                  if (filter != null) {
+                    ref.read(selectedStatusFilterProvider.notifier).state =
+                        filter;
+                  }
+                },
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+
+        // ── Trade list / loading / empty / error ──────────────────────
+        Expanded(
+          child: tradesAsync.when(
+            data: (trades) => RefreshIndicator(
+              onRefresh: () {
+                refreshTrades(ref);
+                return ref.refresh(filteredTradesWithOrderStateProvider.future);
+              },
+              child: trades.isEmpty
+                  ? _EmptyState(colors: colors)
+                  : ListView.builder(
+                      padding: const EdgeInsets.only(
+                        top: AppSpacing.xs,
+                        bottom: AppSpacing.lg,
+                      ),
+                      itemCount: trades.length,
+                      itemBuilder: (context, index) =>
+                          TradesListItem(trade: trades[index]),
+                    ),
+            ),
+            loading: () => const Center(child: CircularProgressIndicator()),
+            error: (e, _) => _ErrorState(
+              colors: colors,
+              onRetry: () =>
+                  ref.invalidate(filteredTradesWithOrderStateProvider),
             ),
           ),
-        ],
-      ),
+        ),
+      ],
+    );
+
+    final body = isDesktop
+        ? Row(
+            children: [
+              const DrawerMenu(persistent: true),
+              const VerticalDivider(width: 1),
+              Expanded(child: mainContent),
+            ],
+          )
+        : mainContent;
+
+    return Scaffold(
+      appBar: isDesktop
+          ? null
+          : AppBar(
+              leading: Builder(
+                builder: (context) => IconButton(
+                  icon: const Icon(Icons.menu),
+                  onPressed: () => Scaffold.of(context).openDrawer(),
+                  tooltip: 'Menu',
+                ),
+              ),
+              title: Image.asset(
+                'assets/images/mostro_logo.png',
+                height: 28,
+                errorBuilder: (_, __, ___) => Text(
+                  'Mostro',
+                  style: Theme.of(context).textTheme.headlineMedium,
+                ),
+              ),
+              centerTitle: true,
+              actions: const [NotificationBell()],
+            ),
+      body: body,
       bottomNavigationBar: const BottomNavBar(),
     );
   }

--- a/lib/features/trades/screens/trades_screen.dart
+++ b/lib/features/trades/screens/trades_screen.dart
@@ -13,11 +13,18 @@ import 'package:mostro/shared/widgets/notification_bell.dart';
 ///
 /// Shows all user trades sorted newest-first with a status filter dropdown.
 /// Tapping a card navigates to `/trade_detail/:orderId`.
-class TradesScreen extends ConsumerWidget {
+class TradesScreen extends ConsumerStatefulWidget {
   const TradesScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<TradesScreen> createState() => _TradesScreenState();
+}
+
+class _TradesScreenState extends ConsumerState<TradesScreen> {
+  bool _drawerOpen = false;
+
+  @override
+  Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<AppColors>();
     if (colors == null) throw StateError('AppColors theme extension must be registered');
 
@@ -102,39 +109,46 @@ class TradesScreen extends ConsumerWidget {
       ],
     );
 
-    final body = isDesktop
-        ? Row(
-            children: [
-              const DrawerMenu(persistent: true),
-              const VerticalDivider(width: 1),
-              Expanded(child: mainContent),
-            ],
-          )
-        : mainContent;
+    if (isDesktop) {
+      return Scaffold(
+        body: Row(
+          children: [
+            const DrawerMenu(persistent: true),
+            const VerticalDivider(width: 1),
+            Expanded(child: SafeArea(child: mainContent)),
+          ],
+        ),
+        bottomNavigationBar: const BottomNavBar(),
+      );
+    }
 
     return Scaffold(
-      appBar: isDesktop
-          ? null
-          : AppBar(
-              leading: Builder(
-                builder: (context) => IconButton(
-                  icon: const Icon(Icons.menu),
-                  onPressed: () => Scaffold.of(context).openDrawer(),
-                  tooltip: 'Menu',
-                ),
-              ),
-              title: Image.asset(
-                'assets/images/mostro_logo.png',
-                height: 28,
-                errorBuilder: (_, __, ___) => Text(
-                  'Mostro',
-                  style: Theme.of(context).textTheme.headlineMedium,
-                ),
-              ),
-              centerTitle: true,
-              actions: const [NotificationBell()],
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.menu),
+          onPressed: () => setState(() => _drawerOpen = true),
+          tooltip: 'Menu',
+        ),
+        title: Image.asset(
+          'assets/images/mostro_logo.png',
+          height: 28,
+          errorBuilder: (_, __, ___) => Text(
+            'Mostro',
+            style: Theme.of(context).textTheme.headlineMedium,
+          ),
+        ),
+        centerTitle: true,
+        actions: const [NotificationBell()],
+      ),
+      body: Stack(
+        children: [
+          mainContent,
+          if (_drawerOpen)
+            DrawerMenu(
+              onClose: () => setState(() => _drawerOpen = false),
             ),
-      body: body,
+        ],
+      ),
       bottomNavigationBar: const BottomNavBar(),
     );
   }


### PR DESCRIPTION
On desktop (≥1200px) the bottom nav bar is hidden. Previously the only way to reach My Trades and Chat was via the bottom bar, making those screens unreachable on desktop.

Changes:
- DrawerMenu is now a ConsumerWidget; in persistent mode it renders three primary nav items (Order Book / My Trades / Chat) above the account items, with active-route highlighting and badge dots
- TradesScreen and ChatRoomsScreen adopt the same desktop Row layout as HomeScreen: persistent sidebar + VerticalDivider + main content; AppBar is hidden on desktop since the sidebar provides context
- _NavItem widget: filled background on active, badge dot for unseen count

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added responsive desktop layouts for Chat and Trades sections featuring persistent sidebar navigation
  * Notification badges now display in the sidebar for Order Book and Chat features
  * Active navigation state highlighting on desktop

* **UI/UX Improvements**
  * Desktop users see optimized layout without top app bar
  * Mobile experience preserved with app bar retained
  * Responsive breakpoint-based layout adjustment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->