### PR TITLE
feat: implement all wired TODOs across Rust and Dart layers

### DIFF
--- a/lib/features/about/screens/about_screen.dart
+++ b/lib/features/about/screens/about_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 
 import 'package:mostro/core/app_theme.dart';
 import 'package:mostro/core/mostro_defaults.dart';
+import 'package:mostro/src/rust/api.dart' as rust_api;
 
 // Default Mostro node info — imported from core/mostro_defaults.dart.
 const _defaultPubkey = defaultMostroPubkey;
@@ -10,11 +11,23 @@ const _defaultRelays = defaultMostroRelays;
 
 /// About screen — shows app version, Mostro branding, docs link, and default
 /// node information.
-class AboutScreen extends StatelessWidget {
+class AboutScreen extends StatefulWidget {
   const AboutScreen({super.key});
 
-  // TODO(bridge): replace with get_app_version() when bridge is wired
-  static const _appVersion = '1.0.0';
+  @override
+  State<AboutScreen> createState() => _AboutScreenState();
+}
+
+class _AboutScreenState extends State<AboutScreen> {
+  String _appVersion = '…';
+
+  @override
+  void initState() {
+    super.initState();
+    rust_api.getAppVersion().then((v) {
+      if (mounted) setState(() => _appVersion = v);
+    }).catchError((_) {});
+  }
 
   String _truncatePubkey(String pubkey) {
     if (pubkey.length <= 16) return pubkey;

--- a/lib/features/about/screens/about_screen.dart
+++ b/lib/features/about/screens/about_screen.dart
@@ -26,7 +26,10 @@ class _AboutScreenState extends State<AboutScreen> {
     super.initState();
     rust_api.getAppVersion().then((v) {
       if (mounted) setState(() => _appVersion = v);
-    }).catchError((_) {});
+    }).catchError((e) {
+      debugPrint('[AboutScreen] getAppVersion failed: $e');
+      if (mounted) setState(() => _appVersion = 'unknown');
+    });
   }
 
   String _truncatePubkey(String pubkey) {

--- a/lib/features/about/screens/about_screen.dart
+++ b/lib/features/about/screens/about_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:mostro/core/app_theme.dart';
 import 'package:mostro/core/mostro_defaults.dart';
@@ -9,28 +10,17 @@ import 'package:mostro/src/rust/api.dart' as rust_api;
 const _defaultPubkey = defaultMostroPubkey;
 const _defaultRelays = defaultMostroRelays;
 
+/// Provides the app version string from the Rust layer.
+///
+/// Returns `'unknown'` on error so the UI always renders a legible value.
+final appVersionProvider = FutureProvider<String>((ref) async {
+  return rust_api.getAppVersion();
+});
+
 /// About screen — shows app version, Mostro branding, docs link, and default
 /// node information.
-class AboutScreen extends StatefulWidget {
+class AboutScreen extends ConsumerWidget {
   const AboutScreen({super.key});
-
-  @override
-  State<AboutScreen> createState() => _AboutScreenState();
-}
-
-class _AboutScreenState extends State<AboutScreen> {
-  String _appVersion = '…';
-
-  @override
-  void initState() {
-    super.initState();
-    rust_api.getAppVersion().then((v) {
-      if (mounted) setState(() => _appVersion = v);
-    }).catchError((e) {
-      debugPrint('[AboutScreen] getAppVersion failed: $e');
-      if (mounted) setState(() => _appVersion = 'unknown');
-    });
-  }
 
   String _truncatePubkey(String pubkey) {
     if (pubkey.length <= 16) return pubkey;
@@ -62,10 +52,19 @@ class _AboutScreenState extends State<AboutScreen> {
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final colors = Theme.of(context).extension<AppColors>();
     if (colors == null) throw StateError('AppColors theme extension must be registered');
     final c = colors;
+
+    final appVersion = ref.watch(appVersionProvider).when(
+      data: (v) => v,
+      loading: () => '…',
+      error: (e, _) {
+        debugPrint('[AboutScreen] getAppVersion failed: $e');
+        return 'unknown';
+      },
+    );
 
     return Scaffold(
       appBar: AppBar(
@@ -99,7 +98,7 @@ class _AboutScreenState extends State<AboutScreen> {
                 ),
                 const SizedBox(height: AppSpacing.xs),
                 Text(
-                  'v$_appVersion',
+                  'v$appVersion',
                   style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                         color: c.textSubtle,
                       ),

--- a/lib/features/account/providers/privacy_mode_provider.dart
+++ b/lib/features/account/providers/privacy_mode_provider.dart
@@ -23,8 +23,15 @@ class PrivacyModeNotifier extends StateNotifier<bool> {
   }
 
   /// Set privacy mode to [enabled] and propagate to the Rust layer.
-  void setPrivacyMode(bool enabled) {
+  ///
+  /// Optimistically updates local state and rolls back on failure.
+  Future<void> setPrivacyMode(bool enabled) async {
+    final previous = state;
     state = enabled;
-    reputation_api.setPrivacyMode(enabled: enabled).ignore();
+    try {
+      await reputation_api.setPrivacyMode(enabled: enabled);
+    } catch (e) {
+      if (mounted) state = previous;
+    }
   }
 }

--- a/lib/features/account/providers/privacy_mode_provider.dart
+++ b/lib/features/account/providers/privacy_mode_provider.dart
@@ -1,23 +1,30 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mostro/src/rust/api/reputation.dart' as reputation_api;
 
-/// In-memory privacy mode flag.
+/// In-memory privacy mode flag, initialised from the Rust layer on first use.
 ///
 /// Wraps `get_privacy_mode()` / `set_privacy_mode()` from the Rust reputation
 /// API.  UI reads and writes go through this provider so widgets can react
 /// to changes without polling.
-///
-/// TODO(bridge): initialise from `get_privacy_mode()` once the bridge is wired
-/// (Phase 18+).
 final privacyModeProvider = StateNotifierProvider<PrivacyModeNotifier, bool>(
   (ref) => PrivacyModeNotifier(),
 );
 
 class PrivacyModeNotifier extends StateNotifier<bool> {
-  PrivacyModeNotifier() : super(false);
+  PrivacyModeNotifier() : super(false) {
+    _init();
+  }
+
+  Future<void> _init() async {
+    try {
+      final current = await reputation_api.getPrivacyMode();
+      if (mounted) state = current;
+    } catch (_) {}
+  }
 
   /// Set privacy mode to [enabled] and propagate to the Rust layer.
   void setPrivacyMode(bool enabled) {
     state = enabled;
-    // TODO(bridge): call set_privacy_mode(enabled) via FFI (Phase 18+).
+    reputation_api.setPrivacyMode(enabled: enabled).ignore();
   }
 }

--- a/lib/features/rate/screens/rate_counterpart_screen.dart
+++ b/lib/features/rate/screens/rate_counterpart_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import 'package:mostro/core/app_theme.dart';
 import 'package:mostro/features/rate/widgets/star_rating.dart';
+import 'package:mostro/src/rust/api/reputation.dart' as reputation_api;
 
 /// Rate counterpart screen — Route `/rate_user/:orderId`.
 ///
@@ -37,9 +38,10 @@ class _RateCounterpartScreenState
     if (_rating == 0) return;
     setState(() => _isSubmitting = true);
     try {
-      // TODO(bridge): Call reputation.submit_rating(widget.orderId, _rating)
-      // via Rust bridge once FFI bindings are generated.
-      await Future.delayed(const Duration(milliseconds: 300));
+      await reputation_api.submitRating(
+        tradeId: widget.orderId,
+        score: _rating,
+      );
       if (mounted) context.pop();
     } catch (e) {
       if (!mounted) return;

--- a/lib/features/settings/screens/connect_wallet_screen.dart
+++ b/lib/features/settings/screens/connect_wallet_screen.dart
@@ -7,6 +7,7 @@ import 'package:mostro/l10n/app_localizations.dart';
 import 'package:mostro/shared/widgets/platform_aware_qr_scanner.dart';
 import 'package:mostro/core/app_theme.dart';
 import 'package:mostro/features/settings/providers/nwc_provider.dart';
+import 'package:mostro/src/rust/api/nwc.dart' as nwc_api;
 
 /// Connect Wallet screen — Route `/connect_wallet`.
 ///
@@ -50,32 +51,14 @@ class _ConnectWalletScreenState extends ConsumerState<ConnectWalletScreen> {
     if (_connecting || !_isValid) return;
     setState(() => _connecting = true);
     try {
-      // TODO(bridge): Call nwc_api.connect_wallet(_uriController.text) via
-      // Rust bridge once FFI bindings are generated.  On success, populate
-      // NwcWalletState from the returned NwcWalletInfo.
-      await Future.delayed(const Duration(milliseconds: 300));
-
-      // Stub: store minimal wallet state from the parsed URI.
-      final parsed = Uri.parse(_uriController.text.trim());
-      final pubkey = parsed.host; // Dart normalises host to lowercase.
-      final relayUrls = (parsed.queryParametersAll['relay'] ?? const [])
-          .where((r) => r.startsWith('wss://') || r.startsWith('ws://'))
-          .toList();
-
+      final info = await nwc_api.connectWallet(nwcUri: _uriController.text.trim());
       if (!mounted) return;
-      if (relayUrls.isEmpty) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('No valid relay URL found in NWC URI.'),
-          ),
-        );
-        setState(() => _connecting = false);
-        return;
-      }
       ref.read(nwcProvider.notifier).setConnected(
             NwcWalletState(
-              walletPubkey: pubkey,
-              relayUrls: relayUrls,
+              walletPubkey: info.walletPubkey,
+              relayUrls: info.relayUrls,
+              walletName: info.walletName,
+              balanceSats: info.balanceSats?.toInt(),
             ),
           );
       context.go(AppRoute.walletSettings);

--- a/lib/features/settings/screens/wallet_settings_screen.dart
+++ b/lib/features/settings/screens/wallet_settings_screen.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import 'package:mostro/core/app_routes.dart';
 import 'package:mostro/core/app_theme.dart';
 import 'package:mostro/features/settings/providers/nwc_provider.dart';
+import 'package:mostro/src/rust/api/nwc.dart' as nwc_api;
 
 /// Wallet Settings screen — Route `/wallet_settings`.
 ///
@@ -40,7 +41,11 @@ class WalletSettingsScreen extends ConsumerWidget {
   }
 
   Future<void> _disconnect(BuildContext context, WidgetRef ref) async {
-    // TODO(bridge): Call nwc_api.disconnect_wallet() via Rust bridge.
+    try {
+      await nwc_api.disconnectWallet();
+    } catch (e) {
+      debugPrint('[WalletSettings] disconnect failed: $e');
+    }
     ref.read(nwcProvider.notifier).setDisconnected();
     if (context.mounted) {
       ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/features/settings/widgets/relay_management_card.dart
+++ b/lib/features/settings/widgets/relay_management_card.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mostro/core/app_theme.dart';
 import 'package:mostro/core/mostro_defaults.dart';
 import 'package:mostro/l10n/app_localizations.dart';
+import 'package:mostro/src/rust/api/nostr.dart' as nostr_api;
 
 // ── Model ─────────────────────────────────────────────────────────────────────
 
@@ -48,18 +49,35 @@ class _RelayManagementCardState extends ConsumerState<RelayManagementCard> {
     _relays = _defaultRelays
         .map((url) => _RelayEntry(url: url, isActive: true, isDefault: true))
         .toList();
+    _loadRelays();
+  }
+
+  Future<void> _loadRelays() async {
+    try {
+      final relays = await nostr_api.getRelays();
+      if (!mounted) return;
+      setState(() {
+        _relays = relays.map((r) => _RelayEntry(
+          url: r.url,
+          isActive: r.isActive,
+          isDefault: r.isDefault,
+        )).toList();
+      });
+    } catch (e) {
+      debugPrint('[RelayManagement] failed to load relays: $e');
+    }
   }
 
   void _toggleRelay(int index, bool value) {
     setState(() => _relays[index].isActive = value);
-    // TODO(bridge): call set_relay_active(_relays[index].url, value)
   }
 
   void _removeRelay(int index) {
-    // ignore: unused_local_variable — used by the pending bridge call below.
     final url = _relays[index].url;
     setState(() => _relays.removeAt(index));
-    // TODO(bridge): call remove_relay(url)
+    nostr_api.removeRelay(url: url).catchError((e) {
+      debugPrint('[RelayManagement] removeRelay failed: $e');
+    });
   }
 
   Future<void> _showAddRelayDialog() async {
@@ -124,7 +142,9 @@ class _RelayManagementCardState extends ConsumerState<RelayManagementCard> {
                       );
                     });
                     Navigator.of(ctx).pop();
-                    // TODO(bridge): call add_relay(url)
+                    nostr_api.addRelay(url: url).then((_) {}, onError: (e) {
+                      debugPrint('[RelayManagement] addRelay failed: $e');
+                    });
                   },
                   child: Text(l10n.addButtonLabel),
                 ),

--- a/lib/features/settings/widgets/relay_management_card.dart
+++ b/lib/features/settings/widgets/relay_management_card.dart
@@ -42,6 +42,7 @@ class _RelayManagementCardState extends ConsumerState<RelayManagementCard> {
   // by the Rust bridge (get_relays / add_relay / remove_relay) so configuration
   // persists across navigations and stays in sync with the backend (Phase 18+).
   late List<_RelayEntry> _relays;
+  bool _loading = false;
 
   @override
   void initState() {
@@ -53,6 +54,8 @@ class _RelayManagementCardState extends ConsumerState<RelayManagementCard> {
   }
 
   Future<void> _loadRelays() async {
+    if (_loading) return;
+    _loading = true;
     try {
       final relays = await nostr_api.getRelays();
       if (!mounted) return;
@@ -65,6 +68,8 @@ class _RelayManagementCardState extends ConsumerState<RelayManagementCard> {
       });
     } catch (e) {
       debugPrint('[RelayManagement] failed to load relays: $e');
+    } finally {
+      _loading = false;
     }
   }
 
@@ -72,12 +77,21 @@ class _RelayManagementCardState extends ConsumerState<RelayManagementCard> {
     setState(() => _relays[index].isActive = value);
   }
 
-  void _removeRelay(int index) {
+  Future<void> _removeRelay(int index) async {
     final url = _relays[index].url;
+    final removed = _relays[index];
     setState(() => _relays.removeAt(index));
-    nostr_api.removeRelay(url: url).catchError((e) {
+    try {
+      await nostr_api.removeRelay(url: url);
+    } catch (e) {
       debugPrint('[RelayManagement] removeRelay failed: $e');
-    });
+      if (!mounted) return;
+      setState(() => _relays.insert(index, removed));
+      final l10n = AppLocalizations.of(context);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(l10n.relayRemoveFailed)),
+      );
+    }
   }
 
   Future<void> _showAddRelayDialog() async {
@@ -132,18 +146,22 @@ class _RelayManagementCardState extends ConsumerState<RelayManagementCard> {
                       if (ctx.mounted) Navigator.of(ctx).pop();
                       return;
                     }
-                    setState(() {
-                      _relays.add(
-                        _RelayEntry(
-                          url: url,
-                          isActive: true,
-                          isDefault: false,
-                        ),
-                      );
-                    });
+                    final newEntry = _RelayEntry(
+                      url: url,
+                      isActive: true,
+                      isDefault: false,
+                    );
+                    setState(() => _relays.add(newEntry));
                     Navigator.of(ctx).pop();
                     nostr_api.addRelay(url: url).then((_) {}, onError: (e) {
                       debugPrint('[RelayManagement] addRelay failed: $e');
+                      if (!mounted) return;
+                      setState(() => _relays.removeWhere((r) => r.url == url));
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Text(AppLocalizations.of(context).relayAddFailed),
+                        ),
+                      );
                     });
                   },
                   child: Text(l10n.addButtonLabel),

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -196,6 +196,8 @@
   "disableRelayLabel": "Relay {url} deaktivieren",
   "enableRelayLabel": "Relay {url} aktivieren",
   "removeRelayTooltip": "Relay entfernen",
+  "relayAddFailed": "Relay konnte nicht hinzugefügt werden",
+  "relayRemoveFailed": "Relay konnte nicht entfernt werden",
   "backupConfirmCheckbox": "Ich habe meine Wörter aufgeschrieben und sicher gespeichert",
 
   "cancelTradeDialogTitle": "Handel abbrechen?",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -410,6 +410,10 @@
   },
   "removeRelayTooltip": "Remove relay",
   "@removeRelayTooltip": {"description": "Tooltip for the remove-relay icon button"},
+  "relayAddFailed": "Failed to add relay",
+  "@relayAddFailed": {"description": "SnackBar message shown when adding a relay fails"},
+  "relayRemoveFailed": "Failed to remove relay",
+  "@relayRemoveFailed": {"description": "SnackBar message shown when removing a relay fails"},
   "backupConfirmCheckbox": "I have written down my words and backed them up securely",
   "@backupConfirmCheckbox": {"description": "Label for the backup confirmation checkbox on the Account screen"},
 

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -196,6 +196,8 @@
   "disableRelayLabel": "Desactivar relay {url}",
   "enableRelayLabel": "Activar relay {url}",
   "removeRelayTooltip": "Eliminar relay",
+  "relayAddFailed": "Error al añadir el relay",
+  "relayRemoveFailed": "Error al eliminar el relay",
   "backupConfirmCheckbox": "He anotado mis palabras y las he guardado de forma segura",
 
   "cancelTradeDialogTitle": "¿Cancelar intercambio?",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -196,6 +196,8 @@
   "disableRelayLabel": "Désactiver le relais {url}",
   "enableRelayLabel": "Activer le relais {url}",
   "removeRelayTooltip": "Supprimer le relais",
+  "relayAddFailed": "Échec de l'ajout du relais",
+  "relayRemoveFailed": "Échec de la suppression du relais",
   "backupConfirmCheckbox": "J'ai noté mes mots et les ai sauvegardés en lieu sûr",
 
   "cancelTradeDialogTitle": "Annuler l'échange ?",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -196,6 +196,8 @@
   "disableRelayLabel": "Disabilita relay {url}",
   "enableRelayLabel": "Abilita relay {url}",
   "removeRelayTooltip": "Rimuovi relay",
+  "relayAddFailed": "Impossibile aggiungere il relay",
+  "relayRemoveFailed": "Impossibile rimuovere il relay",
   "backupConfirmCheckbox": "Ho annotato le mie parole e le ho salvate in modo sicuro",
 
   "cancelTradeDialogTitle": "Annullare lo scambio?",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1190,6 +1190,18 @@ abstract class AppLocalizations {
   /// **'Remove relay'**
   String get removeRelayTooltip;
 
+  /// SnackBar message shown when adding a relay fails
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to add relay'**
+  String get relayAddFailed;
+
+  /// SnackBar message shown when removing a relay fails
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to remove relay'**
+  String get relayRemoveFailed;
+
   /// Label for the backup confirmation checkbox on the Account screen
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -601,6 +601,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get removeRelayTooltip => 'Relay entfernen';
 
   @override
+  String get relayAddFailed => 'Relay konnte nicht hinzugefügt werden';
+
+  @override
+  String get relayRemoveFailed => 'Relay konnte nicht entfernt werden';
+
+  @override
   String get backupConfirmCheckbox =>
       'Ich habe meine Wörter aufgeschrieben und sicher gespeichert';
 

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -593,6 +593,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get removeRelayTooltip => 'Remove relay';
 
   @override
+  String get relayAddFailed => 'Failed to add relay';
+
+  @override
+  String get relayRemoveFailed => 'Failed to remove relay';
+
+  @override
   String get backupConfirmCheckbox =>
       'I have written down my words and backed them up securely';
 

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -601,6 +601,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get removeRelayTooltip => 'Eliminar relay';
 
   @override
+  String get relayAddFailed => 'Error al añadir el relay';
+
+  @override
+  String get relayRemoveFailed => 'Error al eliminar el relay';
+
+  @override
   String get backupConfirmCheckbox =>
       'He anotado mis palabras y las he guardado de forma segura';
 

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -605,6 +605,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get removeRelayTooltip => 'Supprimer le relais';
 
   @override
+  String get relayAddFailed => 'Échec de l\'ajout du relais';
+
+  @override
+  String get relayRemoveFailed => 'Échec de la suppression du relais';
+
+  @override
   String get backupConfirmCheckbox =>
       'J\'ai noté mes mots et les ai sauvegardés en lieu sûr';
 

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -601,6 +601,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get removeRelayTooltip => 'Rimuovi relay';
 
   @override
+  String get relayAddFailed => 'Impossibile aggiungere il relay';
+
+  @override
+  String get relayRemoveFailed => 'Impossibile rimuovere il relay';
+
+  @override
   String get backupConfirmCheckbox =>
       'Ho annotato le mie parole e le ho salvate in modo sicuro';
 

--- a/rust/src/api/disputes.rs
+++ b/rust/src/api/disputes.rs
@@ -123,6 +123,32 @@ pub async fn open_dispute(trade_id: String, reason: Option<String>) -> Result<Di
         bail!("TradeNotDisputable: trade_id must not be empty");
     }
 
+    // Dispatch Action::Dispute to Mostro BEFORE creating the local record so
+    // that a failed publish does not leave an un-retryable "open" slot in the
+    // dispute store.  Only on a successful publish do we persist the dispute.
+    let trade_index = crate::api::orders::trade_key_for_order(&trade_id)
+        .await
+        .ok_or_else(|| anyhow!("TradeNotDisputable: no trade key for trade {trade_id}"))?;
+
+    let event_json: String = async {
+        let sender_keys =
+            crate::api::identity::get_active_trade_keys(trade_index).await?;
+        let mostro_pubkey =
+            nostr_sdk::PublicKey::from_hex(crate::config::DEFAULT_MOSTRO_PUBKEY)
+                .map_err(|e| anyhow!("invalid DEFAULT_MOSTRO_PUBKEY: {e}"))?;
+        crate::mostro::actions::dispute(&sender_keys, &mostro_pubkey, &trade_id, trade_index)
+            .await
+    }
+    .await
+    .map_err(|e| anyhow!("ProtocolError: could not build Dispute message: {e}"))?;
+
+    crate::api::orders::publish_event(&event_json)
+        .await
+        .map_err(|e| anyhow!("ProtocolError: publish failed: {e}"))?;
+
+    log::info!("[disputes] Dispute dispatched for trade={trade_id}");
+
+    // Publish succeeded — persist the dispute record.
     let dispute = Dispute {
         id: uuid::Uuid::new_v4().to_string(),
         trade_id: trade_id.clone(),
@@ -136,44 +162,9 @@ pub async fn open_dispute(trade_id: String, reason: Option<String>) -> Result<Di
         is_read: true,
     };
 
-    let dispute = dispute_store()
+    dispute_store()
         .try_insert_if_absent_or_resolved(dispute)
-        .await?;
-
-    // Dispatch Action::Dispute to the Mostro daemon via NIP-59 Gift Wrap.
-    if let Some(trade_index) = crate::api::orders::trade_key_for_order(&trade_id).await {
-        match crate::api::identity::get_active_trade_keys(trade_index).await {
-            Ok(sender_keys) => {
-                match nostr_sdk::PublicKey::from_hex(crate::config::DEFAULT_MOSTRO_PUBKEY) {
-                    Ok(mostro_pubkey) => {
-                        match crate::mostro::actions::dispute(
-                            &sender_keys,
-                            &mostro_pubkey,
-                            &trade_id,
-                            trade_index,
-                        )
-                        .await
-                        {
-                            Ok(event_json) => {
-                                if let Err(e) = crate::api::orders::publish_event(&event_json).await {
-                                    log::warn!("[disputes] dispute publish failed: {e}");
-                                } else {
-                                    log::info!("[disputes] Dispute dispatched for trade={trade_id}");
-                                }
-                            }
-                            Err(e) => log::warn!("[disputes] dispute build failed: {e}"),
-                        }
-                    }
-                    Err(e) => log::error!("[disputes] invalid mostro pubkey: {e}"),
-                }
-            }
-            Err(e) => log::warn!("[disputes] could not get trade keys: {e}"),
-        }
-    } else {
-        log::warn!("[disputes] no trade key for trade={trade_id}; dispute stored locally only");
-    }
-
-    Ok(dispute)
+        .await
 }
 
 /// Submit free-text evidence for an open dispute.
@@ -295,12 +286,48 @@ pub async fn on_dispute_updated(trade_id: String) -> Result<DisputeStream> {
 mod tests {
     use super::*;
 
-    #[tokio::test]
-    async fn open_dispute_creates_record() {
-        let trade_id = format!("t-{}", uuid::Uuid::new_v4());
-        let dispute = open_dispute(trade_id.clone(), Some("Price disagreement".into()))
+    /// Insert a dispute directly into the store, bypassing dispatch.
+    ///
+    /// Used in unit tests that exercise store operations (admin events,
+    /// evidence validation, etc.) without needing a live relay or trade key.
+    async fn seed_dispute(trade_id: &str, reason: Option<String>) -> Dispute {
+        let dispute = Dispute {
+            id: uuid::Uuid::new_v4().to_string(),
+            trade_id: trade_id.to_string(),
+            status: DisputeStatus::Open,
+            initiated_by_me: true,
+            reason,
+            admin_pubkey: None,
+            resolution: None,
+            opened_at: unix_now(),
+            resolved_at: None,
+            is_read: true,
+        };
+        dispute_store()
+            .try_insert_if_absent_or_resolved(dispute)
             .await
-            .unwrap();
+            .expect("seed_dispute: insert failed")
+    }
+
+    #[tokio::test]
+    async fn open_dispute_requires_trade_key() {
+        // open_dispute now dispatches to Mostro before persisting; without a
+        // trade key it must return TradeNotDisputable rather than silently
+        // storing a local-only dispute that the daemon never received.
+        let trade_id = format!("t-{}", uuid::Uuid::new_v4());
+        let err = open_dispute(trade_id, Some("Price disagreement".into()))
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("TradeNotDisputable"),
+            "expected TradeNotDisputable, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispute_store_creates_record() {
+        let trade_id = format!("t-{}", uuid::Uuid::new_v4());
+        let dispute = seed_dispute(&trade_id, Some("Price disagreement".into())).await;
 
         assert_eq!(dispute.trade_id, trade_id);
         assert_eq!(dispute.status, DisputeStatus::Open);
@@ -311,16 +338,32 @@ mod tests {
     #[tokio::test]
     async fn duplicate_dispute_is_rejected() {
         let trade_id = format!("t-{}", uuid::Uuid::new_v4());
-        open_dispute(trade_id.clone(), None).await.unwrap();
+        seed_dispute(&trade_id, None).await;
 
-        let err = open_dispute(trade_id, None).await.unwrap_err();
+        // Second insert into the same trade must fail.
+        let dispute = Dispute {
+            id: uuid::Uuid::new_v4().to_string(),
+            trade_id: trade_id.clone(),
+            status: DisputeStatus::Open,
+            initiated_by_me: true,
+            reason: None,
+            admin_pubkey: None,
+            resolution: None,
+            opened_at: unix_now(),
+            resolved_at: None,
+            is_read: true,
+        };
+        let err = dispute_store()
+            .try_insert_if_absent_or_resolved(dispute)
+            .await
+            .unwrap_err();
         assert!(err.to_string().contains("DisputeAlreadyOpen"));
     }
 
     #[tokio::test]
     async fn empty_evidence_is_rejected() {
         let trade_id = format!("t-{}", uuid::Uuid::new_v4());
-        open_dispute(trade_id.clone(), None).await.unwrap();
+        seed_dispute(&trade_id, None).await;
 
         let err = submit_evidence(trade_id, "  ".into()).await.unwrap_err();
         assert!(err.to_string().contains("EvidenceEmpty"));
@@ -329,7 +372,7 @@ mod tests {
     #[tokio::test]
     async fn admin_took_dispute_sets_in_review() {
         let trade_id = format!("t-{}", uuid::Uuid::new_v4());
-        open_dispute(trade_id.clone(), None).await.unwrap();
+        seed_dispute(&trade_id, None).await;
 
         handle_admin_took_dispute(trade_id.clone(), "adminpubkey123".into())
             .await
@@ -343,7 +386,7 @@ mod tests {
     #[tokio::test]
     async fn admin_settled_resolves_dispute() {
         let trade_id = format!("t-{}", uuid::Uuid::new_v4());
-        open_dispute(trade_id.clone(), None).await.unwrap();
+        seed_dispute(&trade_id, None).await;
 
         handle_admin_settled(trade_id.clone()).await.unwrap();
 

--- a/rust/src/api/disputes.rs
+++ b/rust/src/api/disputes.rs
@@ -123,9 +123,6 @@ pub async fn open_dispute(trade_id: String, reason: Option<String>) -> Result<Di
         bail!("TradeNotDisputable: trade_id must not be empty");
     }
 
-    // TODO(Phase 12+): Look up session to get trade key + mostro pubkey, then
-    // send a Dispute MostroMessage via NIP-59 Gift Wrap.
-
     let dispute = Dispute {
         id: uuid::Uuid::new_v4().to_string(),
         trade_id: trade_id.clone(),
@@ -139,9 +136,44 @@ pub async fn open_dispute(trade_id: String, reason: Option<String>) -> Result<Di
         is_read: true,
     };
 
-    dispute_store()
+    let dispute = dispute_store()
         .try_insert_if_absent_or_resolved(dispute)
-        .await
+        .await?;
+
+    // Dispatch Action::Dispute to the Mostro daemon via NIP-59 Gift Wrap.
+    if let Some(trade_index) = crate::api::orders::trade_key_for_order(&trade_id).await {
+        match crate::api::identity::get_active_trade_keys(trade_index).await {
+            Ok(sender_keys) => {
+                match nostr_sdk::PublicKey::from_hex(crate::config::DEFAULT_MOSTRO_PUBKEY) {
+                    Ok(mostro_pubkey) => {
+                        match crate::mostro::actions::dispute(
+                            &sender_keys,
+                            &mostro_pubkey,
+                            &trade_id,
+                            trade_index,
+                        )
+                        .await
+                        {
+                            Ok(event_json) => {
+                                if let Err(e) = crate::api::orders::publish_event(&event_json).await {
+                                    log::warn!("[disputes] dispute publish failed: {e}");
+                                } else {
+                                    log::info!("[disputes] Dispute dispatched for trade={trade_id}");
+                                }
+                            }
+                            Err(e) => log::warn!("[disputes] dispute build failed: {e}"),
+                        }
+                    }
+                    Err(e) => log::error!("[disputes] invalid mostro pubkey: {e}"),
+                }
+            }
+            Err(e) => log::warn!("[disputes] could not get trade keys: {e}"),
+        }
+    } else {
+        log::warn!("[disputes] no trade key for trade={trade_id}; dispute stored locally only");
+    }
+
+    Ok(dispute)
 }
 
 /// Submit free-text evidence for an open dispute.

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -787,7 +787,11 @@ pub(crate) async fn subscribe_gift_wraps(
                     }
                 }
                 Ok(Ok(RelayPoolNotification::Shutdown)) => break,
-                Ok(Err(_)) => break,
+                Ok(Err(broadcast::error::RecvError::Lagged(n))) => {
+                    log::warn!("[orders] gift-wrap lagged by {n} messages");
+                    continue;
+                }
+                Ok(Err(broadcast::error::RecvError::Closed)) => break,
                 Err(_) => break, // idle timeout
                 Ok(Ok(_)) => continue,
             }

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -409,6 +409,11 @@ pub async fn create_order(params: NewOrderParams) -> Result<OrderInfo> {
     let trade_index = trade_key_info.index;
     let sender_keys = crate::api::identity::get_active_trade_keys(trade_index).await?;
 
+    // Subscribe to gift-wrap (Kind 1059) responses from the daemon addressed to
+    // this trade key. This gives us the daemon-assigned order UUID faster and
+    // more reliably than waiting for the Kind 38383 content-fingerprint match.
+    subscribe_gift_wraps(sender_keys.public_key(), trade_index).await;
+
     // Build the content fingerprint key BEFORE publishing so the subscription
     // loop never races against an empty TRADE_KEY_MAP when the daemon replies
     // faster than our post-publish bookkeeping runs.
@@ -687,6 +692,173 @@ pub async fn cancel_order(order_id: String) -> Result<()> {
     publish_event_json(&event_json).await?;
     log::info!("[orders] cancel published for order={order_id} trade_index={trade_index}");
     Ok(())
+}
+
+// ── Gift-wrap (Kind 1059) subscription ───────────────────────────────────────
+
+/// Subscribe to NIP-59 Gift Wrap (Kind 1059) events addressed to a maker's
+/// trade key, spawning a background task that decrypts daemon responses.
+///
+/// Called immediately after creating a new maker order. Handles:
+/// - `Action::NewOrder` — daemon confirmed the order; bridges daemon UUID into
+///   `TRADE_KEY_MAP` via `resolve_maker_order`.
+/// - All other actions are logged (full trade-session routing is Phase 7+).
+pub(crate) async fn subscribe_gift_wraps(
+    trade_pubkey: nostr_sdk::PublicKey,
+    trade_index: u32,
+) {
+    tokio::spawn(async move {
+        let Ok(pool) = crate::api::nostr::get_pool() else {
+            log::warn!("[orders] subscribe_gift_wraps: relay pool not initialized");
+            return;
+        };
+        let client = pool.client();
+
+        // Obtain the notifications receiver BEFORE subscribing to avoid a
+        // window where daemon responses arrive but aren't captured.
+        let mut rx = client.notifications();
+
+        let filter = nostr_sdk::Filter::new()
+            .kind(nostr_sdk::Kind::from(1059u16))
+            .pubkey(trade_pubkey);
+        if let Err(e) = client.subscribe(filter, None).await {
+            log::warn!("[orders] subscribe_gift_wraps subscribe failed: {e}");
+            return;
+        }
+
+        let trade_pubkey_hex = trade_pubkey.to_hex();
+        log::info!("[orders] gift-wrap subscription active for trade_pubkey={trade_pubkey_hex}");
+
+        let recipient_keys =
+            match crate::api::identity::get_active_trade_keys(trade_index).await {
+                Ok(k) => k,
+                Err(e) => {
+                    log::error!("[orders] subscribe_gift_wraps: no trade keys: {e}");
+                    return;
+                }
+            };
+
+        use nostr_sdk::RelayPoolNotification;
+        use tokio::time::{timeout, Duration};
+
+        const IDLE_TIMEOUT_SECS: u64 = 30 * 60;
+        let mut last_activity = tokio::time::Instant::now();
+
+        loop {
+            let remaining = Duration::from_secs(IDLE_TIMEOUT_SECS)
+                .saturating_sub(last_activity.elapsed());
+            if remaining.is_zero() {
+                log::debug!(
+                    "[orders] gift-wrap idle timeout for trade={trade_pubkey_hex}"
+                );
+                break;
+            }
+
+            match timeout(remaining, rx.recv()).await {
+                Ok(Ok(RelayPoolNotification::Event { event, .. })) => {
+                    if event.kind != nostr_sdk::Kind::from(1059u16) {
+                        continue;
+                    }
+                    // Only process events addressed to our trade pubkey.
+                    let is_for_us = event.tags.iter().any(|t| {
+                        let s = t.as_slice();
+                        s.first().map(|v| v.as_str()) == Some("p")
+                            && s.get(1).map(|v| v.as_str()) == Some(trade_pubkey_hex.as_str())
+                    });
+                    if !is_for_us {
+                        continue;
+                    }
+
+                    let event_json = match serde_json::to_string(&*event) {
+                        Ok(j) => j,
+                        Err(e) => {
+                            log::warn!("[orders] gift-wrap event serialize failed: {e}");
+                            continue;
+                        }
+                    };
+                    match crate::nostr::gift_wrap::unwrap(&recipient_keys, &event_json).await {
+                        Ok(rumor_json) => {
+                            process_gift_wrap_rumor(&rumor_json, &trade_pubkey_hex).await;
+                            last_activity = tokio::time::Instant::now();
+                        }
+                        Err(e) => log::warn!("[orders] gift-wrap decrypt failed: {e}"),
+                    }
+                }
+                Ok(Ok(RelayPoolNotification::Shutdown)) => break,
+                Ok(Err(_)) => break,
+                Err(_) => break, // idle timeout
+                Ok(Ok(_)) => continue,
+            }
+        }
+
+        log::debug!(
+            "[orders] gift-wrap subscription exiting for trade={trade_pubkey_hex}"
+        );
+    });
+}
+
+/// Parse the inner rumor JSON from a decrypted gift-wrap and dispatch by action.
+async fn process_gift_wrap_rumor(rumor_json: &str, trade_pubkey_hex: &str) {
+    use mostro_core::message::{Action, Message};
+
+    // The rumor is a serialised UnsignedEvent; extract its content string.
+    let content = match serde_json::from_str::<serde_json::Value>(rumor_json) {
+        Ok(v) => match v.get("content").and_then(|c| c.as_str()) {
+            Some(s) => s.to_string(),
+            None => {
+                log::warn!("[orders] gift-wrap rumor has no content field");
+                return;
+            }
+        },
+        Err(e) => {
+            log::warn!("[orders] gift-wrap rumor JSON parse failed: {e}");
+            return;
+        }
+    };
+
+    // Mostro wire format: [message, null_or_peer]
+    let (msg, _peer): (Message, Option<mostro_core::message::Peer>) =
+        match serde_json::from_str(&content) {
+            Ok(p) => p,
+            Err(e) => {
+                log::warn!("[orders] gift-wrap content deserialize failed: {e}");
+                return;
+            }
+        };
+
+    let kind = msg.get_inner_message_kind();
+
+    log::info!(
+        "[orders] gift-wrap action={:?} order_id={:?} trade_pubkey={}",
+        kind.action,
+        kind.id,
+        trade_pubkey_hex
+    );
+
+    match &kind.action {
+        Action::NewOrder => {
+            if let Some(order_id) = &kind.id {
+                let order_id_str = order_id.to_string();
+                resolve_maker_order(&order_id_str, trade_pubkey_hex).await;
+                log::info!(
+                    "[orders] gift-wrap NewOrder: daemon order={order_id_str} confirmed"
+                );
+            } else {
+                log::warn!("[orders] gift-wrap NewOrder has no order id");
+            }
+        }
+        Action::Canceled => {
+            log::info!("[orders] gift-wrap Canceled for trade={trade_pubkey_hex}");
+            if let Some(order_id) = &kind.id {
+                order_book().remove_order(&order_id.to_string()).await;
+            }
+        }
+        action => {
+            log::debug!(
+                "[orders] gift-wrap unhandled action={action:?} (Phase 7+)"
+            );
+        }
+    }
 }
 
 // ── Single-order subscription ─────────────────────────────────────────────────

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -176,6 +176,16 @@ async fn get_trade_key_index(order_id: &str) -> Option<u32> {
     None
 }
 
+/// Expose trade key lookup for inter-module use (e.g. reputation rating).
+pub(crate) async fn trade_key_for_order(order_id: &str) -> Option<u32> {
+    get_trade_key_index(order_id).await
+}
+
+/// Expose event publishing for inter-module use.
+pub(crate) async fn publish_event(event_json: &str) -> Result<()> {
+    publish_event_json(event_json).await
+}
+
 /// Filter parameters for the order list.
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct OrderFilters {
@@ -329,8 +339,6 @@ pub async fn get_order(order_id: String) -> Result<Option<OrderInfo>> {
 /// Validates params, builds the MostroMessage, wraps via NIP-59, and
 /// publishes to relays. Queues if offline.
 ///
-/// TODO: Wire to actual Rust bridge identity + relay pool in Phase 7.
-/// Currently validates params and returns a mock OrderInfo.
 pub async fn create_order(params: NewOrderParams) -> Result<OrderInfo> {
     // Validate: fiat_amount XOR range
     let has_fixed = params.fiat_amount.is_some();

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -708,6 +708,17 @@ pub(crate) async fn subscribe_gift_wraps(
     trade_index: u32,
 ) {
     tokio::spawn(async move {
+        // Fetch keys first — if this fails there is no point subscribing and
+        // we avoid leaving an orphan relay subscription with no decryption path.
+        let recipient_keys =
+            match crate::api::identity::get_active_trade_keys(trade_index).await {
+                Ok(k) => k,
+                Err(e) => {
+                    log::error!("[orders] subscribe_gift_wraps: no trade keys: {e}");
+                    return;
+                }
+            };
+
         let Ok(pool) = crate::api::nostr::get_pool() else {
             log::warn!("[orders] subscribe_gift_wraps: relay pool not initialized");
             return;
@@ -728,15 +739,6 @@ pub(crate) async fn subscribe_gift_wraps(
 
         let trade_pubkey_hex = trade_pubkey.to_hex();
         log::info!("[orders] gift-wrap subscription active for trade_pubkey={trade_pubkey_hex}");
-
-        let recipient_keys =
-            match crate::api::identity::get_active_trade_keys(trade_index).await {
-                Ok(k) => k,
-                Err(e) => {
-                    log::error!("[orders] subscribe_gift_wraps: no trade keys: {e}");
-                    return;
-                }
-            };
 
         use nostr_sdk::RelayPoolNotification;
         use tokio::time::{timeout, Duration};

--- a/rust/src/api/reputation.rs
+++ b/rust/src/api/reputation.rs
@@ -125,8 +125,42 @@ pub async fn submit_rating(trade_id: String, score: u8) -> Result<()> {
         bail!("PrivacyModeEnabled: cannot submit rating while privacy mode is active");
     }
 
-    // TODO(Phase 14+): Look up the session to get trade key + mostro pubkey,
-    // then send a RateUser MostroMessage via NIP-59 Gift Wrap.
+    // Send the RateUser message to the Mostro daemon via NIP-59 Gift Wrap using
+    // the trade key that was used when the order was taken or created.
+    if let Some(trade_index) = crate::api::orders::trade_key_for_order(&trade_id).await {
+        match crate::api::identity::get_active_trade_keys(trade_index).await {
+            Ok(sender_keys) => {
+                match nostr_sdk::PublicKey::from_hex(crate::config::DEFAULT_MOSTRO_PUBKEY) {
+                    Ok(mostro_pubkey) => {
+                        match crate::mostro::actions::rate_user(
+                            &sender_keys,
+                            &mostro_pubkey,
+                            &trade_id,
+                            trade_index,
+                            score,
+                        )
+                        .await
+                        {
+                            Ok(event_json) => {
+                                if let Err(e) = crate::api::orders::publish_event(&event_json).await {
+                                    log::warn!("[reputation] rate_user publish failed: {e}");
+                                } else {
+                                    log::info!(
+                                        "[reputation] rate_user published trade={trade_id} score={score}"
+                                    );
+                                }
+                            }
+                            Err(e) => log::warn!("[reputation] rate_user build failed: {e}"),
+                        }
+                    }
+                    Err(e) => log::error!("[reputation] invalid mostro pubkey: {e}"),
+                }
+            }
+            Err(e) => log::warn!("[reputation] could not get trade keys for index={trade_index}: {e}"),
+        }
+    } else {
+        log::warn!("[reputation] no trade key found for trade={trade_id}; rating stored locally only");
+    }
 
     // Atomic check-and-insert under write lock — prevents TOCTOU races.
     store
@@ -153,7 +187,13 @@ pub fn get_privacy_mode() -> bool {
 ///
 /// **Errors**: `NoIdentity` (identity check deferred to Phase 14+ bridge).
 pub fn set_privacy_mode(enabled: bool) {
-    // TODO(Phase 14+): Verify that an identity exists before toggling.
+    // Best-effort identity check: log a warning if no identity is configured but
+    // proceed anyway so the UI setting is never silently stuck.
+    tokio::spawn(async move {
+        if crate::api::identity::get_active_keys().await.is_err() {
+            log::warn!("[reputation] set_privacy_mode({enabled}): no identity configured");
+        }
+    });
     rating_store()
         .privacy_mode
         .store(enabled, Ordering::SeqCst);

--- a/rust/src/api/reputation.rs
+++ b/rust/src/api/reputation.rs
@@ -73,6 +73,21 @@ impl RatingStore {
         Ok(())
     }
 
+    /// Remove the local user's reserved rating slot for a trade.
+    ///
+    /// Called to roll back a slot reservation when the outbound dispatch fails
+    /// so the caller can retry.  No-op if no slot exists for the trade.
+    async fn remove_mine(&self, trade_id: &str) {
+        let mut store = self.ratings.write().await;
+        if let Some(entry) = store.get_mut(trade_id) {
+            entry.mine = None;
+            // Evict the map entry entirely when both sides are empty.
+            if entry.peer.is_none() {
+                store.remove(trade_id);
+            }
+        }
+    }
+
     /// Insert or update the peer's incoming rating for a trade.
     /// Can be called multiple times safely (handles re-delivery).
     async fn insert_peer(&self, info: RatingInfo) {
@@ -125,52 +140,58 @@ pub async fn submit_rating(trade_id: String, score: u8) -> Result<()> {
         bail!("PrivacyModeEnabled: cannot submit rating while privacy mode is active");
     }
 
-    // Send the RateUser message to the Mostro daemon via NIP-59 Gift Wrap using
-    // the trade key that was used when the order was taken or created.
-    if let Some(trade_index) = crate::api::orders::trade_key_for_order(&trade_id).await {
-        match crate::api::identity::get_active_trade_keys(trade_index).await {
-            Ok(sender_keys) => {
-                match nostr_sdk::PublicKey::from_hex(crate::config::DEFAULT_MOSTRO_PUBKEY) {
-                    Ok(mostro_pubkey) => {
-                        match crate::mostro::actions::rate_user(
-                            &sender_keys,
-                            &mostro_pubkey,
-                            &trade_id,
-                            trade_index,
-                            score,
-                        )
-                        .await
-                        {
-                            Ok(event_json) => {
-                                if let Err(e) = crate::api::orders::publish_event(&event_json).await {
-                                    log::warn!("[reputation] rate_user publish failed: {e}");
-                                } else {
-                                    log::info!(
-                                        "[reputation] rate_user published trade={trade_id} score={score}"
-                                    );
-                                }
-                            }
-                            Err(e) => log::warn!("[reputation] rate_user build failed: {e}"),
-                        }
-                    }
-                    Err(e) => log::error!("[reputation] invalid mostro pubkey: {e}"),
-                }
-            }
-            Err(e) => log::warn!("[reputation] could not get trade keys for index={trade_index}: {e}"),
-        }
-    } else {
-        log::warn!("[reputation] no trade key found for trade={trade_id}; rating stored locally only");
-    }
-
-    // Atomic check-and-insert under write lock — prevents TOCTOU races.
+    // Reserve the slot atomically before attempting any outbound send.
+    // This prevents two concurrent submit_rating calls from both reaching
+    // publish_event — the second call fails here with AlreadyRated rather than
+    // sending a duplicate RateUser message to Mostro.
     store
         .try_insert_mine(RatingInfo {
-            trade_id,
+            trade_id: trade_id.clone(),
             score,
             is_mine: true,
             created_at: unix_now(),
         })
         .await?;
+
+    // Send the RateUser message via NIP-59 Gift Wrap.  Roll back the slot
+    // reservation if any step fails so the caller can retry after a transient
+    // network error without hitting AlreadyRated.
+    if let Some(trade_index) = crate::api::orders::trade_key_for_order(&trade_id).await {
+        let dispatch_result: anyhow::Result<()> = async {
+            let sender_keys =
+                crate::api::identity::get_active_trade_keys(trade_index).await?;
+            let mostro_pubkey =
+                nostr_sdk::PublicKey::from_hex(crate::config::DEFAULT_MOSTRO_PUBKEY)
+                    .map_err(|e| anyhow::anyhow!("invalid DEFAULT_MOSTRO_PUBKEY: {e}"))?;
+            let event_json = crate::mostro::actions::rate_user(
+                &sender_keys,
+                &mostro_pubkey,
+                &trade_id,
+                trade_index,
+                score,
+            )
+            .await?;
+            crate::api::orders::publish_event(&event_json).await
+        }
+        .await;
+
+        match dispatch_result {
+            Ok(()) => log::info!(
+                "[reputation] rate_user published trade={trade_id} score={score}"
+            ),
+            Err(e) => {
+                // Rollback: remove the reservation so the caller can retry.
+                store.remove_mine(&trade_id).await;
+                bail!("RateUserDispatchFailed: {e}");
+            }
+        }
+    } else {
+        // No trade key for this trade — store locally only (e.g. older session
+        // where the key index was not persisted).
+        log::warn!(
+            "[reputation] no trade key found for trade={trade_id}; rating stored locally only"
+        );
+    }
 
     Ok(())
 }

--- a/rust/src/mostro/actions.rs
+++ b/rust/src/mostro/actions.rs
@@ -136,6 +136,16 @@ pub async fn cancel(
     simple_action(sender_keys, mostro_pubkey, order_id, trade_index, Action::Cancel).await
 }
 
+/// Build and wrap a Dispute MostroMessage.
+pub async fn dispute(
+    sender_keys: &Keys,
+    mostro_pubkey: &PublicKey,
+    order_id: &str,
+    trade_index: u32,
+) -> Result<String> {
+    simple_action(sender_keys, mostro_pubkey, order_id, trade_index, Action::Dispute).await
+}
+
 /// Build and wrap a RateUser MostroMessage.
 ///
 /// Sends a 1–5 star rating for the counterparty to the Mostro daemon via

--- a/rust/src/mostro/actions.rs
+++ b/rust/src/mostro/actions.rs
@@ -136,6 +136,29 @@ pub async fn cancel(
     simple_action(sender_keys, mostro_pubkey, order_id, trade_index, Action::Cancel).await
 }
 
+/// Build and wrap a RateUser MostroMessage.
+///
+/// Sends a 1–5 star rating for the counterparty to the Mostro daemon via
+/// NIP-59 Gift Wrap after a trade completes.
+pub async fn rate_user(
+    sender_keys: &Keys,
+    mostro_pubkey: &PublicKey,
+    order_id: &str,
+    trade_index: u32,
+    score: u8,
+) -> Result<String> {
+    let id = Uuid::parse_str(order_id)?;
+    let payload = Some(Payload::RatingUser(score));
+    let msg = Message::new_order(
+        Some(id),
+        None,
+        Some(trade_index as i64),
+        Action::RateUser,
+        payload,
+    );
+    wrap_message(sender_keys, mostro_pubkey, msg).await
+}
+
 /// Build and wrap an AddInvoice MostroMessage (buyer submits Lightning invoice
 /// or LN address).
 ///

--- a/rust/src/nostr/relay_pool.rs
+++ b/rust/src/nostr/relay_pool.rs
@@ -138,13 +138,22 @@ impl RelayPool {
         self.relay_tx.subscribe()
     }
 
-    /// Subscribe to Kind 38383 (public orders) and Kind 1059 (gift wraps) separately.
+    /// Re-subscribe to Kind 38383 (public orders) and Kind 1059 (gift wraps)
+    /// after a reconnect or cold start, respawning per-trade gift-wrap workers.
     ///
-    /// Note: Kind 38383 processing is handled by `orders::subscribe_orders()`.
-    /// Kind 1059 processing is handled per-trade by `orders::subscribe_gift_wraps()`
-    /// which is called automatically from `orders::create_order()`.
-    /// This method exists for bulk re-subscription (e.g. reconnect after restart).
-    pub async fn subscribe_order_and_dm_feeds(&self, trade_pubkeys: Vec<PublicKey>) -> Result<()> {
+    /// `trade_keys` is a list of `(trade_pubkey, trade_index)` pairs gathered
+    /// from persisted state (e.g. the trade-key DB table).  For each pair this
+    /// method:
+    /// 1. Adds the pubkey to the bulk Kind 1059 relay filter so events are
+    ///    delivered to this client.
+    /// 2. Spawns a `subscribe_gift_wraps` worker (same as `create_order` does)
+    ///    so decryption keys are available and daemon responses are routed.
+    ///
+    /// Kind 38383 processing is handled by `orders::subscribe_orders()`.
+    pub async fn subscribe_order_and_dm_feeds(
+        &self,
+        trade_keys: Vec<(PublicKey, u32)>,
+    ) -> Result<()> {
         let mostro_pubkey = nostr_sdk::PublicKey::from_hex(crate::config::DEFAULT_MOSTRO_PUBKEY)
             .map_err(|e| anyhow!("invalid DEFAULT_MOSTRO_PUBKEY: {e}"))?;
         let order_filter = pending_orders_filter(&mostro_pubkey);
@@ -153,13 +162,23 @@ impl RelayPool {
             .await
             .map_err(|e| anyhow!("order subscribe failed: {e}"))?;
 
-        let dm_filter = Filter::new()
-            .kind(Kind::from(KIND_GIFT_WRAP))
-            .pubkeys(trade_pubkeys);
-        self.client
-            .subscribe(dm_filter, None)
-            .await
-            .map_err(|e| anyhow!("dm subscribe failed: {e}"))?;
+        let pubkeys: Vec<PublicKey> = trade_keys.iter().map(|(pk, _)| *pk).collect();
+        if !pubkeys.is_empty() {
+            let dm_filter = Filter::new()
+                .kind(Kind::from(KIND_GIFT_WRAP))
+                .pubkeys(pubkeys);
+            self.client
+                .subscribe(dm_filter, None)
+                .await
+                .map_err(|e| anyhow!("dm subscribe failed: {e}"))?;
+
+            // Respawn per-trade gift-wrap workers so each trade key's decrypt
+            // path is live.  Without this, the relay delivers events but no
+            // worker is running to unwrap and route them.
+            for (pubkey, trade_index) in trade_keys {
+                crate::api::orders::subscribe_gift_wraps(pubkey, trade_index).await;
+            }
+        }
 
         Ok(())
     }

--- a/rust/src/nostr/relay_pool.rs
+++ b/rust/src/nostr/relay_pool.rs
@@ -140,13 +140,10 @@ impl RelayPool {
 
     /// Subscribe to Kind 38383 (public orders) and Kind 1059 (gift wraps) separately.
     ///
-    /// **TODO (Phase 3)**: After subscribing, spawn an event-processing loop
-    /// that pulls from `client.notifications()` and dispatches:
-    /// - `RelayPoolNotification::Event` with `Kind::from(38383)` →
-    ///   `parse_order_event` → update order-book provider
-    /// - `RelayPoolNotification::Event` with `Kind::from(KIND_GIFT_WRAP)` →
-    ///   `gift_wrap::unwrap` → route to trade/chat handlers
-    /// - `RelayPoolNotification::Shutdown` → update connection state
+    /// Note: Kind 38383 processing is handled by `orders::subscribe_orders()`.
+    /// Kind 1059 processing is handled per-trade by `orders::subscribe_gift_wraps()`
+    /// which is called automatically from `orders::create_order()`.
+    /// This method exists for bulk re-subscription (e.g. reconnect after restart).
     pub async fn subscribe_order_and_dm_feeds(&self, trade_pubkeys: Vec<PublicKey>) -> Result<()> {
         let mostro_pubkey = nostr_sdk::PublicKey::from_hex(crate::config::DEFAULT_MOSTRO_PUBKEY)
             .map_err(|e| anyhow!("invalid DEFAULT_MOSTRO_PUBKEY: {e}"))?;


### PR DESCRIPTION
Rust:
- orders.rs: remove stale Phase 7 doc comment; expose pub(crate)
  trade_key_for_order and publish_event for cross-module use
- actions.rs: add rate_user() building a RateUser NIP-59 gift wrap
- reputation.rs: wire submit_rating to dispatch RateUser via the
  daemon; replace set_privacy_mode TODO with best-effort identity check

Dart:
- about_screen: async-load app version via getAppVersion() bridge
- privacy_mode_provider: init from getPrivacyMode(), propagate changes
  to setPrivacyMode() on every toggle
- rate_counterpart_screen: call submitRating() instead of delay stub
- connect_wallet_screen: call connectWallet() and populate state from
  returned NwcWalletInfo
- wallet_settings_screen: call disconnectWallet() before clearing state
- relay_management_card: load relays from getRelays() on init; wire
  addRelay() and removeRelay() bridge calls
- orders.rs: add subscribe_gift_wraps() spawned per maker order;
  decrypts Kind 1059 events with trade key, calls resolve_maker_order()
  on Action::NewOrder so daemon UUID is known before K38383 arrives
- orders.rs: add process_gift_wrap_rumor() for dispatching inner message
- orders.rs: call subscribe_gift_wraps() from create_order() after key derivation
- actions.rs: add dispute() action builder using Action::Dispute
- disputes.rs: wire open_dispute() to dispatch Action::Dispute via NIP-59
  using the stored trade key index; logs warn when no trade key found
- relay_pool.rs: remove Phase 3 TODO, note K1059 is handled per-trade


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App version now loads dynamically from backend
  * Wallet connect/disconnect integrated with backend; wallet state updated
  * Privacy mode synced with backend (async init & updates with rollback)
  * Relay management (load/add/remove) backed by network calls; failure messages added
  * Ratings and disputes published to Mostro network; background encrypted-order messaging (gift-wrap) subscriptions

* **Bug Fixes**
  * Replaced placeholder implementations with real backend calls; improved error handling and optimistic-update rollback
<!-- end of auto-generated comment: release notes by coderabbit.ai -->