### PR TITLE
feat: wire relay toggle, mostro node selector, log stream, and disput…

### DIFF
--- a/lib/features/disputes/screens/dispute_chat_screen.dart
+++ b/lib/features/disputes/screens/dispute_chat_screen.dart
@@ -43,7 +43,9 @@ class _DisputeChatScreenState extends ConsumerState<DisputeChatScreen> {
   }
 
   void _onSendText(String text) {
-    // TODO(bridge): Encrypt with adminSharedKey and publish via Rust bridge.
+    // Dispute messaging requires an adminSharedKey derived from the trade key
+    // and the admin's pubkey (Phase 12). The Rust bridge will expose
+    // `send_dispute_message(dispute_id, text, admin_shared_key)` when ready.
     final l10n = AppLocalizations.of(context);
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
@@ -54,7 +56,8 @@ class _DisputeChatScreenState extends ConsumerState<DisputeChatScreen> {
   }
 
   void _onAttachFile() {
-    // TODO(bridge): Open file picker, encrypt with adminSharedKey, upload.
+    // File attachments in disputes require the same adminSharedKey as text
+    // messages (Phase 12). Will use file picker + encrypt + upload flow.
     final l10n = AppLocalizations.of(context);
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(

--- a/lib/features/settings/providers/log_provider.dart
+++ b/lib/features/settings/providers/log_provider.dart
@@ -5,13 +5,17 @@ import 'package:mostro/src/rust/api/types.dart';
 
 /// Live log entries from the Rust backend, newest first.
 ///
-/// Caps at 500 entries to bound memory usage.
+/// Caps at 500 entries to bound memory usage.  The stream is cancelled
+/// when the provider is disposed (e.g. when LogReportScreen is popped).
 final logEntriesProvider = StreamProvider.autoDispose<List<LogEntry>>((ref) async* {
+  var cancelled = false;
+  ref.onDispose(() => cancelled = true);
+
   final stream = await logging_api.onLogEntry();
   final entries = <LogEntry>[];
-  while (true) {
+  while (!cancelled) {
     final entry = await stream.next();
-    if (entry == null) break;
+    if (entry == null || cancelled) break;
     entries.insert(0, entry); // newest first
     if (entries.length > 500) entries.removeLast();
     yield List.unmodifiable(entries);

--- a/lib/features/settings/providers/log_provider.dart
+++ b/lib/features/settings/providers/log_provider.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:mostro/src/rust/api/logging.dart' as logging_api;
+import 'package:mostro/src/rust/api/types.dart';
+
+/// Live log entries from the Rust backend, newest first.
+///
+/// Caps at 500 entries to bound memory usage.
+final logEntriesProvider = StreamProvider.autoDispose<List<LogEntry>>((ref) async* {
+  final stream = await logging_api.onLogEntry();
+  final entries = <LogEntry>[];
+  while (true) {
+    final entry = await stream.next();
+    if (entry == null) break;
+    entries.insert(0, entry); // newest first
+    if (entries.length > 500) entries.removeLast();
+    yield List.unmodifiable(entries);
+  }
+});

--- a/lib/features/settings/screens/log_report_screen.dart
+++ b/lib/features/settings/screens/log_report_screen.dart
@@ -3,29 +3,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:share_plus/share_plus.dart';
 
 import 'package:mostro/core/app_theme.dart';
+import 'package:mostro/features/settings/providers/log_provider.dart';
 import 'package:mostro/features/settings/providers/settings_provider.dart';
-
-// ── Local log level enum (mirrors Rust LogLevel) ──────────────────────────────
-
-enum _LogLevel { debug, info, warning, error }
-
-// ── Local log entry model ─────────────────────────────────────────────────────
-
-class _LogEntry {
-  const _LogEntry({
-    required this.id,
-    required this.level,
-    required this.tag,
-    required this.message,
-    required this.timestamp,
-  });
-
-  final int id;
-  final _LogLevel level;
-  final String tag;
-  final String message;
-  final int timestamp; // Unix seconds
-}
+import 'package:mostro/src/rust/api/types.dart';
 
 // ── Screen ────────────────────────────────────────────────────────────────────
 
@@ -37,42 +17,15 @@ class LogReportScreen extends ConsumerStatefulWidget {
 }
 
 class _LogReportScreenState extends ConsumerState<LogReportScreen> {
-  // Sample data shown when no bridge is connected.
-  // TODO(bridge): replace _mockEntries with a live stream from the Rust log
-  // sink once the log bridge API is implemented (Phase 18+).  The bridge
-  // should expose an on_log_entry() stream that emits LogEntry structs; consume
-  // it here via a StreamBuilder or a Riverpod StreamProvider and remove the
-  // static list below.
-  static final List<_LogEntry> _mockEntries = List.unmodifiable([
-    _LogEntry(
-      id: 1,
-      level: _LogLevel.info,
-      tag: 'App',
-      message: 'Application started successfully',
-      timestamp: DateTime.now().millisecondsSinceEpoch ~/ 1000 - 120,
-    ),
-    _LogEntry(
-      id: 2,
-      level: _LogLevel.warning,
-      tag: 'Relay',
-      message: 'Connection to wss://nos.lol timed out, retrying…',
-      timestamp: DateTime.now().millisecondsSinceEpoch ~/ 1000 - 60,
-    ),
-    _LogEntry(
-      id: 3,
-      level: _LogLevel.debug,
-      tag: 'Order',
-      message: 'Fetched 42 orders from relay',
-      timestamp: DateTime.now().millisecondsSinceEpoch ~/ 1000 - 10,
-    ),
-  ]);
-
   @override
   Widget build(BuildContext context) {
     final loggingEnabled = ref.watch(settingsProvider).loggingEnabled;
     final colorsRaw = Theme.of(context).extension<AppColors>();
     if (colorsRaw == null) throw StateError('AppColors theme extension must be registered');
     final colors = colorsRaw;
+
+    final logAsync = ref.watch(logEntriesProvider);
+    final entries = logAsync.valueOrNull ?? const [];
 
     return Scaffold(
       appBar: AppBar(
@@ -81,8 +34,8 @@ class _LogReportScreenState extends ConsumerState<LogReportScreen> {
           // Share logs — disabled when no entries exist.
           IconButton(
             icon: const Icon(Icons.share_outlined),
-            tooltip: _mockEntries.isNotEmpty ? 'Share logs' : 'No logs to share',
-            onPressed: _mockEntries.isNotEmpty ? _shareLogs : null,
+            tooltip: entries.isNotEmpty ? 'Share logs' : 'No logs to share',
+            onPressed: entries.isNotEmpty ? () => _shareLogs(entries) : null,
           ),
           // Toggle logging
           IconButton(
@@ -138,7 +91,7 @@ class _LogReportScreenState extends ConsumerState<LogReportScreen> {
           ),
           // Log entries
           Expanded(
-            child: _mockEntries.isEmpty
+            child: entries.isEmpty
                 ? Center(
                     child: Text(
                       'No log entries',
@@ -147,10 +100,10 @@ class _LogReportScreenState extends ConsumerState<LogReportScreen> {
                   )
                 : ListView.builder(
                     padding: const EdgeInsets.all(AppSpacing.md),
-                    itemCount: _mockEntries.length,
+                    itemCount: entries.length,
                     itemBuilder: (context, index) {
                       return _LogEntryTile(
-                        entry: _mockEntries[index],
+                        entry: entries[index],
                         colors: colors,
                       );
                     },
@@ -161,8 +114,8 @@ class _LogReportScreenState extends ConsumerState<LogReportScreen> {
     );
   }
 
-  Future<void> _shareLogs() async {
-    final lines = _mockEntries.map((e) {
+  Future<void> _shareLogs(List<LogEntry> entries) async {
+    final lines = entries.map((e) {
       final time = _formatTimestamp(e.timestamp);
       final level = e.level.name.toUpperCase().padRight(7);
       final tag = _sanitizeForShare(e.tag);
@@ -192,7 +145,7 @@ class _LogReportScreenState extends ConsumerState<LogReportScreen> {
 class _LogEntryTile extends StatelessWidget {
   const _LogEntryTile({required this.entry, required this.colors});
 
-  final _LogEntry entry;
+  final LogEntry entry;
   final AppColors colors;
 
   @override
@@ -258,12 +211,12 @@ class _LogEntryTile extends StatelessWidget {
     );
   }
 
-  (Color, Color) _levelColors(_LogLevel level) {
+  (Color, Color) _levelColors(LogLevel level) {
     return switch (level) {
-      _LogLevel.debug => (const Color(0xFF374151), const Color(0xFFD1D5DB)),
-      _LogLevel.info => (const Color(0xFF1E3A8A), const Color(0xFF93C5FD)),
-      _LogLevel.warning => (const Color(0xFF854D0E), const Color(0xFFFCD34D)),
-      _LogLevel.error => (const Color(0xFF7F1D1D), const Color(0xFFFCA5A5)),
+      LogLevel.debug => (const Color(0xFF374151), const Color(0xFFD1D5DB)),
+      LogLevel.info => (const Color(0xFF1E3A8A), const Color(0xFF93C5FD)),
+      LogLevel.warning => (const Color(0xFF854D0E), const Color(0xFFFCD34D)),
+      LogLevel.error => (const Color(0xFF7F1D1D), const Color(0xFFFCA5A5)),
     };
   }
 }

--- a/lib/features/settings/widgets/mostro_node_selector.dart
+++ b/lib/features/settings/widgets/mostro_node_selector.dart
@@ -3,16 +3,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:mostro/core/app_theme.dart';
 import 'package:mostro/core/mostro_defaults.dart';
+import 'package:mostro/src/rust/api/settings.dart' as settings_api;
 
 // ── Provider for current Mostro node pubkey ───────────────────────────────────
 
 const _defaultMostroPubkey = defaultMostroPubkey;
 
-/// In-memory override of the Mostro node pubkey.
-///
-/// **UI-only placeholder** — this value is not yet passed to the Rust bridge.
-/// TODO(bridge): read mostroPubkeyProvider when constructing outgoing Nostr
-/// events so order routing uses the selected node (Phase 18+).
+/// Active Mostro node pubkey — synced to the Rust bridge so outgoing events
+/// are routed to the selected node.
 final mostroPubkeyProvider = StateProvider<String>(
   (ref) => _defaultMostroPubkey,
 );
@@ -63,6 +61,7 @@ class _MostroNodeSelectorState extends ConsumerState<MostroNodeSelector> {
 
   void _useDefault() {
     ref.read(mostroPubkeyProvider.notifier).state = _defaultMostroPubkey;
+    settings_api.setMostroPubkey(pubkey: null);
     _controller.clear();
     setState(() => _errorText = null);
     Navigator.of(context).pop();
@@ -78,7 +77,9 @@ class _MostroNodeSelectorState extends ConsumerState<MostroNodeSelector> {
       setState(() => _errorText = 'Must be a 64-character hex string');
       return;
     }
-    ref.read(mostroPubkeyProvider.notifier).state = input.toLowerCase();
+    final pubkey = input.toLowerCase();
+    ref.read(mostroPubkeyProvider.notifier).state = pubkey;
+    settings_api.setMostroPubkey(pubkey: pubkey);
     Navigator.of(context).pop();
   }
 

--- a/lib/features/settings/widgets/mostro_node_selector.dart
+++ b/lib/features/settings/widgets/mostro_node_selector.dart
@@ -59,18 +59,27 @@ class _MostroNodeSelectorState extends ConsumerState<MostroNodeSelector> {
     super.dispose();
   }
 
-  void _useDefault() {
+  Future<void> _useDefault() async {
+    final previous = ref.read(mostroPubkeyProvider);
     ref.read(mostroPubkeyProvider.notifier).state = _defaultMostroPubkey;
-    settings_api.setMostroPubkey(pubkey: null);
-    _controller.clear();
-    setState(() => _errorText = null);
-    Navigator.of(context).pop();
+    try {
+      await settings_api.setMostroPubkey(pubkey: null);
+      if (!mounted) return;
+      _controller.clear();
+      setState(() => _errorText = null);
+      Navigator.of(context).pop();
+    } catch (e) {
+      debugPrint('[MostroNodeSelector] setMostroPubkey(null) failed: $e');
+      ref.read(mostroPubkeyProvider.notifier).state = previous;
+      if (!mounted) return;
+      setState(() => _errorText = 'Failed to reset node');
+    }
   }
 
-  void _confirm() {
+  Future<void> _confirm() async {
     final input = _controller.text.trim();
     if (input.isEmpty) {
-      _useDefault();
+      await _useDefault();
       return;
     }
     if (!_hexRegex.hasMatch(input)) {
@@ -78,9 +87,18 @@ class _MostroNodeSelectorState extends ConsumerState<MostroNodeSelector> {
       return;
     }
     final pubkey = input.toLowerCase();
+    final previous = ref.read(mostroPubkeyProvider);
     ref.read(mostroPubkeyProvider.notifier).state = pubkey;
-    settings_api.setMostroPubkey(pubkey: pubkey);
-    Navigator.of(context).pop();
+    try {
+      await settings_api.setMostroPubkey(pubkey: pubkey);
+      if (!mounted) return;
+      Navigator.of(context).pop();
+    } catch (e) {
+      debugPrint('[MostroNodeSelector] setMostroPubkey failed: $e');
+      ref.read(mostroPubkeyProvider.notifier).state = previous;
+      if (!mounted) return;
+      setState(() => _errorText = 'Invalid pubkey or bridge error');
+    }
   }
 
   @override

--- a/lib/features/settings/widgets/relay_management_card.dart
+++ b/lib/features/settings/widgets/relay_management_card.dart
@@ -38,9 +38,6 @@ class _RelayManagementCardState extends ConsumerState<RelayManagementCard> {
   // Defaults mirror rust/src/config.rs — imported from core/mostro_defaults.dart.
   static const _defaultRelays = defaultMostroRelays;
 
-  // TODO(bridge): replace _relays local state with a Riverpod provider backed
-  // by the Rust bridge (get_relays / add_relay / remove_relay) so configuration
-  // persists across navigations and stays in sync with the backend (Phase 18+).
   late List<_RelayEntry> _relays;
   bool _loading = false;
 
@@ -73,8 +70,29 @@ class _RelayManagementCardState extends ConsumerState<RelayManagementCard> {
     }
   }
 
-  void _toggleRelay(int index, bool value) {
+  Future<void> _toggleRelay(int index, bool value) async {
+    final url = _relays[index].url;
     setState(() => _relays[index].isActive = value);
+    try {
+      if (value) {
+        await nostr_api.addRelay(url: url);
+      } else {
+        await nostr_api.removeRelay(url: url);
+      }
+    } catch (e) {
+      debugPrint('[RelayManagement] toggleRelay failed: $e');
+      if (!mounted) return;
+      setState(() {
+        final currentIndex = _relays.indexWhere((r) => r.url == url);
+        if (currentIndex != -1) {
+          _relays[currentIndex].isActive = !value;
+        }
+      });
+      final l10n = AppLocalizations.of(context);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(value ? l10n.relayAddFailed : l10n.relayRemoveFailed)),
+      );
+    }
   }
 
   Future<void> _removeRelay(int index) async {

--- a/rust/src/api/disputes.rs
+++ b/rust/src/api/disputes.rs
@@ -134,8 +134,8 @@ pub async fn open_dispute(trade_id: String, reason: Option<String>) -> Result<Di
         let sender_keys =
             crate::api::identity::get_active_trade_keys(trade_index).await?;
         let mostro_pubkey =
-            nostr_sdk::PublicKey::from_hex(crate::config::DEFAULT_MOSTRO_PUBKEY)
-                .map_err(|e| anyhow!("invalid DEFAULT_MOSTRO_PUBKEY: {e}"))?;
+            nostr_sdk::PublicKey::from_hex(&crate::config::active_mostro_pubkey())
+                .map_err(|e| anyhow!("invalid mostro pubkey: {e}"))?;
         crate::mostro::actions::dispute(&sender_keys, &mostro_pubkey, &trade_id, trade_index)
             .await
     }

--- a/rust/src/api/logging.rs
+++ b/rust/src/api/logging.rs
@@ -26,6 +26,8 @@ fn log_sender() -> &'static broadcast::Sender<LogEntry> {
 // ── Forwarding bridge (sync → async) ────────────────────────────────────────
 
 static LOG_STD_TX: OnceLock<Mutex<mpsc::Sender<LogEntry>>> = OnceLock::new();
+
+/// Monotonically increasing ID for log entries.
 static COUNTER: AtomicU32 = AtomicU32::new(0);
 
 /// Install the log capture bridge.

--- a/rust/src/api/logging.rs
+++ b/rust/src/api/logging.rs
@@ -1,5 +1,9 @@
 //! Log sink — captures `log` crate records and exposes them to Flutter
 //! via a flutter_rust_bridge stream.
+//!
+//! [`install_log_bridge`] replaces the active `log` backend with a forwarder
+//! that sends every record to both the platform logger (android_logger on
+//! Android, stderr elsewhere) **and** the Flutter [`on_log_entry`] stream.
 
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{mpsc, Mutex, OnceLock};
@@ -22,14 +26,13 @@ fn log_sender() -> &'static broadcast::Sender<LogEntry> {
 // ── Forwarding bridge (sync → async) ────────────────────────────────────────
 
 static LOG_STD_TX: OnceLock<Mutex<mpsc::Sender<LogEntry>>> = OnceLock::new();
-#[allow(dead_code)]
 static COUNTER: AtomicU32 = AtomicU32::new(0);
 
-/// Install the in-process log capture hook.
+/// Install the log capture bridge.
 ///
-/// Must be called once during app initialization.  After this call, every
-/// [`forward_log`] invocation forwards the entry to the Flutter
-/// `on_log_entry()` stream.
+/// Must be called once during app initialization (from `init_app()`).
+/// After this call, every `log::info!()` / `log::warn!()` etc. in Rust
+/// is forwarded to the Flutter `on_log_entry()` stream.
 pub fn install_log_bridge() {
     static INSTALLED: std::sync::Once = std::sync::Once::new();
     INSTALLED.call_once(|| {
@@ -45,15 +48,58 @@ pub fn install_log_bridge() {
         });
 
         LOG_STD_TX.get_or_init(|| Mutex::new(std_tx));
+
+        // Install a custom log::Log that forwards every record.
+        // max_level is set to Debug so Info/Warn/Error all flow through.
+        let _ = log::set_logger(&BRIDGE_LOGGER);
+        log::set_max_level(log::LevelFilter::Debug);
     });
 }
 
+/// Global logger instance that forwards records to the Flutter stream
+/// and also prints to stderr (or android_logger on Android).
+static BRIDGE_LOGGER: BridgeLogger = BridgeLogger;
+
+struct BridgeLogger;
+
+impl log::Log for BridgeLogger {
+    fn enabled(&self, metadata: &log::Metadata) -> bool {
+        metadata.level() <= log::Level::Debug
+    }
+
+    fn log(&self, record: &log::Record) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+
+        // Forward to Flutter stream.
+        forward_log(record.level(), record.target(), &record.args().to_string());
+
+        // Also print to platform output so adb logcat / stderr still works.
+        #[cfg(target_os = "android")]
+        {
+            // android_logger is no longer the active backend, so print manually.
+            let tag = record.target().split("::").last().unwrap_or(record.target());
+            let msg = format!("[{}] {}", tag, record.args());
+            // Use __android_log_print via the log crate's Android integration
+            // or just eprintln as a fallback — logcat picks up stderr.
+            eprintln!("{msg}");
+        }
+        #[cfg(not(target_os = "android"))]
+        {
+            eprintln!(
+                "[{level}] {target}: {msg}",
+                level = record.level(),
+                target = record.target(),
+                msg = record.args(),
+            );
+        }
+    }
+
+    fn flush(&self) {}
+}
+
 /// Forward a log record to the Flutter stream.
-///
-/// Called from Rust code that wants to surface log entries to the UI.
-/// The `log` crate integration is left to the caller (e.g. a custom
-/// `log::Log` implementation or explicit calls at key log sites).
-#[allow(dead_code)]
 pub(crate) fn forward_log(level: log::Level, target: &str, message: &str) {
     if let Some(tx) = LOG_STD_TX.get() {
         let entry = LogEntry {

--- a/rust/src/api/logging.rs
+++ b/rust/src/api/logging.rs
@@ -1,0 +1,142 @@
+//! Log sink — captures `log` crate records and exposes them to Flutter
+//! via a flutter_rust_bridge stream.
+
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{mpsc, Mutex, OnceLock};
+
+use tokio::sync::broadcast;
+
+use crate::api::types::{LogEntry, LogLevel};
+
+// ── Global broadcast channel for log entries ─────────────────────────────────
+
+static LOG_TX: OnceLock<broadcast::Sender<LogEntry>> = OnceLock::new();
+
+fn log_sender() -> &'static broadcast::Sender<LogEntry> {
+    LOG_TX.get_or_init(|| {
+        let (tx, _) = broadcast::channel(512);
+        tx
+    })
+}
+
+// ── Forwarding bridge (sync → async) ────────────────────────────────────────
+
+static LOG_STD_TX: OnceLock<Mutex<mpsc::Sender<LogEntry>>> = OnceLock::new();
+#[allow(dead_code)]
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+/// Install the in-process log capture hook.
+///
+/// Must be called once during app initialization.  After this call, every
+/// [`forward_log`] invocation forwards the entry to the Flutter
+/// `on_log_entry()` stream.
+pub fn install_log_bridge() {
+    static INSTALLED: std::sync::Once = std::sync::Once::new();
+    INSTALLED.call_once(|| {
+        let tx = log_sender().clone();
+        let (std_tx, std_rx) = mpsc::channel::<LogEntry>();
+
+        // Background thread: reads from the std mpsc channel and broadcasts
+        // to the tokio broadcast channel.
+        std::thread::spawn(move || {
+            while let Ok(entry) = std_rx.recv() {
+                let _ = tx.send(entry);
+            }
+        });
+
+        LOG_STD_TX.get_or_init(|| Mutex::new(std_tx));
+    });
+}
+
+/// Forward a log record to the Flutter stream.
+///
+/// Called from Rust code that wants to surface log entries to the UI.
+/// The `log` crate integration is left to the caller (e.g. a custom
+/// `log::Log` implementation or explicit calls at key log sites).
+#[allow(dead_code)]
+pub(crate) fn forward_log(level: log::Level, target: &str, message: &str) {
+    if let Some(tx) = LOG_STD_TX.get() {
+        let entry = LogEntry {
+            id: COUNTER.fetch_add(1, Ordering::Relaxed),
+            level: match level {
+                log::Level::Error => LogLevel::Error,
+                log::Level::Warn => LogLevel::Warning,
+                log::Level::Info => LogLevel::Info,
+                _ => LogLevel::Debug,
+            },
+            tag: target.split("::").last().unwrap_or(target).to_string(),
+            message: message.to_string(),
+            timestamp: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs() as i64,
+        };
+        if let Ok(g) = tx.lock() {
+            let _ = g.send(entry);
+        }
+    }
+}
+
+// ── FRB stream ───────────────────────────────────────────────────────────────
+
+/// Stream of log entries for consumption by Flutter.
+pub struct LogEntryStream {
+    rx: broadcast::Receiver<LogEntry>,
+}
+
+impl LogEntryStream {
+    /// Poll for the next log entry.
+    pub async fn next(&mut self) -> Option<LogEntry> {
+        loop {
+            match self.rx.recv().await {
+                Ok(entry) => return Some(entry),
+                Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(broadcast::error::RecvError::Closed) => return None,
+            }
+        }
+    }
+}
+
+/// Subscribe to the live log stream.
+///
+/// Each call returns a new independent stream.  Call [`install_log_bridge`]
+/// during initialization or no entries will be emitted.
+pub fn on_log_entry() -> LogEntryStream {
+    LogEntryStream {
+        rx: log_sender().subscribe(),
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn forward_log_does_not_panic() {
+        // Calling forward_log should not panic regardless of bridge state.
+        // If bridge is installed, this forwards; if not, it's a no-op.
+        forward_log(log::Level::Info, "test", "should not panic");
+    }
+
+    #[tokio::test]
+    async fn install_and_receive_log() {
+        install_log_bridge();
+        let mut stream = on_log_entry();
+
+        forward_log(log::Level::Warn, "nwc::client", "test warning");
+
+        let entry = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            stream.next(),
+        )
+        .await
+        .expect("timed out waiting for log entry")
+        .expect("stream closed unexpectedly");
+
+        assert_eq!(entry.level, LogLevel::Warning);
+        assert_eq!(entry.tag, "client");
+        assert_eq!(entry.message, "test warning");
+    }
+}

--- a/rust/src/api/logging.rs
+++ b/rust/src/api/logging.rs
@@ -1,9 +1,9 @@
 //! Log sink — captures `log` crate records and exposes them to Flutter
 //! via a flutter_rust_bridge stream.
 //!
-//! [`install_log_bridge`] replaces the active `log` backend with a forwarder
-//! that sends every record to both the platform logger (android_logger on
-//! Android, stderr elsewhere) **and** the Flutter [`on_log_entry`] stream.
+//! [`install_log_bridge`] sets the global `log` backend to a [`BridgeLogger`]
+//! that sends every record to both stderr (logcat on Android) **and** the
+//! Flutter [`on_log_entry`] stream.
 
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{mpsc, Mutex, OnceLock};
@@ -59,7 +59,7 @@ pub fn install_log_bridge() {
 }
 
 /// Global logger instance that forwards records to the Flutter stream
-/// and also prints to stderr (or android_logger on Android).
+/// and prints to stderr (logcat on Android).
 static BRIDGE_LOGGER: BridgeLogger = BridgeLogger;
 
 struct BridgeLogger;
@@ -77,25 +77,13 @@ impl log::Log for BridgeLogger {
         // Forward to Flutter stream.
         forward_log(record.level(), record.target(), &record.args().to_string());
 
-        // Also print to platform output so adb logcat / stderr still works.
-        #[cfg(target_os = "android")]
-        {
-            // android_logger is no longer the active backend, so print manually.
-            let tag = record.target().split("::").last().unwrap_or(record.target());
-            let msg = format!("[{}] {}", tag, record.args());
-            // Use __android_log_print via the log crate's Android integration
-            // or just eprintln as a fallback — logcat picks up stderr.
-            eprintln!("{msg}");
-        }
-        #[cfg(not(target_os = "android"))]
-        {
-            eprintln!(
-                "[{level}] {target}: {msg}",
-                level = record.level(),
-                target = record.target(),
-                msg = record.args(),
-            );
-        }
+        // Also print to stderr so adb logcat / terminal output still works.
+        eprintln!(
+            "[{level}] {target}: {msg}",
+            level = record.level(),
+            target = record.target(),
+            msg = record.args(),
+        );
     }
 
     fn flush(&self) {}

--- a/rust/src/api/mod.rs
+++ b/rust/src/api/mod.rs
@@ -1,5 +1,6 @@
 pub mod disputes;
 pub mod identity;
+pub mod logging;
 pub mod messages;
 pub mod nostr;
 pub mod nwc;

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::{broadcast, RwLock};
 
 use crate::api::types::{NewOrderParams, OrderInfo, OrderKind, OrderStatus};
-use crate::config::DEFAULT_MOSTRO_PUBKEY;
+use crate::config::active_mostro_pubkey;
 use crate::db::Storage;
 use crate::mostro::actions;
 use crate::nostr::order_events::parse_order_event;
@@ -436,7 +436,7 @@ pub async fn create_order(params: NewOrderParams) -> Result<OrderInfo> {
     store_pending_local_id(&ck, &order.id);
     order_book().upsert_order(order.clone()).await;
 
-    let mostro_pubkey = nostr_sdk::PublicKey::from_hex(DEFAULT_MOSTRO_PUBKEY)?;
+    let mostro_pubkey = nostr_sdk::PublicKey::from_hex(&active_mostro_pubkey())?;
     let event_json =
         actions::new_order(&sender_keys, &mostro_pubkey, &params_for_dispatch, trade_index)
             .await?;
@@ -535,7 +535,7 @@ pub async fn take_order(
     // Dispatch the take action to Mostro using the trade key for signing.
     match crate::api::identity::get_active_trade_keys(trade_index).await {
         Ok(sender_keys) => {
-            match nostr_sdk::PublicKey::from_hex(DEFAULT_MOSTRO_PUBKEY) {
+            match nostr_sdk::PublicKey::from_hex(&active_mostro_pubkey()) {
                 Ok(mostro_pubkey) => {
                     // Read default LN address from settings (take-sell-ln-address flow).
                     let ln_address: Option<String> =
@@ -628,7 +628,7 @@ pub async fn send_invoice(
     let trade_index = get_trade_key_index(&order_id).await
         .ok_or_else(|| anyhow::anyhow!("no persisted trade key for order {order_id}"))?;
     let sender_keys = crate::api::identity::get_active_trade_keys(trade_index).await?;
-    let mostro_pubkey = nostr_sdk::PublicKey::from_hex(DEFAULT_MOSTRO_PUBKEY)?;
+    let mostro_pubkey = nostr_sdk::PublicKey::from_hex(&active_mostro_pubkey())?;
     let event_json = actions::add_invoice(
         &sender_keys,
         &mostro_pubkey,
@@ -656,7 +656,7 @@ pub async fn send_fiat_sent(order_id: String) -> Result<()> {
     let trade_index = get_trade_key_index(&order_id).await
         .ok_or_else(|| anyhow::anyhow!("no persisted trade key for order {order_id}"))?;
     let sender_keys = crate::api::identity::get_active_trade_keys(trade_index).await?;
-    let mostro_pubkey = nostr_sdk::PublicKey::from_hex(DEFAULT_MOSTRO_PUBKEY)?;
+    let mostro_pubkey = nostr_sdk::PublicKey::from_hex(&active_mostro_pubkey())?;
     let event_json = actions::fiat_sent(&sender_keys, &mostro_pubkey, &order_id, trade_index).await?;
     publish_event_json(&event_json).await?;
     log::info!("[orders] fiat_sent published for order={order_id} trade_index={trade_index}");
@@ -671,7 +671,7 @@ pub async fn release_order(order_id: String) -> Result<()> {
     let trade_index = get_trade_key_index(&order_id).await
         .ok_or_else(|| anyhow::anyhow!("no persisted trade key for order {order_id}"))?;
     let sender_keys = crate::api::identity::get_active_trade_keys(trade_index).await?;
-    let mostro_pubkey = nostr_sdk::PublicKey::from_hex(DEFAULT_MOSTRO_PUBKEY)?;
+    let mostro_pubkey = nostr_sdk::PublicKey::from_hex(&active_mostro_pubkey())?;
     let event_json = actions::release(&sender_keys, &mostro_pubkey, &order_id, trade_index).await?;
     publish_event_json(&event_json).await?;
     log::info!("[orders] release published for order={order_id} trade_index={trade_index}");
@@ -687,7 +687,7 @@ pub async fn cancel_order(order_id: String) -> Result<()> {
     let trade_index = get_trade_key_index(&order_id).await
         .ok_or_else(|| anyhow::anyhow!("no persisted trade key for order {order_id}"))?;
     let sender_keys = crate::api::identity::get_active_trade_keys(trade_index).await?;
-    let mostro_pubkey = nostr_sdk::PublicKey::from_hex(DEFAULT_MOSTRO_PUBKEY)?;
+    let mostro_pubkey = nostr_sdk::PublicKey::from_hex(&active_mostro_pubkey())?;
     let event_json = actions::cancel(&sender_keys, &mostro_pubkey, &order_id, trade_index).await?;
     publish_event_json(&event_json).await?;
     log::info!("[orders] cancel published for order={order_id} trade_index={trade_index}");
@@ -884,7 +884,7 @@ async fn subscribe_single_order(order_id: &str) {
         };
         let client = pool.client();
         let mostro_pubkey =
-            match nostr_sdk::PublicKey::from_hex(crate::config::DEFAULT_MOSTRO_PUBKEY) {
+            match nostr_sdk::PublicKey::from_hex(&crate::config::active_mostro_pubkey()) {
                 Ok(pk) => pk,
                 Err(e) => {
                     log::error!("[orders] subscribe_single_order: invalid pubkey: {e}");
@@ -1011,10 +1011,10 @@ async fn _run_order_subscription() {
 
     // The Mostro daemon is the author of all Kind 38383 events.
     // Use the compiled-in default pubkey (mirrors config.rs / settings screen).
-    let mostro_pubkey = match nostr_sdk::PublicKey::from_hex(crate::config::DEFAULT_MOSTRO_PUBKEY) {
+    let mostro_pubkey = match nostr_sdk::PublicKey::from_hex(&crate::config::active_mostro_pubkey()) {
         Ok(pk) => pk,
         Err(e) => {
-            log::error!("[orders] invalid DEFAULT_MOSTRO_PUBKEY: {e}");
+            log::error!("[orders] invalid mostro pubkey: {e}");
             return;
         }
     };

--- a/rust/src/api/reputation.rs
+++ b/rust/src/api/reputation.rs
@@ -161,8 +161,8 @@ pub async fn submit_rating(trade_id: String, score: u8) -> Result<()> {
             let sender_keys =
                 crate::api::identity::get_active_trade_keys(trade_index).await?;
             let mostro_pubkey =
-                nostr_sdk::PublicKey::from_hex(crate::config::DEFAULT_MOSTRO_PUBKEY)
-                    .map_err(|e| anyhow::anyhow!("invalid DEFAULT_MOSTRO_PUBKEY: {e}"))?;
+                nostr_sdk::PublicKey::from_hex(&crate::config::active_mostro_pubkey())
+                    .map_err(|e| anyhow::anyhow!("invalid mostro pubkey: {e}"))?;
             let event_json = crate::mostro::actions::rate_user(
                 &sender_keys,
                 &mostro_pubkey,

--- a/rust/src/api/settings.rs
+++ b/rust/src/api/settings.rs
@@ -180,6 +180,26 @@ pub async fn set_default_lightning_address(address: Option<String>) -> Result<()
     Ok(())
 }
 
+/// Set or clear the active Mostro node pubkey.
+///
+/// Pass `Some("hex...")` to route orders to a custom Mostro node, or `None`
+/// to revert to the compiled-in default.
+///
+/// **Errors**: `InvalidPubkey` if `pubkey` is Some but not a valid 64-char hex key.
+pub fn set_mostro_pubkey(pubkey: Option<String>) -> Result<()> {
+    if let Some(ref pk) = pubkey {
+        nostr_sdk::PublicKey::from_hex(pk)
+            .map_err(|e| anyhow::anyhow!("InvalidPubkey: {e}"))?;
+    }
+    crate::config::set_active_mostro_pubkey(pubkey);
+    Ok(())
+}
+
+/// Return the currently active Mostro node pubkey (override or default).
+pub fn get_mostro_pubkey() -> String {
+    crate::config::active_mostro_pubkey()
+}
+
 /// Toggle the in-memory logging flag (not persisted to disk).
 ///
 /// When a Tokio runtime is available the update is dispatched asynchronously

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -3,6 +3,8 @@
 //! These are compiled into the app and used on first launch when no
 //! user-configured relays or Mostro node exist in the database.
 
+use std::sync::RwLock;
+
 /// Default relay URLs seeded on first launch.
 pub const DEFAULT_RELAYS: &[&str] = &[
     "wss://relay.mostro.network",
@@ -15,3 +17,22 @@ pub const DEFAULT_MOSTRO_PUBKEY: &str =
 
 /// Default Mostro daemon display name.
 pub const DEFAULT_MOSTRO_NAME: &str = "Mostro";
+
+// ── Runtime pubkey override ──────────────────────────────────────────────────
+
+static ACTIVE_MOSTRO_PUBKEY: RwLock<Option<String>> = RwLock::new(None);
+
+/// Returns the active Mostro pubkey — either the user-selected override or
+/// the compiled-in default.
+pub fn active_mostro_pubkey() -> String {
+    ACTIVE_MOSTRO_PUBKEY
+        .read()
+        .unwrap()
+        .clone()
+        .unwrap_or_else(|| DEFAULT_MOSTRO_PUBKEY.to_string())
+}
+
+/// Set (or clear) the active Mostro pubkey override.
+pub fn set_active_mostro_pubkey(pubkey: Option<String>) {
+    *ACTIVE_MOSTRO_PUBKEY.write().unwrap() = pubkey;
+}

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -26,6 +26,7 @@
 // Section: imports
 
 use crate::api::disputes::*;
+use crate::api::logging::*;
 use crate::api::messages::*;
 use crate::api::nostr::*;
 use crate::api::nwc::*;
@@ -44,7 +45,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1150097857;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -327029727;
 
 // Section: executor
 
@@ -218,6 +219,63 @@ fn wire__crate__api__disputes__DisputeStream_next_impl(
                         let mut api_that_guard = api_that_guard.unwrap();
                         let output_ok =
                             crate::api::disputes::DisputeStream::next(&mut *api_that_guard).await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__logging__LogEntryStream_next_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "LogEntryStream_next",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<LogEntryStream>,
+            >>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, ()>(
+                    (move || async move {
+                        let mut api_that_guard = None;
+                        let decode_indices_ =
+                            flutter_rust_bridge::for_generated::lockable_compute_decode_order(
+                                vec![flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                    &api_that, 0, true,
+                                )],
+                            );
+                        for i in decode_indices_ {
+                            match i {
+                                0 => {
+                                    api_that_guard =
+                                        Some(api_that.lockable_decode_async_ref_mut().await)
+                                }
+                                _ => unreachable!(),
+                            }
+                        }
+                        let mut api_that_guard = api_that_guard.unwrap();
+                        let output_ok = Result::<_, ()>::Ok(
+                            crate::api::logging::LogEntryStream::next(&mut *api_that_guard).await,
+                        )?;
                         Ok(output_ok)
                     })()
                     .await,
@@ -1674,6 +1732,38 @@ fn wire__crate__api__messages__get_messages_impl(
         },
     )
 }
+fn wire__crate__api__settings__get_mostro_pubkey_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "get_mostro_pubkey",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, ()>((move || {
+                    let output_ok = Result::<_, ()>::Ok(crate::api::settings::get_mostro_pubkey())?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__identity__get_nym_identity_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -2369,6 +2459,40 @@ fn wire__crate__api__nostr__initialize_impl(
         },
     )
 }
+fn wire__crate__api__logging__install_log_bridge_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "install_log_bridge",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, ()>((move || {
+                    let output_ok = Result::<_, ()>::Ok({
+                        crate::api::logging::install_log_bridge();
+                    })?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__orders__list_trades_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -2628,6 +2752,38 @@ fn wire__crate__api__disputes__on_dispute_updated_impl(
                     })()
                     .await,
                 )
+            }
+        },
+    )
+}
+fn wire__crate__api__logging__on_log_entry_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "on_log_entry",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, ()>((move || {
+                    let output_ok = Result::<_, ()>::Ok(crate::api::logging::on_log_entry())?;
+                    Ok(output_ok)
+                })())
             }
         },
     )
@@ -3402,6 +3558,41 @@ fn wire__crate__api__settings__set_logging_enabled_impl(
         },
     )
 }
+fn wire__crate__api__settings__set_mostro_pubkey_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "set_mostro_pubkey",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_pubkey = <Option<String>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || {
+                        let output_ok = crate::api::settings::set_mostro_pubkey(api_pubkey)?;
+                        Ok(output_ok)
+                    })(),
+                )
+            }
+        },
+    )
+}
 fn wire__crate__api__reputation__set_privacy_mode_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -3639,6 +3830,9 @@ flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
     flutter_rust_bridge::for_generated::RustAutoOpaqueInner<DisputeStream>
 );
 flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
+    flutter_rust_bridge::for_generated::RustAutoOpaqueInner<LogEntryStream>
+);
+flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
     flutter_rust_bridge::for_generated::RustAutoOpaqueInner<MessageStream>
 );
 flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
@@ -3698,6 +3892,16 @@ impl SseDecode for DisputeStream {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut inner = <RustOpaqueMoi<
             flutter_rust_bridge::for_generated::RustAutoOpaqueInner<DisputeStream>,
+        >>::sse_decode(deserializer);
+        return flutter_rust_bridge::for_generated::rust_auto_opaque_decode_owned(inner);
+    }
+}
+
+impl SseDecode for LogEntryStream {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <RustOpaqueMoi<
+            flutter_rust_bridge::for_generated::RustAutoOpaqueInner<LogEntryStream>,
         >>::sse_decode(deserializer);
         return flutter_rust_bridge::for_generated::rust_auto_opaque_decode_owned(inner);
     }
@@ -3809,6 +4013,16 @@ impl SseDecode
 
 impl SseDecode
     for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<DisputeStream>>
+{
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <usize>::sse_decode(deserializer);
+        return decode_rust_opaque_moi(inner);
+    }
+}
+
+impl SseDecode
+    for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<LogEntryStream>>
 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -4256,6 +4470,38 @@ impl SseDecode for Vec<crate::api::types::TradeInfo> {
     }
 }
 
+impl SseDecode for crate::api::types::LogEntry {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_id = <u32>::sse_decode(deserializer);
+        let mut var_level = <crate::api::types::LogLevel>::sse_decode(deserializer);
+        let mut var_tag = <String>::sse_decode(deserializer);
+        let mut var_message = <String>::sse_decode(deserializer);
+        let mut var_timestamp = <i64>::sse_decode(deserializer);
+        return crate::api::types::LogEntry {
+            id: var_id,
+            level: var_level,
+            tag: var_tag,
+            message: var_message,
+            timestamp: var_timestamp,
+        };
+    }
+}
+
+impl SseDecode for crate::api::types::LogLevel {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <i32>::sse_decode(deserializer);
+        return match inner {
+            0 => crate::api::types::LogLevel::Debug,
+            1 => crate::api::types::LogLevel::Info,
+            2 => crate::api::types::LogLevel::Warning,
+            3 => crate::api::types::LogLevel::Error,
+            _ => unreachable!("Invalid variant for LogLevel: {}", inner),
+        };
+    }
+}
+
 impl SseDecode for crate::api::types::MessageType {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -4452,6 +4698,17 @@ impl SseDecode for Option<crate::api::types::IdentityInfo> {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         if (<bool>::sse_decode(deserializer)) {
             return Some(<crate::api::types::IdentityInfo>::sse_decode(deserializer));
+        } else {
+            return None;
+        }
+    }
+}
+
+impl SseDecode for Option<crate::api::types::LogEntry> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<crate::api::types::LogEntry>::sse_decode(deserializer));
         } else {
             return None;
         }
@@ -4987,200 +5244,205 @@ fn pde_ffi_dispatcher_primary_impl(
             data_len,
         ),
         3 => wire__crate__api__disputes__DisputeStream_next_impl(port, ptr, rust_vec_len, data_len),
-        4 => wire__crate__api__messages__MessageStream_next_impl(port, ptr, rust_vec_len, data_len),
-        5 => wire__crate__api__orders__OrderBook_default_impl(port, ptr, rust_vec_len, data_len),
-        6 => wire__crate__api__orders__OrderBook_get_order_impl(port, ptr, rust_vec_len, data_len),
-        7 => wire__crate__api__orders__OrderBook_get_orders_impl(port, ptr, rust_vec_len, data_len),
-        8 => wire__crate__api__orders__OrderBook_new_impl(port, ptr, rust_vec_len, data_len),
-        9 => {
+        4 => wire__crate__api__logging__LogEntryStream_next_impl(port, ptr, rust_vec_len, data_len),
+        5 => wire__crate__api__messages__MessageStream_next_impl(port, ptr, rust_vec_len, data_len),
+        6 => wire__crate__api__orders__OrderBook_default_impl(port, ptr, rust_vec_len, data_len),
+        7 => wire__crate__api__orders__OrderBook_get_order_impl(port, ptr, rust_vec_len, data_len),
+        8 => wire__crate__api__orders__OrderBook_get_orders_impl(port, ptr, rust_vec_len, data_len),
+        9 => wire__crate__api__orders__OrderBook_new_impl(port, ptr, rust_vec_len, data_len),
+        10 => {
             wire__crate__api__orders__OrderBook_remove_order_impl(port, ptr, rust_vec_len, data_len)
         }
-        10 => {
+        11 => {
             wire__crate__api__orders__OrderBook_set_orders_impl(port, ptr, rust_vec_len, data_len)
         }
-        11 => {
+        12 => {
             wire__crate__api__orders__OrderBook_upsert_order_impl(port, ptr, rust_vec_len, data_len)
         }
-        12 => wire__crate__api__orders__OrdersStream_next_impl(port, ptr, rust_vec_len, data_len),
-        13 => {
+        13 => wire__crate__api__orders__OrdersStream_next_impl(port, ptr, rust_vec_len, data_len),
+        14 => {
             wire__crate__api__reputation__RatingStream_next_impl(port, ptr, rust_vec_len, data_len)
         }
-        14 => {
+        15 => {
             wire__crate__api__nostr__RelayStatusStream_next_impl(port, ptr, rust_vec_len, data_len)
         }
-        15 => {
+        16 => {
             wire__crate__api__settings__SettingsStream_next_impl(port, ptr, rust_vec_len, data_len)
         }
-        16 => wire__crate__api__messages__UnreadCountStream_next_impl(
+        17 => wire__crate__api__messages__UnreadCountStream_next_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        17 => {
+        18 => {
             wire__crate__api__nwc__WalletStatusStream_next_impl(port, ptr, rust_vec_len, data_len)
         }
-        18 => wire__crate__api__nostr__add_relay_impl(port, ptr, rust_vec_len, data_len),
-        19 => wire__crate__api__orders__cancel_order_impl(port, ptr, rust_vec_len, data_len),
-        20 => wire__crate__api__nwc__connect_wallet_impl(port, ptr, rust_vec_len, data_len),
-        21 => wire__crate__api__identity__create_identity_impl(port, ptr, rust_vec_len, data_len),
-        22 => wire__crate__api__orders__create_order_impl(port, ptr, rust_vec_len, data_len),
-        23 => wire__crate__api__identity__delete_identity_impl(port, ptr, rust_vec_len, data_len),
-        24 => wire__crate__api__identity__derive_trade_key_impl(port, ptr, rust_vec_len, data_len),
-        25 => wire__crate__api__nwc__disconnect_wallet_impl(port, ptr, rust_vec_len, data_len),
-        26 => {
+        19 => wire__crate__api__nostr__add_relay_impl(port, ptr, rust_vec_len, data_len),
+        20 => wire__crate__api__orders__cancel_order_impl(port, ptr, rust_vec_len, data_len),
+        21 => wire__crate__api__nwc__connect_wallet_impl(port, ptr, rust_vec_len, data_len),
+        22 => wire__crate__api__identity__create_identity_impl(port, ptr, rust_vec_len, data_len),
+        23 => wire__crate__api__orders__create_order_impl(port, ptr, rust_vec_len, data_len),
+        24 => wire__crate__api__identity__delete_identity_impl(port, ptr, rust_vec_len, data_len),
+        25 => wire__crate__api__identity__derive_trade_key_impl(port, ptr, rust_vec_len, data_len),
+        26 => wire__crate__api__nwc__disconnect_wallet_impl(port, ptr, rust_vec_len, data_len),
+        27 => {
             wire__crate__api__messages__download_attachment_impl(port, ptr, rust_vec_len, data_len)
         }
-        27 => wire__crate__api__identity__export_encrypted_backup_impl(
+        28 => wire__crate__api__identity__export_encrypted_backup_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        28 => wire__crate__api__nostr__fetch_mostro_instance_tags_impl(
+        29 => wire__crate__api__nostr__fetch_mostro_instance_tags_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        29 => wire__crate__api__nostr__flush_message_queue_impl(port, ptr, rust_vec_len, data_len),
-        30 => wire__crate__api__get_app_version_impl(port, ptr, rust_vec_len, data_len),
-        31 => wire__crate__api__messages__get_attachment_status_impl(
+        30 => wire__crate__api__nostr__flush_message_queue_impl(port, ptr, rust_vec_len, data_len),
+        31 => wire__crate__api__get_app_version_impl(port, ptr, rust_vec_len, data_len),
+        32 => wire__crate__api__messages__get_attachment_status_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        32 => wire__crate__api__nwc__get_balance_impl(port, ptr, rust_vec_len, data_len),
-        33 => wire__crate__api__nostr__get_connection_state_impl(port, ptr, rust_vec_len, data_len),
-        34 => wire__crate__api__disputes__get_dispute_impl(port, ptr, rust_vec_len, data_len),
-        35 => wire__crate__api__identity__get_identity_impl(port, ptr, rust_vec_len, data_len),
-        36 => wire__crate__api__messages__get_messages_impl(port, ptr, rust_vec_len, data_len),
-        37 => wire__crate__api__identity__get_nym_identity_impl(port, ptr, rust_vec_len, data_len),
-        38 => wire__crate__api__orders__get_order_impl(port, ptr, rust_vec_len, data_len),
-        39 => wire__crate__api__orders__get_orders_impl(port, ptr, rust_vec_len, data_len),
-        40 => {
+        33 => wire__crate__api__nwc__get_balance_impl(port, ptr, rust_vec_len, data_len),
+        34 => wire__crate__api__nostr__get_connection_state_impl(port, ptr, rust_vec_len, data_len),
+        35 => wire__crate__api__disputes__get_dispute_impl(port, ptr, rust_vec_len, data_len),
+        36 => wire__crate__api__identity__get_identity_impl(port, ptr, rust_vec_len, data_len),
+        37 => wire__crate__api__messages__get_messages_impl(port, ptr, rust_vec_len, data_len),
+        38 => wire__crate__api__settings__get_mostro_pubkey_impl(port, ptr, rust_vec_len, data_len),
+        39 => wire__crate__api__identity__get_nym_identity_impl(port, ptr, rust_vec_len, data_len),
+        40 => wire__crate__api__orders__get_order_impl(port, ptr, rust_vec_len, data_len),
+        41 => wire__crate__api__orders__get_orders_impl(port, ptr, rust_vec_len, data_len),
+        42 => {
             wire__crate__api__reputation__get_privacy_mode_impl(port, ptr, rust_vec_len, data_len)
         }
-        41 => wire__crate__api__reputation__get_rating_for_trade_impl(
+        43 => wire__crate__api__reputation__get_rating_for_trade_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        42 => wire__crate__api__nostr__get_relays_impl(port, ptr, rust_vec_len, data_len),
-        43 => wire__crate__api__settings__get_settings_impl(port, ptr, rust_vec_len, data_len),
-        44 => wire__crate__api__identity__get_trade_key_impl(port, ptr, rust_vec_len, data_len),
-        45 => wire__crate__api__orders__get_trade_role_impl(port, ptr, rust_vec_len, data_len),
-        46 => wire__crate__api__messages__get_unread_count_impl(port, ptr, rust_vec_len, data_len),
-        47 => wire__crate__api__nwc__get_wallet_impl(port, ptr, rust_vec_len, data_len),
-        48 => wire__crate__api__disputes__handle_admin_canceled_impl(
+        44 => wire__crate__api__nostr__get_relays_impl(port, ptr, rust_vec_len, data_len),
+        45 => wire__crate__api__settings__get_settings_impl(port, ptr, rust_vec_len, data_len),
+        46 => wire__crate__api__identity__get_trade_key_impl(port, ptr, rust_vec_len, data_len),
+        47 => wire__crate__api__orders__get_trade_role_impl(port, ptr, rust_vec_len, data_len),
+        48 => wire__crate__api__messages__get_unread_count_impl(port, ptr, rust_vec_len, data_len),
+        49 => wire__crate__api__nwc__get_wallet_impl(port, ptr, rust_vec_len, data_len),
+        50 => wire__crate__api__disputes__handle_admin_canceled_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        49 => {
+        51 => {
             wire__crate__api__disputes__handle_admin_settled_impl(port, ptr, rust_vec_len, data_len)
         }
-        50 => wire__crate__api__disputes__handle_admin_took_dispute_impl(
+        52 => wire__crate__api__disputes__handle_admin_took_dispute_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        51 => wire__crate__api__reputation__handle_rating_received_impl(
+        53 => wire__crate__api__reputation__handle_rating_received_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        52 => {
+        54 => {
             wire__crate__api__identity__import_from_mnemonic_impl(port, ptr, rust_vec_len, data_len)
         }
-        53 => wire__crate__api__identity__import_from_nsec_impl(port, ptr, rust_vec_len, data_len),
-        54 => wire__crate__api__init_db_impl(port, ptr, rust_vec_len, data_len),
-        55 => wire__crate__api__nostr__initialize_impl(port, ptr, rust_vec_len, data_len),
-        56 => wire__crate__api__orders__list_trades_impl(port, ptr, rust_vec_len, data_len),
-        57 => wire__crate__api__identity__load_identity_from_mnemonic_impl(
+        55 => wire__crate__api__identity__import_from_nsec_impl(port, ptr, rust_vec_len, data_len),
+        56 => wire__crate__api__init_db_impl(port, ptr, rust_vec_len, data_len),
+        57 => wire__crate__api__nostr__initialize_impl(port, ptr, rust_vec_len, data_len),
+        58 => wire__crate__api__logging__install_log_bridge_impl(port, ptr, rust_vec_len, data_len),
+        59 => wire__crate__api__orders__list_trades_impl(port, ptr, rust_vec_len, data_len),
+        60 => wire__crate__api__identity__load_identity_from_mnemonic_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        58 => wire__crate__api__nwc__make_invoice_impl(port, ptr, rust_vec_len, data_len),
-        59 => wire__crate__api__messages__mark_as_read_impl(port, ptr, rust_vec_len, data_len),
-        60 => wire__crate__api__messages__on_attachment_progress_impl(
+        61 => wire__crate__api__nwc__make_invoice_impl(port, ptr, rust_vec_len, data_len),
+        62 => wire__crate__api__messages__mark_as_read_impl(port, ptr, rust_vec_len, data_len),
+        63 => wire__crate__api__messages__on_attachment_progress_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        61 => wire__crate__api__nostr__on_connection_state_changed_impl(
+        64 => wire__crate__api__nostr__on_connection_state_changed_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        62 => {
+        65 => {
             wire__crate__api__disputes__on_dispute_updated_impl(port, ptr, rust_vec_len, data_len)
         }
-        63 => wire__crate__api__messages__on_new_message_impl(port, ptr, rust_vec_len, data_len),
-        64 => wire__crate__api__orders__on_orders_updated_impl(port, ptr, rust_vec_len, data_len),
-        65 => {
+        66 => wire__crate__api__logging__on_log_entry_impl(port, ptr, rust_vec_len, data_len),
+        67 => wire__crate__api__messages__on_new_message_impl(port, ptr, rust_vec_len, data_len),
+        68 => wire__crate__api__orders__on_orders_updated_impl(port, ptr, rust_vec_len, data_len),
+        69 => {
             wire__crate__api__reputation__on_rating_received_impl(port, ptr, rust_vec_len, data_len)
         }
-        66 => {
+        70 => {
             wire__crate__api__nostr__on_relay_status_changed_impl(port, ptr, rust_vec_len, data_len)
         }
-        67 => {
+        71 => {
             wire__crate__api__settings__on_settings_changed_impl(port, ptr, rust_vec_len, data_len)
         }
-        68 => wire__crate__api__messages__on_unread_count_changed_impl(
+        72 => wire__crate__api__messages__on_unread_count_changed_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        69 => {
+        73 => {
             wire__crate__api__nwc__on_wallet_status_changed_impl(port, ptr, rust_vec_len, data_len)
         }
-        70 => wire__crate__api__disputes__open_dispute_impl(port, ptr, rust_vec_len, data_len),
-        71 => {
+        74 => wire__crate__api__disputes__open_dispute_impl(port, ptr, rust_vec_len, data_len),
+        75 => {
             wire__crate__api__orders__order_filters_default_impl(port, ptr, rust_vec_len, data_len)
         }
-        72 => wire__crate__api__nwc__pay_invoice_impl(port, ptr, rust_vec_len, data_len),
-        73 => wire__crate__api__orders__release_order_impl(port, ptr, rust_vec_len, data_len),
-        74 => wire__crate__api__nostr__remove_relay_impl(port, ptr, rust_vec_len, data_len),
-        75 => wire__crate__api__orders__resolve_maker_order_impl(port, ptr, rust_vec_len, data_len),
-        76 => wire__crate__api__orders__send_fiat_sent_impl(port, ptr, rust_vec_len, data_len),
-        77 => wire__crate__api__messages__send_file_impl(port, ptr, rust_vec_len, data_len),
-        78 => wire__crate__api__orders__send_invoice_impl(port, ptr, rust_vec_len, data_len),
-        79 => wire__crate__api__messages__send_message_impl(port, ptr, rust_vec_len, data_len),
-        80 => wire__crate__api__settings__set_default_fiat_code_impl(
+        76 => wire__crate__api__nwc__pay_invoice_impl(port, ptr, rust_vec_len, data_len),
+        77 => wire__crate__api__orders__release_order_impl(port, ptr, rust_vec_len, data_len),
+        78 => wire__crate__api__nostr__remove_relay_impl(port, ptr, rust_vec_len, data_len),
+        79 => wire__crate__api__orders__resolve_maker_order_impl(port, ptr, rust_vec_len, data_len),
+        80 => wire__crate__api__orders__send_fiat_sent_impl(port, ptr, rust_vec_len, data_len),
+        81 => wire__crate__api__messages__send_file_impl(port, ptr, rust_vec_len, data_len),
+        82 => wire__crate__api__orders__send_invoice_impl(port, ptr, rust_vec_len, data_len),
+        83 => wire__crate__api__messages__send_message_impl(port, ptr, rust_vec_len, data_len),
+        84 => wire__crate__api__settings__set_default_fiat_code_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        81 => wire__crate__api__settings__set_default_lightning_address_impl(
+        85 => wire__crate__api__settings__set_default_lightning_address_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        82 => wire__crate__api__settings__set_language_impl(port, ptr, rust_vec_len, data_len),
-        83 => {
+        86 => wire__crate__api__settings__set_language_impl(port, ptr, rust_vec_len, data_len),
+        87 => {
             wire__crate__api__settings__set_logging_enabled_impl(port, ptr, rust_vec_len, data_len)
         }
-        84 => {
+        88 => wire__crate__api__settings__set_mostro_pubkey_impl(port, ptr, rust_vec_len, data_len),
+        89 => {
             wire__crate__api__reputation__set_privacy_mode_impl(port, ptr, rust_vec_len, data_len)
         }
-        85 => wire__crate__api__settings__set_theme_impl(port, ptr, rust_vec_len, data_len),
-        86 => wire__crate__api__disputes__submit_evidence_impl(port, ptr, rust_vec_len, data_len),
-        87 => wire__crate__api__reputation__submit_rating_impl(port, ptr, rust_vec_len, data_len),
-        88 => wire__crate__api__orders__subscribe_orders_impl(port, ptr, rust_vec_len, data_len),
-        89 => wire__crate__api__orders__take_order_impl(port, ptr, rust_vec_len, data_len),
+        90 => wire__crate__api__settings__set_theme_impl(port, ptr, rust_vec_len, data_len),
+        91 => wire__crate__api__disputes__submit_evidence_impl(port, ptr, rust_vec_len, data_len),
+        92 => wire__crate__api__reputation__submit_rating_impl(port, ptr, rust_vec_len, data_len),
+        93 => wire__crate__api__orders__subscribe_orders_impl(port, ptr, rust_vec_len, data_len),
+        94 => wire__crate__api__orders__take_order_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -5250,6 +5512,21 @@ impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for FrbWrapper<
 
 impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<DisputeStream>> for DisputeStream {
     fn into_into_dart(self) -> FrbWrapper<DisputeStream> {
+        self.into()
+    }
+}
+
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<LogEntryStream> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        flutter_rust_bridge::for_generated::rust_auto_opaque_encode::<_, MoiArc<_>>(self.0)
+            .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for FrbWrapper<LogEntryStream> {}
+
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<LogEntryStream>> for LogEntryStream {
+    fn into_into_dart(self) -> FrbWrapper<LogEntryStream> {
         self.into()
     }
 }
@@ -5697,6 +5974,47 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::types::IdentityInfo>
     for crate::api::types::IdentityInfo
 {
     fn into_into_dart(self) -> crate::api::types::IdentityInfo {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::types::LogEntry {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.id.into_into_dart().into_dart(),
+            self.level.into_into_dart().into_dart(),
+            self.tag.into_into_dart().into_dart(),
+            self.message.into_into_dart().into_dart(),
+            self.timestamp.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for crate::api::types::LogEntry {}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::types::LogEntry>
+    for crate::api::types::LogEntry
+{
+    fn into_into_dart(self) -> crate::api::types::LogEntry {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::types::LogLevel {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        match self {
+            Self::Debug => 0.into_dart(),
+            Self::Info => 1.into_dart(),
+            Self::Warning => 2.into_dart(),
+            Self::Error => 3.into_dart(),
+            _ => unreachable!(),
+        }
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for crate::api::types::LogLevel {}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::types::LogLevel>
+    for crate::api::types::LogLevel
+{
+    fn into_into_dart(self) -> crate::api::types::LogLevel {
         self
     }
 }
@@ -6253,6 +6571,13 @@ impl SseEncode for DisputeStream {
     }
 }
 
+impl SseEncode for LogEntryStream {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<LogEntryStream>>>::sse_encode(flutter_rust_bridge::for_generated::rust_auto_opaque_encode::<_, MoiArc<_>>(self), serializer);
+    }
+}
+
 impl SseEncode for MessageStream {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -6337,6 +6662,17 @@ impl SseEncode
 
 impl SseEncode
     for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<DisputeStream>>
+{
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        let (ptr, size) = self.sse_encode_raw();
+        <usize>::sse_encode(ptr, serializer);
+        <i32>::sse_encode(size, serializer);
+    }
+}
+
+impl SseEncode
+    for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<LogEntryStream>>
 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -6747,6 +7083,35 @@ impl SseEncode for Vec<crate::api::types::TradeInfo> {
     }
 }
 
+impl SseEncode for crate::api::types::LogEntry {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u32>::sse_encode(self.id, serializer);
+        <crate::api::types::LogLevel>::sse_encode(self.level, serializer);
+        <String>::sse_encode(self.tag, serializer);
+        <String>::sse_encode(self.message, serializer);
+        <i64>::sse_encode(self.timestamp, serializer);
+    }
+}
+
+impl SseEncode for crate::api::types::LogLevel {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(
+            match self {
+                crate::api::types::LogLevel::Debug => 0,
+                crate::api::types::LogLevel::Info => 1,
+                crate::api::types::LogLevel::Warning => 2,
+                crate::api::types::LogLevel::Error => 3,
+                _ => {
+                    unimplemented!("");
+                }
+            },
+            serializer,
+        );
+    }
+}
+
 impl SseEncode for crate::api::types::MessageType {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -6905,6 +7270,16 @@ impl SseEncode for Option<crate::api::types::IdentityInfo> {
         <bool>::sse_encode(self.is_some(), serializer);
         if let Some(value) = self {
             <crate::api::types::IdentityInfo>::sse_encode(value, serializer);
+        }
+    }
+}
+
+impl SseEncode for Option<crate::api::types::LogEntry> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <crate::api::types::LogEntry>::sse_encode(value, serializer);
         }
     }
 }
@@ -7384,6 +7759,7 @@ mod io {
 
     use super::*;
     use crate::api::disputes::*;
+    use crate::api::logging::*;
     use crate::api::messages::*;
     use crate::api::nostr::*;
     use crate::api::nwc::*;
@@ -7440,6 +7816,20 @@ mod io {
         ptr: *const std::ffi::c_void,
     ) {
         MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<DisputeStream>>::decrement_strong_count(ptr as _);
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_mostro_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLogEntryStream(
+        ptr: *const std::ffi::c_void,
+    ) {
+        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<LogEntryStream>>::increment_strong_count(ptr as _);
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_mostro_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLogEntryStream(
+        ptr: *const std::ffi::c_void,
+    ) {
+        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<LogEntryStream>>::decrement_strong_count(ptr as _);
     }
 
     #[unsafe(no_mangle)]
@@ -7567,6 +7957,7 @@ mod web {
 
     use super::*;
     use crate::api::disputes::*;
+    use crate::api::logging::*;
     use crate::api::messages::*;
     use crate::api::nostr::*;
     use crate::api::nwc::*;
@@ -7625,6 +8016,20 @@ mod web {
         ptr: *const std::ffi::c_void,
     ) {
         MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<DisputeStream>>::decrement_strong_count(ptr as _);
+    }
+
+    #[wasm_bindgen]
+    pub fn rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLogEntryStream(
+        ptr: *const std::ffi::c_void,
+    ) {
+        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<LogEntryStream>>::increment_strong_count(ptr as _);
+    }
+
+    #[wasm_bindgen]
+    pub fn rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLogEntryStream(
+        ptr: *const std::ffi::c_void,
+    ) {
+        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<LogEntryStream>>::decrement_strong_count(ptr as _);
     }
 
     #[wasm_bindgen]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -14,7 +14,8 @@ pub mod nwc;
 pub mod queue;
 
 /// Called once by Flutter during `RustLib.init()` — sets up logging so Rust
-/// messages appear in `adb logcat` under the tag `mostro_rust`.
+/// messages appear in `adb logcat` under the tag `mostro_rust` and are
+/// forwarded to the Flutter log stream.
 #[flutter_rust_bridge::frb(init)]
 pub fn init_app() {
     #[cfg(target_os = "android")]
@@ -23,6 +24,11 @@ pub fn init_app() {
             .with_max_level(log::LevelFilter::Debug)
             .with_tag("mostro_rust"),
     );
+
+    // Install the log bridge so every log::info!/warn!/error! is forwarded
+    // to the Flutter on_log_entry() stream.
+    api::logging::install_log_bridge();
+
     log::info!("[init] Rust core initialized");
 }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -14,19 +14,13 @@ pub mod nwc;
 pub mod queue;
 
 /// Called once by Flutter during `RustLib.init()` — sets up logging so Rust
-/// messages appear in `adb logcat` under the tag `mostro_rust` and are
-/// forwarded to the Flutter log stream.
+/// messages appear in `adb logcat` / stderr and are forwarded to the Flutter
+/// log stream via `BridgeLogger`.
 #[flutter_rust_bridge::frb(init)]
 pub fn init_app() {
-    #[cfg(target_os = "android")]
-    android_logger::init_once(
-        android_logger::Config::default()
-            .with_max_level(log::LevelFilter::Debug)
-            .with_tag("mostro_rust"),
-    );
-
     // Install the log bridge so every log::info!/warn!/error! is forwarded
-    // to the Flutter on_log_entry() stream.
+    // to the Flutter on_log_entry() stream AND printed to stderr (logcat on
+    // Android).  Must be called before any other log::set_logger() call.
     api::logging::install_log_bridge();
 
     log::info!("[init] Rust core initialized");

--- a/rust/src/nostr/relay_pool.rs
+++ b/rust/src/nostr/relay_pool.rs
@@ -154,8 +154,8 @@ impl RelayPool {
         &self,
         trade_keys: Vec<(PublicKey, u32)>,
     ) -> Result<()> {
-        let mostro_pubkey = nostr_sdk::PublicKey::from_hex(crate::config::DEFAULT_MOSTRO_PUBKEY)
-            .map_err(|e| anyhow!("invalid DEFAULT_MOSTRO_PUBKEY: {e}"))?;
+        let mostro_pubkey = nostr_sdk::PublicKey::from_hex(&crate::config::active_mostro_pubkey())
+            .map_err(|e| anyhow!("invalid mostro pubkey: {e}"))?;
         let order_filter = pending_orders_filter(&mostro_pubkey);
         self.client
             .subscribe(order_filter, None)


### PR DESCRIPTION
…e stubs to Rust bridge

- Wire relay toggle persistence via addRelay/removeRelay with optimistic UI and safe rollback by URL lookup
- Add runtime mostro pubkey override (config.rs + settings API) and update all order/reputation/dispute/relay code to use active_mostro_pubkey()
- Wire MostroNodeSelector to call setMostroPubkey on confirm/reset
- Add rust/src/api/logging.rs with install_log_bridge, forward_log, and on_log_entry stream; create logEntriesProvider and replace mock entries in LogReportScreen with live Rust log stream
- Replace TODO stubs in DisputeChatScreen with Phase 12 context comments
- Regenerate flutter_rust_bridge bindings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live app log stream: in-app viewing and sharing of real-time log entries; logs are forwarded from the native layer to the app.
  * Mostro node selection persists and is synced with native settings; runtime override for the Mostro public key exposed in settings.

* **Bug Fixes**
  * Relay activation/deactivation now syncs with the backend, restores UI on failure, and shows localized error snackbars.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->