### PR TITLE
feat(messages): implement Blossom upload/download with Kind-24242 auth 

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2325,6 +2325,7 @@ version = "0.1.0"
 dependencies = [
  "android_logger 0.14.1",
  "anyhow",
+ "base64",
  "bip32",
  "bip39",
  "chacha20poly1305",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -28,6 +28,9 @@ hex = "0.4"
 # Logging
 log = "0.4"
 
+# Base64 encoding (Blossom auth events)
+base64 = "0.22"
+
 # File attachment encryption (ChaCha20-Poly1305)
 chacha20poly1305 = "0.10"
 rand = { version = "0.8", features = ["getrandom"] }

--- a/rust/src/api/messages.rs
+++ b/rust/src/api/messages.rs
@@ -250,30 +250,99 @@ pub async fn send_file(
         bail!("UnsupportedFileType: {mime_type}");
     }
 
-    // TODO(Phase 10+): Derive ECDH shared key from session, encrypt file,
-    // upload encrypted bytes to Blossom via blossom::upload_blob, then
-    // publish NIP-59 gift-wrapped message with Blossom URL + metadata.
-    //
-    // For now, construct the message with a placeholder URL.
+    // 1. Get the shared key from session (derive it fresh if not yet cached).
+    let shared_key: [u8; 32] = {
+        let session = crate::mostro::session::session_manager()
+            .get_session(&trade_id)
+            .await
+            .ok_or_else(|| anyhow!("SessionNotFound: {trade_id}"))?;
+
+        if let Some(k) = session.shared_key {
+            k
+        } else {
+            let sender_keys = crate::api::identity::get_active_trade_keys(
+                session.trade_key_index,
+            )
+            .await?;
+            let peer_hex = session
+                .peer_pubkey
+                .as_deref()
+                .ok_or_else(|| anyhow!("PeerUnknown: cannot encrypt attachment without peer pubkey"))?;
+            let peer_pubkey = nostr_sdk::PublicKey::from_hex(peer_hex)
+                .map_err(|e| anyhow!("invalid peer pubkey: {e}"))?;
+            crate::crypto::ecdh::derive_nip04_shared_key(&sender_keys, &peer_pubkey)?
+        }
+    };
+
+    // 2. Encrypt the file bytes.
+    let encrypted_bytes = crate::crypto::file_enc::encrypt_file(&file_bytes, &shared_key)
+        .map_err(|e| anyhow!("FileEncryptionFailed: {e}"))?;
+
+    // 3. Upload encrypted blob to Blossom.
     let file_type = mime_to_file_type(&mime_type);
     let file_size = file_bytes.len() as u64;
+    let msg_id = uuid::Uuid::new_v4().to_string();
+    let _ = message_store().attachment_tx.send((msg_id.clone(), 0.1));
+
+    let blossom_url = blossom::upload_blob(encrypted_bytes, mime_type.clone(), None)
+        .await
+        .map_err(|e| anyhow!("UploadFailed: {e}"))?;
+
+    let _ = message_store().attachment_tx.send((msg_id.clone(), 1.0));
+
+    // 4. Build attachment metadata and publish via NIP-59 gift wrap.
+    let payload = serde_json::json!({
+        "url": blossom_url,
+        "name": file_name,
+        "mime_type": mime_type,
+        "size": file_size,
+        "type": "file",
+    })
+    .to_string();
+
+    let session = crate::mostro::session::session_manager()
+        .get_session(&trade_id)
+        .await
+        .ok_or_else(|| anyhow!("SessionNotFound: {trade_id}"))?;
+
+    let sender_keys =
+        crate::api::identity::get_active_trade_keys(session.trade_key_index).await?;
+    let sender_pubkey = sender_keys.public_key().to_hex();
+
+    if let Some(peer_hex) = &session.peer_pubkey {
+        if let Ok(peer_pubkey) = nostr_sdk::PublicKey::from_hex(peer_hex) {
+            if let Ok(event_json) = crate::nostr::gift_wrap::wrap(
+                &sender_keys,
+                &peer_pubkey,
+                &payload,
+                nostr_sdk::Kind::from(14u16),
+            )
+            .await
+            {
+                if let Ok(pool) = crate::api::nostr::get_pool() {
+                    if let Ok(event) = serde_json::from_str::<nostr_sdk::Event>(&event_json) {
+                        let _ = pool.client().send_event(&event).await;
+                    }
+                }
+            }
+        }
+    }
 
     let attachment = AttachmentInfo {
         file_name: file_name.clone(),
         mime_type: mime_type.clone(),
         file_size,
         file_type,
-        download_status: DownloadStatus::Pending,
+        download_status: DownloadStatus::Downloaded,
         local_path: None,
     };
 
     let now = unix_now();
-    let msg_id = uuid::Uuid::new_v4().to_string();
     let msg = ChatMessage {
         id: msg_id.clone(),
         trade_id: trade_id.clone(),
-        sender_pubkey: String::new(),
-        content: file_name.clone(),
+        sender_pubkey,
+        content: blossom_url,
         message_type: MessageType::Peer,
         is_mine: true,
         is_read: true,
@@ -283,17 +352,6 @@ pub async fn send_file(
     };
 
     message_store().add_message(msg.clone()).await;
-
-    // Simulate upload progress
-    let tx = message_store().attachment_tx.clone();
-    let id = msg_id.clone();
-    tokio::spawn(async move {
-        for pct in [0.25, 0.5, 0.75, 1.0_f64] {
-            tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
-            let _ = tx.send((id.clone(), pct));
-        }
-    });
-
     Ok(msg)
 }
 
@@ -315,20 +373,68 @@ pub async fn download_attachment(message_id: String) -> Result<FileDownloadResul
         .attachment
         .ok_or_else(|| anyhow!("AttachmentNotFound: message has no attachment"))?;
 
-    // TODO(Phase 10+): Download encrypted bytes from Blossom URL, derive
-    // decryption key from session shared key, decrypt, write to temp dir.
-    //
-    // For now return a stub result.
+    // 1. Get Blossom URL from message content.
+    let blossom_url = msg.content.clone();
+    if blossom_url.is_empty()
+        || (!blossom_url.starts_with("http://") && !blossom_url.starts_with("https://"))
+    {
+        bail!("AttachmentNotFound: message has no valid Blossom URL in content");
+    }
+
+    // 2. Get the session shared key to decrypt.
+    let session = crate::mostro::session::session_manager()
+        .get_session(&msg.trade_id)
+        .await;
+
+    let shared_key: [u8; 32] = match session {
+        None => bail!("SessionNotFound: cannot decrypt attachment without session"),
+        Some(s) => {
+            if let Some(k) = s.shared_key {
+                k
+            } else {
+                let sender_keys =
+                    crate::api::identity::get_active_trade_keys(s.trade_key_index).await?;
+                let peer_hex = s
+                    .peer_pubkey
+                    .as_deref()
+                    .ok_or_else(|| anyhow!("PeerUnknown: cannot derive key without peer pubkey"))?;
+                let peer_pubkey = nostr_sdk::PublicKey::from_hex(peer_hex)
+                    .map_err(|e| anyhow!("invalid peer pubkey: {e}"))?;
+                crate::crypto::ecdh::derive_nip04_shared_key(&sender_keys, &peer_pubkey)?
+            }
+        }
+    };
+
+    // 3. Download encrypted blob from Blossom.
+    let _ = message_store()
+        .attachment_tx
+        .send((message_id.clone(), 0.1));
+    let encrypted_bytes = blossom::download_blob(blossom_url)
+        .await
+        .map_err(|e| anyhow!("DownloadFailed: {e}"))?;
+
+    // 4. Decrypt.
+    let plaintext = crate::crypto::file_enc::decrypt_file(&encrypted_bytes, &shared_key)
+        .map_err(|e| anyhow!("DecryptionFailed: {e}"))?;
+
+    // 5. Write to temp dir with safe filename.
     let safe_name = safe_filename(&attachment.file_name);
     let local_path = std::env::temp_dir()
         .join(&safe_name)
         .to_string_lossy()
         .into_owned();
+
+    std::fs::write(&local_path, &plaintext).map_err(|e| anyhow!("WriteFailed: {e}"))?;
+
+    let _ = message_store()
+        .attachment_tx
+        .send((message_id.clone(), 1.0));
+
     let result = FileDownloadResult {
-        local_path,
-        file_name: attachment.file_name,
-        mime_type: attachment.mime_type,
-        file_size: attachment.file_size,
+        local_path: local_path.clone(),
+        file_name: attachment.file_name.clone(),
+        mime_type: attachment.mime_type.clone(),
+        file_size: plaintext.len() as u64,
     };
 
     // Update the local message to reflect Downloaded status
@@ -559,6 +665,54 @@ mod tests {
         assert_eq!(safe_filename("normal.jpg"), "normal.jpg");
         assert_eq!(safe_filename(""), "attachment");
         assert_eq!(safe_filename("/"), "attachment");
+    }
+
+    #[tokio::test]
+    async fn send_file_fails_without_session() {
+        let trade_id = uuid::Uuid::new_v4().to_string();
+        let result = send_file(
+            trade_id,
+            vec![1, 2, 3],
+            "photo.jpg".to_string(),
+            "image/jpeg".to_string(),
+        )
+        .await;
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("SessionNotFound"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn download_attachment_fails_without_session() {
+        let trade_id = uuid::Uuid::new_v4().to_string();
+        let store = message_store();
+        let msg_id = uuid::Uuid::new_v4().to_string();
+        let fake_att = AttachmentInfo {
+            file_name: "file.jpg".to_string(),
+            mime_type: "image/jpeg".to_string(),
+            file_size: 100,
+            file_type: FileType::Image,
+            download_status: DownloadStatus::Pending,
+            local_path: None,
+        };
+        let msg = ChatMessage {
+            id: msg_id.clone(),
+            trade_id: trade_id.clone(),
+            sender_pubkey: "peer".to_string(),
+            content: "https://blossom.example.com/abc123".to_string(),
+            message_type: MessageType::Peer,
+            is_mine: false,
+            is_read: false,
+            has_attachment: true,
+            attachment: Some(fake_att),
+            created_at: unix_now(),
+        };
+        store.add_message(msg).await;
+
+        let result = download_attachment(msg_id).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("SessionNotFound"), "got: {err}");
     }
 
     #[test]

--- a/rust/src/api/messages.rs
+++ b/rust/src/api/messages.rs
@@ -310,8 +310,9 @@ pub async fn send_file(
     let sender_pubkey = sender_keys.public_key().to_hex();
 
     if let Some(peer_hex) = &session.peer_pubkey {
-        if let Ok(peer_pubkey) = nostr_sdk::PublicKey::from_hex(peer_hex) {
-            if let Ok(event_json) = crate::nostr::gift_wrap::wrap(
+        match nostr_sdk::PublicKey::from_hex(peer_hex) {
+            Err(e) => log::warn!("[messages] send_file invalid peer pubkey: {e}"),
+            Ok(peer_pubkey) => match crate::nostr::gift_wrap::wrap(
                 &sender_keys,
                 &peer_pubkey,
                 &payload,
@@ -319,13 +320,22 @@ pub async fn send_file(
             )
             .await
             {
-                if let Ok(pool) = crate::api::nostr::get_pool() {
-                    if let Ok(event) = serde_json::from_str::<nostr_sdk::Event>(&event_json) {
-                        let _ = pool.client().send_event(&event).await;
-                    }
-                }
-            }
+                Err(e) => log::warn!("[messages] send_file gift wrap failed: {e}"),
+                Ok(event_json) => match crate::api::nostr::get_pool() {
+                    Err(_) => log::warn!("[messages] send_file relay pool not ready"),
+                    Ok(pool) => match serde_json::from_str::<nostr_sdk::Event>(&event_json) {
+                        Err(e) => log::warn!("[messages] send_file event parse failed: {e}"),
+                        Ok(event) => {
+                            if let Err(e) = pool.client().send_event(&event).await {
+                                log::warn!("[messages] send_file publish failed: {e}");
+                            }
+                        }
+                    },
+                },
+            },
         }
+    } else {
+        log::warn!("[messages] send_file peer not yet known — local-only");
     }
 
     let attachment = AttachmentInfo {
@@ -417,10 +427,11 @@ pub async fn download_attachment(message_id: String) -> Result<FileDownloadResul
     let plaintext = crate::crypto::file_enc::decrypt_file(&encrypted_bytes, &shared_key)
         .map_err(|e| anyhow!("DecryptionFailed: {e}"))?;
 
-    // 5. Write to temp dir with safe filename.
+    // 5. Write to temp dir with unique filename to avoid collisions.
     let safe_name = safe_filename(&attachment.file_name);
+    let unique_name = format!("{message_id}_{safe_name}");
     let local_path = std::env::temp_dir()
-        .join(&safe_name)
+        .join(&unique_name)
         .to_string_lossy()
         .into_owned();
 

--- a/rust/src/api/messages.rs
+++ b/rust/src/api/messages.rs
@@ -250,28 +250,26 @@ pub async fn send_file(
         bail!("UnsupportedFileType: {mime_type}");
     }
 
-    // 1. Get the shared key from session (derive it fresh if not yet cached).
-    let shared_key: [u8; 32] = {
-        let session = crate::mostro::session::session_manager()
-            .get_session(&trade_id)
-            .await
-            .ok_or_else(|| anyhow!("SessionNotFound: {trade_id}"))?;
+    // 1. Fetch session once and extract everything needed for the entire flow.
+    let session = crate::mostro::session::session_manager()
+        .get_session(&trade_id)
+        .await
+        .ok_or_else(|| anyhow!("SessionNotFound: {trade_id}"))?;
 
-        if let Some(k) = session.shared_key {
-            k
-        } else {
-            let sender_keys = crate::api::identity::get_active_trade_keys(
-                session.trade_key_index,
-            )
-            .await?;
-            let peer_hex = session
-                .peer_pubkey
-                .as_deref()
-                .ok_or_else(|| anyhow!("PeerUnknown: cannot encrypt attachment without peer pubkey"))?;
-            let peer_pubkey = nostr_sdk::PublicKey::from_hex(peer_hex)
-                .map_err(|e| anyhow!("invalid peer pubkey: {e}"))?;
-            crate::crypto::ecdh::derive_nip04_shared_key(&sender_keys, &peer_pubkey)?
-        }
+    let trade_key_index = session.trade_key_index;
+    let peer_pubkey_hex = session.peer_pubkey.clone();
+
+    let shared_key: [u8; 32] = if let Some(k) = session.shared_key {
+        k
+    } else {
+        let sender_keys =
+            crate::api::identity::get_active_trade_keys(trade_key_index).await?;
+        let peer_hex = peer_pubkey_hex
+            .as_deref()
+            .ok_or_else(|| anyhow!("PeerUnknown: cannot encrypt attachment without peer pubkey"))?;
+        let peer_pubkey = nostr_sdk::PublicKey::from_hex(peer_hex)
+            .map_err(|e| anyhow!("invalid peer pubkey: {e}"))?;
+        crate::crypto::ecdh::derive_nip04_shared_key(&sender_keys, &peer_pubkey)?
     };
 
     // 2. Encrypt the file bytes.
@@ -300,16 +298,11 @@ pub async fn send_file(
     })
     .to_string();
 
-    let session = crate::mostro::session::session_manager()
-        .get_session(&trade_id)
-        .await
-        .ok_or_else(|| anyhow!("SessionNotFound: {trade_id}"))?;
-
     let sender_keys =
-        crate::api::identity::get_active_trade_keys(session.trade_key_index).await?;
+        crate::api::identity::get_active_trade_keys(trade_key_index).await?;
     let sender_pubkey = sender_keys.public_key().to_hex();
 
-    if let Some(peer_hex) = &session.peer_pubkey {
+    if let Some(peer_hex) = &peer_pubkey_hex {
         match nostr_sdk::PublicKey::from_hex(peer_hex) {
             Err(e) => log::warn!("[messages] send_file invalid peer pubkey: {e}"),
             Ok(peer_pubkey) => match crate::nostr::gift_wrap::wrap(

--- a/rust/src/api/messages.rs
+++ b/rust/src/api/messages.rs
@@ -428,7 +428,9 @@ pub async fn download_attachment(message_id: String) -> Result<FileDownloadResul
         .to_string_lossy()
         .into_owned();
 
-    std::fs::write(&local_path, &plaintext).map_err(|e| anyhow!("WriteFailed: {e}"))?;
+    tokio::fs::write(&local_path, &plaintext)
+        .await
+        .map_err(|e| anyhow!("WriteFailed: {e}"))?;
 
     let _ = message_store()
         .attachment_tx

--- a/rust/src/nostr/blossom.rs
+++ b/rust/src/nostr/blossom.rs
@@ -120,13 +120,9 @@ pub async fn download_blob(url: String) -> Result<Vec<u8>> {
 
 /// Attempt to upload a blob to a single Blossom server.
 ///
-/// Uses `PUT /{sha256}` per BUD-01. The `Authorization: Nostr {base64_event}`
-/// header is required by most servers — here we send the SHA-256 only and
-/// expect open servers that don't require auth to accept.
-///
-/// TODO(Phase 10+): Build and sign a Kind-24242 Blossom auth event using
-/// `crate::api::identity::get_active_keys()` and attach it as the
-/// Authorization header once the key infrastructure is exposed here.
+/// Uses `PUT /{sha256}` per BUD-01.  Builds a Kind-24242 Nostr auth event
+/// and attaches it as `Authorization: Nostr {base64_event}` per BUD-02.
+/// If no identity is loaded the upload is attempted without auth.
 async fn try_upload(
     server: &str,
     sha256: &str,
@@ -135,23 +131,59 @@ async fn try_upload(
 ) -> Result<String> {
     #[cfg(not(target_arch = "wasm32"))]
     {
+        use base64::{engine::general_purpose::STANDARD, Engine};
+        use nostr_sdk::prelude::*;
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let expiration = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+            + 600; // 10 minutes
+
+        // Build and sign the auth event.
+        // Fallback: if no identity is loaded (e.g. first-run upload before
+        // identity is set), attempt upload without auth header.
+        let auth_header: Option<String> =
+            match crate::api::identity::get_active_keys().await {
+                Err(_) => None,
+                Ok(keys) => {
+                    let event = EventBuilder::new(
+                        Kind::Custom(24242),
+                        format!("Upload {sha256}"),
+                    )
+                    .tag(Tag::parse(["t", "upload"])?)
+                    .tag(Tag::parse(["x", sha256])?)
+                    .tag(Tag::parse(["expiration", &expiration.to_string()])?)
+                    .sign_with_keys(&keys)?;
+
+                    let event_json = event.as_json();
+                    Some(format!("Nostr {}", STANDARD.encode(event_json)))
+                }
+            };
+
         let client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(60))
             .build()
             .map_err(|e| anyhow!("HTTP client build failed: {e}"))?;
 
         let url = format!("{server}/{sha256}");
-        let response = client
+        let mut request = client
             .put(&url)
             .header("Content-Type", mime_type)
             .header("Content-Length", bytes.len().to_string())
-            .body(bytes.to_vec())
+            .body(bytes.to_vec());
+
+        if let Some(auth) = auth_header {
+            request = request.header("Authorization", auth);
+        }
+
+        let response = request
             .send()
             .await
             .map_err(|e| anyhow!("PUT {url} failed: {e}"))?;
 
         if response.status().is_success() {
-            // Return the canonical URL for this blob
             Ok(format!("{server}/{sha256}"))
         } else {
             Err(anyhow!(

--- a/rust/src/nostr/blossom.rs
+++ b/rust/src/nostr/blossom.rs
@@ -146,7 +146,10 @@ async fn try_upload(
         // identity is set), attempt upload without auth header.
         let auth_header: Option<String> =
             match crate::api::identity::get_active_keys().await {
-                Err(_) => None,
+                Err(e) => {
+                    log::debug!("[blossom] no active keys for upload {sha256}: {e}");
+                    None
+                }
                 Ok(keys) => {
                     let event = EventBuilder::new(
                         Kind::Custom(24242),


### PR DESCRIPTION
Replace TODO stubs in send_file and download_attachment with real
encrypt-upload-publish and download-decrypt-write flows.

Add Kind-24242 Nostr auth event to Blossom try_upload per BUD-01/02,
signed with the active identity key and attached as Authorization
header. Falls back to unauthenticated upload if no identity loaded.

send_file: derives ECDH shared key from session, encrypts with
ChaCha20-Poly1305, uploads to Blossom, publishes NIP-59 gift-wrapped
message with URL and metadata.

download_attachment: validates Blossom URL, derives shared key,
downloads encrypted blob, decrypts, writes to temp dir.

Add base64 dependency for auth event encoding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Encrypted file attachments now fully functional, enabling secure sending and receiving of files.
  * Implemented proper authentication for file upload operations to enhance security.

* **Bug Fixes**
  * Resolved placeholder behavior in file attachment handling with real encrypted file transfer functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->