### PR TITLE
fix(settings): persist user preferences across app restarts

### DIFF
--- a/lib/core/app.dart
+++ b/lib/core/app.dart
@@ -25,7 +25,7 @@ class MostroApp extends ConsumerWidget {
     final locale = ref.watch(localeProvider);
 
     // Theme mode from settings; dark is the default.
-    final themeMode = ref.watch(settingsProvider).themeMode;
+    final themeMode = ref.watch(settingsProvider.select((s) => s.themeMode));
 
     return MaterialApp.router(
       title: 'Mostro',

--- a/lib/features/settings/providers/settings_provider.dart
+++ b/lib/features/settings/providers/settings_provider.dart
@@ -1,5 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+// ── Preference keys ────────────────────────────────────────────────────────────
+
+const _kLanguage = 'settings.language';
+const _kFiatCode = 'settings.fiatCode';
+const _kLightningAddress = 'settings.lightningAddress';
+const _kLoggingEnabled = 'settings.loggingEnabled';
+const _kThemeMode = 'settings.themeMode';
 
 // ── State ─────────────────────────────────────────────────────────────────────
 
@@ -39,6 +48,21 @@ class AppSettingsState {
       themeMode: themeMode ?? this.themeMode,
     );
   }
+
+  /// Load initial values from [SharedPreferences].
+  factory AppSettingsState.fromPrefs(SharedPreferences prefs) {
+    final themeModeStr = prefs.getString(_kThemeMode) ?? 'dark';
+    return AppSettingsState(
+      language: prefs.getString(_kLanguage) ?? 'en',
+      defaultFiatCode: prefs.getString(_kFiatCode),
+      defaultLightningAddress: prefs.getString(_kLightningAddress),
+      loggingEnabled: prefs.getBool(_kLoggingEnabled) ?? false,
+      themeMode: ThemeMode.values.firstWhere(
+        (m) => m.name == themeModeStr,
+        orElse: () => ThemeMode.dark,
+      ),
+    );
+  }
 }
 
 // Sentinel to distinguish "not provided" from explicit null in copyWith.
@@ -47,28 +71,55 @@ const _unset = Object();
 // ── Notifier ──────────────────────────────────────────────────────────────────
 
 class SettingsNotifier extends StateNotifier<AppSettingsState> {
-  SettingsNotifier() : super(const AppSettingsState());
+  SettingsNotifier({SharedPreferences? prefs, AppSettingsState? initial})
+      : _prefs = prefs,
+        super(initial ?? const AppSettingsState());
 
-  void setLanguage(String code) => state = state.copyWith(language: code);
+  final SharedPreferences? _prefs;
 
-  void setDefaultFiatCode(String? code) =>
-      state = state.copyWith(defaultFiatCode: code);
+  void setLanguage(String code) {
+    state = state.copyWith(language: code);
+    _prefs?.setString(_kLanguage, code);
+  }
 
-  void setDefaultLightningAddress(String? address) =>
-      state = state.copyWith(defaultLightningAddress: address);
+  void setDefaultFiatCode(String? code) {
+    state = state.copyWith(defaultFiatCode: code);
+    if (code == null) {
+      _prefs?.remove(_kFiatCode);
+    } else {
+      _prefs?.setString(_kFiatCode, code);
+    }
+  }
 
-  void setLoggingEnabled(bool enabled) =>
-      state = state.copyWith(loggingEnabled: enabled);
+  void setDefaultLightningAddress(String? address) {
+    state = state.copyWith(defaultLightningAddress: address);
+    if (address == null) {
+      _prefs?.remove(_kLightningAddress);
+    } else {
+      _prefs?.setString(_kLightningAddress, address);
+    }
+  }
 
-  void setThemeMode(ThemeMode mode) => state = state.copyWith(themeMode: mode);
+  void setLoggingEnabled(bool enabled) {
+    state = state.copyWith(loggingEnabled: enabled);
+    _prefs?.setBool(_kLoggingEnabled, enabled);
+  }
+
+  void setThemeMode(ThemeMode mode) {
+    state = state.copyWith(themeMode: mode);
+    _prefs?.setString(_kThemeMode, mode.name);
+  }
 }
 
 // ── Providers ─────────────────────────────────────────────────────────────────
 
