### PR TITLE
fix(trades): remove spurious badge dot and pending status flash

### DIFF
--- a/lib/features/order/providers/trade_state_provider.dart
+++ b/lib/features/order/providers/trade_state_provider.dart
@@ -26,14 +26,15 @@ final tradeAmountProvider =
 
 /// Live order status for a single trade, polled from the order book every 2 s.
 ///
-/// Returns [OrderStatus.pending] as the initial / fallback value while loading.
+/// Starts with an immediate fetch (no initial delay) so the first emission
+/// reflects the real relay status. While loading, callers fall back to the
+/// DB-stored [TradeListItem.status] via [AsyncValue.whenOrNull].
 final tradeStatusProvider =
     StreamProvider.family.autoDispose<OrderStatus, String>((ref, orderId) async* {
-  yield OrderStatus.pending; // immediate first emission so UI doesn't hang
   while (true) {
-    await Future.delayed(const Duration(seconds: 2));
     final info = await orders_api.getOrder(orderId: orderId);
     if (info != null) yield info.status;
+    await Future.delayed(const Duration(seconds: 2));
   }
 });
 

--- a/lib/features/trades/providers/trades_providers.dart
+++ b/lib/features/trades/providers/trades_providers.dart
@@ -220,8 +220,10 @@ final orderBookNotificationCountProvider = Provider<int>((ref) {
             ref.watch(tradeStatusProvider(trade.order.id)).valueOrNull;
         if (live == null) continue;
         final seen = lastSeen[trade.order.id];
-        // Unseen if no prior snapshot or status changed.
-        if (seen == null || seen != live) count++;
+        // Only count as unseen when status changed from a known prior state.
+        // No snapshot yet (seen == null) means the user hasn't visited the tab
+        // in this session — don't treat existing trades as new notifications.
+        if (seen != null && seen != live) count++;
       }
       return count;
     },


### PR DESCRIPTION
Badge: change notification count logic from 'unseen if no prior snapshot' to 'unseen only if status changed from a known prior state'. With an empty _lastSeenStatusesProvider on app start every non-terminal trade counted as unseen, causing the red dot to appear before the user had missed anything.

Status flash: remove the immediate yield of OrderStatus.pending from tradeStatusProvider. The pending yield was overriding the correct DB-stored status for 2 s until the first real getOrder() fetch completed. TradesListItem already falls back to trade.status (DB value) while the stream is in loading state, so removing the bogus yield shows the correct status from the start.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Notification badge counts in the order book now more accurately reflect unread and changed trades.
  * Trade status updates are retrieved more reliably with improved initial loading behavior.

* **Performance Improvements**
  * Trade status polling optimized to fetch initial updates immediately, followed by efficient interval-based refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->