### PR TITLE
fix(web): resolve dart2js compile errors for flutter build web

### DIFF
--- a/lib/core/services/identity_service.dart
+++ b/lib/core/services/identity_service.dart
@@ -3,6 +3,12 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import 'package:mostro/src/rust/api/identity.dart' as identity_api;
 
+/// Returns [v] as the correct `PlatformInt64` type for the current platform:
+/// `int` on native, `BigInt` on web (dart2js). Returning `dynamic` lets
+/// callers pass it directly to bridge parameters typed as `PlatformInt64?`
+/// without a static-type error on either platform.
+dynamic _toInt64(int v) => kIsWeb ? BigInt.from(v) : v;
+
 /// Secure-storage keys.
 const _kMnemonic = 'mostro_identity_mnemonic';
 const _kTradeKeyIndex = 'mostro_trade_key_index';
@@ -189,7 +195,7 @@ class IdentityService {
       words: words,
       tradeKeyIndex: tradeKeyIndex,
       privacyMode: privacyMode,
-      createdAt: createdAt > 0 ? createdAt ~/ 1000 : null,
+      createdAt: createdAt > 0 ? _toInt64(createdAt ~/ 1000) : null,
     );
 
     debugPrint('[identity] identity loaded — pubkey=${info.publicKey}');

--- a/lib/core/stubs/path_provider_stub.dart
+++ b/lib/core/stubs/path_provider_stub.dart
@@ -1,0 +1,11 @@
+// Web stub — path_provider is not available on web.
+// Provides a no-op signature so conditional imports compile without errors.
+// The implementation is never called: callers guard with kIsWeb before use.
+
+class StubDirectory {
+  final String path = '';
+}
+
+Future<StubDirectory> getApplicationDocumentsDirectory() async {
+  throw UnsupportedError('getApplicationDocumentsDirectory is not supported on web');
+}

--- a/lib/features/home/providers/home_order_providers.dart
+++ b/lib/features/home/providers/home_order_providers.dart
@@ -36,6 +36,11 @@ final ratingFilterProvider =
 final premiumRangeFilterProvider =
     StateProvider<({double min, double max})>((_) => defaultPremiumRange);
 
+/// Converts a `PlatformInt64` value (int on native, BigInt on web/dart2js)
+/// to a plain Dart `int`.
+// ignore: unnecessary_cast
+int _platformInt64ToInt(dynamic v) => v is BigInt ? v.toInt() : v as int;
+
 // ── Order model ───────────────────────────────────────────────────────────────
 
 /// Lightweight Dart-side order model for the UI layer.
@@ -126,18 +131,10 @@ class OrderItem {
         premium: info.premium,
         creatorPubkey: info.creatorPubkey,
         createdAt: DateTime.fromMillisecondsSinceEpoch(
-            (info.createdAt is BigInt
-                    ? (info.createdAt as BigInt).toInt()
-                    // ignore: unnecessary_cast
-                    : info.createdAt as int) *
-                1000),
+            _platformInt64ToInt(info.createdAt) * 1000),
         expiresAt: info.expiresAt != null
             ? DateTime.fromMillisecondsSinceEpoch(
-                (info.expiresAt! is BigInt
-                        ? (info.expiresAt! as BigInt).toInt()
-                        // ignore: unnecessary_cast
-                        : info.expiresAt! as int) *
-                    1000)
+                _platformInt64ToInt(info.expiresAt!) * 1000)
             : null,
         status: info.status,
         amountSats: info.amountSats,

--- a/lib/features/home/providers/home_order_providers.dart
+++ b/lib/features/home/providers/home_order_providers.dart
@@ -125,9 +125,19 @@ class OrderItem {
         paymentMethod: info.paymentMethod,
         premium: info.premium,
         creatorPubkey: info.creatorPubkey,
-        createdAt: DateTime.fromMillisecondsSinceEpoch(info.createdAt * 1000),
+        createdAt: DateTime.fromMillisecondsSinceEpoch(
+            (info.createdAt is BigInt
+                    ? (info.createdAt as BigInt).toInt()
+                    // ignore: unnecessary_cast
+                    : info.createdAt as int) *
+                1000),
         expiresAt: info.expiresAt != null
-            ? DateTime.fromMillisecondsSinceEpoch(info.expiresAt! * 1000)
+            ? DateTime.fromMillisecondsSinceEpoch(
+                (info.expiresAt! is BigInt
+                        ? (info.expiresAt! as BigInt).toInt()
+                        // ignore: unnecessary_cast
+                        : info.expiresAt! as int) *
+                    1000)
             : null,
         status: info.status,
         amountSats: info.amountSats,

--- a/lib/features/notifications/providers/notifications_provider.dart
+++ b/lib/features/notifications/providers/notifications_provider.dart
@@ -8,7 +8,7 @@ import 'package:mostro/features/notifications/models/notification_model.dart';
 
 // Platform-specific imports — path_provider is only needed on non-web.
 import 'package:path_provider/path_provider.dart'
-    if (dart.library.html) 'dart:html';
+    if (dart.library.html) 'package:mostro/core/stubs/path_provider_stub.dart';
 import 'package:sembast/sembast_io.dart';
 import 'package:sembast/sembast_memory.dart' show databaseFactoryMemory;
 

--- a/lib/features/trades/providers/trades_providers.dart
+++ b/lib/features/trades/providers/trades_providers.dart
@@ -106,7 +106,7 @@ TradeListItem _tradeInfoToItem(rust_types.TradeInfo trade) {
   // yet implemented; the BigInt branch guards future correctness.
   final createdAt = trade.startedAt is BigInt
       ? (trade.startedAt as BigInt).toInt()
-      : trade.startedAt;
+      : trade.startedAt as int; // ignore: unnecessary_cast
 
   return TradeListItem(
     orderId: trade.order.id,


### PR DESCRIPTION
identity_service.dart: add _toInt64() helper returning dynamic to pass int values as PlatformInt64 (BigInt on web, int on native) to frb bridge.

home_order_providers.dart: convert PlatformInt64 createdAt/expiresAt to int before passing to DateTime.fromMillisecondsSinceEpoch via is-BigInt guard with unnecessary_cast suppression for native builds.

trades_providers.dart: cast else-branch to int in startedAt ternary so the expression is typed int (not Object) on both platforms.

notifications_provider.dart + core/stubs/path_provider_stub.dart: replace conditional import target 'dart:html' with a proper stub that provides getApplicationDocumentsDirectory() so dart2js finds the symbol even though the kIsWeb branch never calls it at runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved cross-platform timestamp type mismatches to ensure consistent date/time handling on web and native.
  * Fixed timestamp conversion for orders, trades, and notifications so displayed times are accurate across environments.

* **Chores**
  * Improved platform compatibility for web builds to prevent runtime issues when platform-specific APIs are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->