-/// Main settings provider. Holds all user preferences in memory.
+/// Main settings provider. Holds all user preferences, persisted to
+/// SharedPreferences. Override in [main] via [ProviderScope] overrides so that
+/// the [SharedPreferences] instance and saved initial values are injected
+/// synchronously before the first frame.
 final settingsProvider =
     StateNotifierProvider<SettingsNotifier, AppSettingsState>(
-  (ref) => SettingsNotifier(),
+  (ref) => SettingsNotifier(), // no-persistence fallback; replaced in main()
 );
 
 /// Current display locale, derived automatically from [settingsProvider].

--- a/lib/features/settings/widgets/language_selector.dart
+++ b/lib/features/settings/widgets/language_selector.dart
@@ -75,12 +75,13 @@ class LanguageSelector extends ConsumerWidget {
                   ? Icon(Icons.check_circle, color: colors.mostroGreen)
                   : null,
               onTap: () {
-                // Pop first, then change locale. Changing locale while the
+                Navigator.of(context).pop();
+                if (lang.code == currentCode) return;
+                // Change locale after the sheet is gone. Changing it while the
                 // bottom sheet is still mounted causes MostroApp to rebuild
                 // with a new AppLocalizations before the sheet's widgets are
                 // deactivated, triggering _dependents.isEmpty assertions.
                 final notifier = ref.read(settingsProvider.notifier);
-                Navigator.of(context).pop();
                 WidgetsBinding.instance.addPostFrameCallback(
                   (_) => notifier.setLanguage(lang.code),
                 );

--- a/lib/features/settings/widgets/language_selector.dart
+++ b/lib/features/settings/widgets/language_selector.dart
@@ -75,8 +75,15 @@ class LanguageSelector extends ConsumerWidget {
                   ? Icon(Icons.check_circle, color: colors.mostroGreen)
                   : null,
               onTap: () {
-                ref.read(settingsProvider.notifier).setLanguage(lang.code);
+                // Pop first, then change locale. Changing locale while the
+                // bottom sheet is still mounted causes MostroApp to rebuild
+                // with a new AppLocalizations before the sheet's widgets are
+                // deactivated, triggering _dependents.isEmpty assertions.
+                final notifier = ref.read(settingsProvider.notifier);
                 Navigator.of(context).pop();
+                WidgetsBinding.instance.addPostFrameCallback(
+                  (_) => notifier.setLanguage(lang.code),
+                );
               },
             );
           }),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:mostro/core/app.dart';
 import 'package:mostro/core/services/identity_service.dart';
+import 'package:mostro/features/settings/providers/settings_provider.dart';
 import 'package:mostro/features/walkthrough/providers/first_run_provider.dart';
 import 'package:mostro/features/account/providers/backup_reminder_provider.dart';
 import 'package:mostro/src/rust/frb_generated.dart';
@@ -43,6 +44,7 @@ Future<void> main() async {
   final backupDismissed = prefs.getBool(kBackupReminderDismissedKey) ?? false;
   final backupActive = prefs.getBool(kBackupReminderActiveKey) ?? false;
   final backupPending = backupActive && !backupDismissed;
+  final savedSettings = AppSettingsState.fromPrefs(prefs);
 
   // Initialize the Nostr relay pool with default relays (from config.rs).
   // This must happen before any Nostr/order API calls.
@@ -63,6 +65,9 @@ Future<void> main() async {
       ),
       backupReminderProvider.overrideWith(
         (ref) => BackupReminderNotifier(initialValue: backupPending),
+      ),
+      settingsProvider.overrideWith(
+        (ref) => SettingsNotifier(prefs: prefs, initial: savedSettings),
       ),
     ],
     child: const MostroApp(),


### PR DESCRIPTION
Wire SettingsNotifier to SharedPreferences so language, fiat currency, lightning address, theme and logging choices survive app restarts. Load saved values synchronously at startup via ProviderScope override, matching the existing pattern used for firstRunProvider.

Also fix _dependents.isEmpty assertion (red screen) when saving settings while a dialog is open: scope MostroApp's settingsProvider watch to themeMode only via select(), and defer locale changes in LanguageSelector to the next frame so the bottom sheet is fully torn down before AppLocalizations is replaced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User preferences now persist across app sessions, including language, theme mode, default currency, and logging settings

* **Improvements**
  * Optimized app performance by reducing unnecessary rebuilds when theme settings change
  * Enhanced language selection experience with improved interaction timing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->