### PR TITLE
feat(nwc): wire payment and invoice widgets to Rust bridge

### DIFF
--- a/lib/shared/widgets/nwc_invoice_widget.dart
+++ b/lib/shared/widgets/nwc_invoice_widget.dart
@@ -1,13 +1,12 @@
 import 'package:flutter/material.dart';
 
 import 'package:mostro/core/app_theme.dart';
+import 'package:mostro/src/rust/api/nwc.dart' as nwc_api;
 
 /// Auto-generates a Lightning invoice via NWC when wallet is connected.
 ///
 /// Shows loading state while generating. Calls [onInvoiceConfirmed] when
 /// the invoice is ready, or [onFallbackToManual] on failure.
-///
-/// TODO: Wire to NWC wallet bridge in Phase 14.
 class NwcInvoiceWidget extends StatefulWidget {
   const NwcInvoiceWidget({
     super.key,
@@ -36,16 +35,15 @@ class _NwcInvoiceWidgetState extends State<NwcInvoiceWidget> {
 
   Future<void> _generateInvoice() async {
     try {
-      // TODO: Call NWC make_invoice(amount_sats) via Rust bridge.
-      // When wired, this will await the actual NWC response.
-
+      final bolt11 = await nwc_api.makeInvoice(
+        amountSats: BigInt.from(widget.amountSats),
+        description: null,
+      );
       if (!mounted) return;
-
-      // NWC not configured — fall back to manual entry immediately.
       setState(() => _loading = false);
-      widget.onFallbackToManual();
-    } catch (e, stack) {
-      debugPrint('NWC invoice generation failed: $e\n$stack');
+      widget.onInvoiceConfirmed(bolt11);
+    } catch (e) {
+      debugPrint('NWC invoice generation failed: $e');
       if (!mounted) return;
       setState(() {
         _loading = false;

--- a/lib/shared/widgets/nwc_payment_widget.dart
+++ b/lib/shared/widgets/nwc_payment_widget.dart
@@ -1,13 +1,12 @@
 import 'package:flutter/material.dart';
 
 import 'package:mostro/core/app_theme.dart';
+import 'package:mostro/src/rust/api/nwc.dart' as nwc_api;
 
 /// NWC auto-pay widget — single "Pay with Wallet" button.
 ///
 /// Calls NWC pay_invoice(bolt11) via Rust bridge.
 /// On success → [onPaymentSuccess]. On failure → [onFallbackToManual].
-///
-/// TODO: Wire to NWC wallet bridge in Phase 14.
 class NwcPaymentWidget extends StatefulWidget {
   const NwcPaymentWidget({
     super.key,
@@ -32,17 +31,16 @@ class _NwcPaymentWidgetState extends State<NwcPaymentWidget> {
   Future<void> _pay() async {
     setState(() => _paying = true);
     try {
-      // TODO(Phase 14): Replace with nwc_api.pay_invoice(widget.bolt11)
-      // via Rust bridge once NWC module is implemented.
-      // On success: call widget.onPaymentSuccess().
-      // On API failure: call widget.onFallbackToManual().
-      await Future.delayed(const Duration(seconds: 1));
-
+      final result = await nwc_api.payInvoice(bolt11: widget.bolt11);
       if (!mounted) return;
-      // NWC not wired yet — fall back to manual payment.
-      widget.onFallbackToManual();
+      if (result.success) {
+        widget.onPaymentSuccess();
+      } else {
+        debugPrint('NWC payment failed: ${result.error}');
+        widget.onFallbackToManual();
+      }
     } catch (e) {
-      debugPrint('NWC payment failed: $e');
+      debugPrint('NWC payment error: $e');
       if (!mounted) return;
       widget.onFallbackToManual();
     } finally {

--- a/rust/src/api/nwc.rs
+++ b/rust/src/api/nwc.rs
@@ -157,6 +157,9 @@ pub async fn make_invoice(amount_sats: u64, description: Option<String>) -> Resu
     if amount_sats == 0 {
         bail!("InvalidAmount: amount_sats must be greater than zero");
     }
+    if amount_sats > u64::MAX / 1000 {
+        bail!("InvalidAmount: amount_sats too large");
+    }
 
     let client = {
         let guard = wallet_store().client.read().await;
@@ -250,6 +253,12 @@ mod tests {
     #[tokio::test]
     async fn make_invoice_rejects_zero_amount() {
         let err = make_invoice(0, None).await.unwrap_err();
+        assert!(err.to_string().contains("InvalidAmount"));
+    }
+
+    #[tokio::test]
+    async fn make_invoice_rejects_overflow_amount() {
+        let err = make_invoice(u64::MAX, None).await.unwrap_err();
         assert!(err.to_string().contains("InvalidAmount"));
     }
 

--- a/rust/src/api/nwc.rs
+++ b/rust/src/api/nwc.rs
@@ -147,6 +147,29 @@ pub async fn pay_invoice(bolt11: String) -> Result<PaymentResult> {
     client.pay_invoice(&bolt11).await
 }
 
+/// Request the wallet to create a new Lightning invoice.
+///
+/// `amount_sats` is the invoice amount in satoshis (converted to msats
+/// for the NIP-47 request).  Returns the BOLT-11 invoice string.
+///
+/// **Errors**: `NoWalletConnected`, `WalletError`.
+pub async fn make_invoice(amount_sats: u64, description: Option<String>) -> Result<String> {
+    if amount_sats == 0 {
+        bail!("InvalidAmount: amount_sats must be greater than zero");
+    }
+
+    let client = {
+        let guard = wallet_store().client.read().await;
+        Arc::clone(
+            guard
+                .as_ref()
+                .ok_or_else(|| anyhow!("NoWalletConnected: no wallet is currently connected"))?,
+        )
+    };
+
+    client.make_invoice(amount_sats, description).await
+}
+
 // ── Stream ────────────────────────────────────────────────────────────────────
 
 /// Stream that emits [NwcWalletInfo] (or `None` on disconnect) whenever the
@@ -221,6 +244,20 @@ mod tests {
         let _g = wallet_lock().lock().unwrap();
         let _ = disconnect_wallet().await;
         let err = pay_invoice("lnbc1...".into()).await.unwrap_err();
+        assert!(err.to_string().contains("NoWalletConnected"));
+    }
+
+    #[tokio::test]
+    async fn make_invoice_rejects_zero_amount() {
+        let err = make_invoice(0, None).await.unwrap_err();
+        assert!(err.to_string().contains("InvalidAmount"));
+    }
+
+    #[tokio::test]
+    async fn make_invoice_errors_when_not_connected() {
+        let _g = wallet_lock().lock().unwrap();
+        let _ = disconnect_wallet().await;
+        let err = make_invoice(1000, None).await.unwrap_err();
         assert!(err.to_string().contains("NoWalletConnected"));
     }
 

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -44,7 +44,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -194778824;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1150097857;
 
 // Section: executor
 
@@ -2441,6 +2441,44 @@ fn wire__crate__api__identity__load_identity_from_mnemonic_impl(
                             api_created_at,
                         )
                         .await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__nwc__make_invoice_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "make_invoice",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_amount_sats = <u64>::sse_decode(&mut deserializer);
+            let api_description = <Option<String>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || async move {
+                        let output_ok =
+                            crate::api::nwc::make_invoice(api_amount_sats, api_description).await?;
                         Ok(output_ok)
                     })()
                     .await,
@@ -5070,78 +5108,79 @@ fn pde_ffi_dispatcher_primary_impl(
             rust_vec_len,
             data_len,
         ),
-        58 => wire__crate__api__messages__mark_as_read_impl(port, ptr, rust_vec_len, data_len),
-        59 => wire__crate__api__messages__on_attachment_progress_impl(
+        58 => wire__crate__api__nwc__make_invoice_impl(port, ptr, rust_vec_len, data_len),
+        59 => wire__crate__api__messages__mark_as_read_impl(port, ptr, rust_vec_len, data_len),
+        60 => wire__crate__api__messages__on_attachment_progress_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        60 => wire__crate__api__nostr__on_connection_state_changed_impl(
+        61 => wire__crate__api__nostr__on_connection_state_changed_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        61 => {
+        62 => {
             wire__crate__api__disputes__on_dispute_updated_impl(port, ptr, rust_vec_len, data_len)
         }
-        62 => wire__crate__api__messages__on_new_message_impl(port, ptr, rust_vec_len, data_len),
-        63 => wire__crate__api__orders__on_orders_updated_impl(port, ptr, rust_vec_len, data_len),
-        64 => {
+        63 => wire__crate__api__messages__on_new_message_impl(port, ptr, rust_vec_len, data_len),
+        64 => wire__crate__api__orders__on_orders_updated_impl(port, ptr, rust_vec_len, data_len),
+        65 => {
             wire__crate__api__reputation__on_rating_received_impl(port, ptr, rust_vec_len, data_len)
         }
-        65 => {
+        66 => {
             wire__crate__api__nostr__on_relay_status_changed_impl(port, ptr, rust_vec_len, data_len)
         }
-        66 => {
+        67 => {
             wire__crate__api__settings__on_settings_changed_impl(port, ptr, rust_vec_len, data_len)
         }
-        67 => wire__crate__api__messages__on_unread_count_changed_impl(
+        68 => wire__crate__api__messages__on_unread_count_changed_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        68 => {
+        69 => {
             wire__crate__api__nwc__on_wallet_status_changed_impl(port, ptr, rust_vec_len, data_len)
         }
-        69 => wire__crate__api__disputes__open_dispute_impl(port, ptr, rust_vec_len, data_len),
-        70 => {
+        70 => wire__crate__api__disputes__open_dispute_impl(port, ptr, rust_vec_len, data_len),
+        71 => {
             wire__crate__api__orders__order_filters_default_impl(port, ptr, rust_vec_len, data_len)
         }
-        71 => wire__crate__api__nwc__pay_invoice_impl(port, ptr, rust_vec_len, data_len),
-        72 => wire__crate__api__orders__release_order_impl(port, ptr, rust_vec_len, data_len),
-        73 => wire__crate__api__nostr__remove_relay_impl(port, ptr, rust_vec_len, data_len),
-        74 => wire__crate__api__orders__resolve_maker_order_impl(port, ptr, rust_vec_len, data_len),
-        75 => wire__crate__api__orders__send_fiat_sent_impl(port, ptr, rust_vec_len, data_len),
-        76 => wire__crate__api__messages__send_file_impl(port, ptr, rust_vec_len, data_len),
-        77 => wire__crate__api__orders__send_invoice_impl(port, ptr, rust_vec_len, data_len),
-        78 => wire__crate__api__messages__send_message_impl(port, ptr, rust_vec_len, data_len),
-        79 => wire__crate__api__settings__set_default_fiat_code_impl(
+        72 => wire__crate__api__nwc__pay_invoice_impl(port, ptr, rust_vec_len, data_len),
+        73 => wire__crate__api__orders__release_order_impl(port, ptr, rust_vec_len, data_len),
+        74 => wire__crate__api__nostr__remove_relay_impl(port, ptr, rust_vec_len, data_len),
+        75 => wire__crate__api__orders__resolve_maker_order_impl(port, ptr, rust_vec_len, data_len),
+        76 => wire__crate__api__orders__send_fiat_sent_impl(port, ptr, rust_vec_len, data_len),
+        77 => wire__crate__api__messages__send_file_impl(port, ptr, rust_vec_len, data_len),
+        78 => wire__crate__api__orders__send_invoice_impl(port, ptr, rust_vec_len, data_len),
+        79 => wire__crate__api__messages__send_message_impl(port, ptr, rust_vec_len, data_len),
+        80 => wire__crate__api__settings__set_default_fiat_code_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        80 => wire__crate__api__settings__set_default_lightning_address_impl(
+        81 => wire__crate__api__settings__set_default_lightning_address_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        81 => wire__crate__api__settings__set_language_impl(port, ptr, rust_vec_len, data_len),
-        82 => {
+        82 => wire__crate__api__settings__set_language_impl(port, ptr, rust_vec_len, data_len),
+        83 => {
             wire__crate__api__settings__set_logging_enabled_impl(port, ptr, rust_vec_len, data_len)
         }
-        83 => {
+        84 => {
             wire__crate__api__reputation__set_privacy_mode_impl(port, ptr, rust_vec_len, data_len)
         }
-        84 => wire__crate__api__settings__set_theme_impl(port, ptr, rust_vec_len, data_len),
-        85 => wire__crate__api__disputes__submit_evidence_impl(port, ptr, rust_vec_len, data_len),
-        86 => wire__crate__api__reputation__submit_rating_impl(port, ptr, rust_vec_len, data_len),
-        87 => wire__crate__api__orders__subscribe_orders_impl(port, ptr, rust_vec_len, data_len),
-        88 => wire__crate__api__orders__take_order_impl(port, ptr, rust_vec_len, data_len),
+        85 => wire__crate__api__settings__set_theme_impl(port, ptr, rust_vec_len, data_len),
+        86 => wire__crate__api__disputes__submit_evidence_impl(port, ptr, rust_vec_len, data_len),
+        87 => wire__crate__api__reputation__submit_rating_impl(port, ptr, rust_vec_len, data_len),
+        88 => wire__crate__api__orders__subscribe_orders_impl(port, ptr, rust_vec_len, data_len),
+        89 => wire__crate__api__orders__take_order_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/rust/src/nwc/client.rs
+++ b/rust/src/nwc/client.rs
@@ -149,43 +149,51 @@ mod native {
                 .author(self.uri.public_key)
                 .since(event.created_at);
 
-            self.client
+            let sub_output = self.client
                 .subscribe(filter, None)
                 .await
                 .map_err(|e| anyhow!("Failed to subscribe for NIP-47 response: {e}"))?;
+            let sub_id = sub_output.val;
 
             // 2. Send the request event.
-            self.client
-                .send_event(&event)
-                .await
-                .map_err(|e| anyhow!("Failed to send NIP-47 request: {e}"))?;
+            let result: Result<Nip47Response> = async {
+                self.client
+                    .send_event(&event)
+                    .await
+                    .map_err(|e| anyhow!("Failed to send NIP-47 request: {e}"))?;
 
-            // 3. Wait for the matching response on the notification channel.
-            let deadline = tokio::time::Instant::now() + NWC_TIMEOUT;
-            loop {
-                let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-                if remaining.is_zero() {
-                    bail!("NWC timeout: no response received from wallet within {NWC_TIMEOUT:?}");
-                }
-
-                match tokio::time::timeout(remaining, notifications.recv()).await {
-                    Ok(Ok(RelayPoolNotification::Event {
-                        event: resp_event, ..
-                    })) => {
-                        if resp_event.kind == Kind::WalletConnectResponse {
-                            match parse_nip47_response(&self.uri, &resp_event) {
-                                Ok(resp) => return Ok(resp),
-                                Err(_) => continue,
-                            }
-                        }
-                    }
-                    Ok(Ok(_)) => continue, // other notification types
-                    Ok(Err(_)) => continue, // lagged, retry
-                    Err(_) => {
+                // 3. Wait for the matching response on the notification channel.
+                let deadline = tokio::time::Instant::now() + NWC_TIMEOUT;
+                loop {
+                    let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+                    if remaining.is_zero() {
                         bail!("NWC timeout: no response received from wallet within {NWC_TIMEOUT:?}");
                     }
+
+                    match tokio::time::timeout(remaining, notifications.recv()).await {
+                        Ok(Ok(RelayPoolNotification::Event {
+                            event: resp_event, ..
+                        })) => {
+                            if resp_event.kind == Kind::WalletConnectResponse {
+                                match parse_nip47_response(&self.uri, &resp_event) {
+                                    Ok(resp) => return Ok(resp),
+                                    Err(_) => continue,
+                                }
+                            }
+                        }
+                        Ok(Ok(_)) => continue, // other notification types
+                        Ok(Err(_)) => continue, // lagged, retry
+                        Err(_) => {
+                            bail!("NWC timeout: no response received from wallet within {NWC_TIMEOUT:?}");
+                        }
+                    }
                 }
-            }
+            }.await;
+
+            // Always clean up the subscription, even on timeout/error.
+            self.client.unsubscribe(&sub_id).await;
+
+            result
         }
 
         /// Query wallet info (name, supported methods) via NIP-47 `get_info`.
@@ -424,26 +432,30 @@ mod tests {
         assert!(err.to_string().contains("InvalidNwcUri"));
     }
 
+    /// Placeholder URI for parsing tests. Replace with a real NWC URI
+    /// (e.g. via NWC_URI env var) to run the ignored integration tests.
+    #[allow(dead_code)]
     fn test_uri() -> &'static str {
-        "nostr+walletconnect://0cc2b404a3ff52138e489db480048b3c096eb7d6438c872b5ecd386494b06084?relay=wss://relay.getalby.com&relay=wss://relay2.getalby.com&secret=09ef2ea6bb48dc1786529254dae8bf5f9340ec93576baea91f3bdc8f8493903a&lud16=lncurl_blighted_waffle@getalby.com"
+        "nostr+walletconnect://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa?relay=wss://relay.example.com&secret=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
     }
 
+    /// Requires a live NWC wallet — set NWC_URI env var before running.
     #[tokio::test]
-    async fn connect_to_alby_relay() {
-        let client = NwcClient::new(test_uri()).await.unwrap();
+    #[ignore = "requires a live NWC wallet — set NWC_URI env var before running"]
+    async fn connect_to_live_relay() {
+        let uri = std::env::var("NWC_URI").expect("NWC_URI env var required");
+        let client = NwcClient::new(&uri).await.unwrap();
         assert_eq!(client.info.status, crate::api::types::WalletStatus::Connecting);
         assert!(!client.info.relay_urls.is_empty());
-        // Verify the URI was parsed correctly.
-        assert_eq!(
-            client.info.wallet_pubkey,
-            "0cc2b404a3ff52138e489db480048b3c096eb7d6438c872b5ecd386494b06084"
-        );
         client.disconnect().await;
     }
 
+    /// Requires a live NWC wallet — set NWC_URI env var before running.
     #[tokio::test]
-    async fn get_info_from_alby() {
-        let mut client = NwcClient::new(test_uri()).await.unwrap();
+    #[ignore = "requires a live NWC wallet — set NWC_URI env var before running"]
+    async fn get_info_from_live_wallet() {
+        let uri = std::env::var("NWC_URI").expect("NWC_URI env var required");
+        let mut client = NwcClient::new(&uri).await.unwrap();
         let info = client.get_info().await.unwrap();
         assert_eq!(info.status, crate::api::types::WalletStatus::Connected);
         assert!(info.last_connected_at.is_some());
@@ -451,9 +463,12 @@ mod tests {
         client.disconnect().await;
     }
 
+    /// Requires a live NWC wallet — set NWC_URI env var before running.
     #[tokio::test]
-    async fn get_balance_from_alby() {
-        let mut client = NwcClient::new(test_uri()).await.unwrap();
+    #[ignore = "requires a live NWC wallet — set NWC_URI env var before running"]
+    async fn get_balance_from_live_wallet() {
+        let uri = std::env::var("NWC_URI").expect("NWC_URI env var required");
+        let mut client = NwcClient::new(&uri).await.unwrap();
         client.get_info().await.unwrap();
         let balance = client.get_balance().await.unwrap();
         println!("balance_sats: {:?}", balance);


### PR DESCRIPTION
Wire NwcPaymentWidget to nwc_api.payInvoice() and NwcInvoiceWidget to nwc_api.makeInvoice(). Add make_invoice public API function in the Rust NWC layer (the client method already existed) with input validation and unit tests. Regenerate flutter_rust_bridge bindings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated invoice generation via connected Nostr Wallet Connect (NWC) wallets
  * Automated payment processing via connected NWC wallets

* **Bug Fixes**
  * More reliable wallet communication with improved request/response cleanup
  * Clearer error messages and more consistent fallback to manual entry when wallet operations fail
<!-- end of auto-generated comment: release notes by coderabbit.ai -->