### PR TITLE
feat(settings): persist Mostro node selection and skip rating in priv…

### DIFF
--- a/lib/features/account/screens/account_screen.dart
+++ b/lib/features/account/screens/account_screen.dart
@@ -455,7 +455,7 @@ class _AccountScreenState extends ConsumerState<AccountScreen> {
                 onPressed: () async {
                   Navigator.pop(dialogContext);
                   try {
-                    await orders_api.subscribeOrders();
+                    await orders_api.restartOrdersSubscription();
                     if (!context.mounted) return;
                     ScaffoldMessenger.of(context).showSnackBar(
                       const SnackBar(content: Text('Order book refreshed')),
@@ -464,7 +464,13 @@ class _AccountScreenState extends ConsumerState<AccountScreen> {
                     debugPrint('[account] refresh error: $e');
                     if (!context.mounted) return;
                     ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(content: Text('Refresh failed: $e')),
+                      SnackBar(
+                        content: Text(
+                          kDebugMode
+                              ? 'Refresh failed: $e'
+                              : 'Refresh failed',
+                        ),
+                      ),
                     );
                   }
                 },

--- a/lib/features/account/screens/account_screen.dart
+++ b/lib/features/account/screens/account_screen.dart
@@ -10,6 +10,7 @@ import 'package:mostro/features/account/providers/backup_reminder_provider.dart'
 import 'package:mostro/features/account/providers/privacy_mode_provider.dart';
 import 'package:mostro/l10n/app_localizations.dart';
 import 'package:mostro/shared/providers/session_provider.dart';
+import 'package:mostro/src/rust/api/orders.dart' as orders_api;
 
 /// Account screen — Route `/key_management`.
 ///
@@ -451,9 +452,21 @@ class _AccountScreenState extends ConsumerState<AccountScreen> {
                 child: const Text('Cancel'),
               ),
               FilledButton(
-                onPressed: () {
+                onPressed: () async {
                   Navigator.pop(dialogContext);
-                  // TODO: wire restore-session action in Phase 7.
+                  try {
+                    await orders_api.subscribeOrders();
+                    if (!context.mounted) return;
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Order book refreshed')),
+                    );
+                  } catch (e) {
+                    debugPrint('[account] refresh error: $e');
+                    if (!context.mounted) return;
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text('Refresh failed: $e')),
+                    );
+                  }
                 },
                 child: const Text('Refresh'),
               ),

--- a/lib/features/home/providers/home_order_providers.dart
+++ b/lib/features/home/providers/home_order_providers.dart
@@ -44,13 +44,6 @@ int _platformInt64ToInt(dynamic v) => v is BigInt ? v.toInt() : v as int;
 // ── Order model ───────────────────────────────────────────────────────────────
 
 /// Lightweight Dart-side order model for the UI layer.
-///
-/// TODO(Phase 18+): Add `OrderItem.fromInfo(OrderInfo info)` factory once
-/// `flutter_rust_bridge_codegen generate` has been run and the generated
-/// `OrderInfo` type is available at `package:rust/src/rust/api/orders.dart`.
-/// Field mapping: id, kind.name.toLowerCase(), fiatAmount, fiatAmountMin,
-/// fiatAmountMax, fiatCode, paymentMethod, premium, creatorPubkey,
-/// DateTime.fromMillisecondsSinceEpoch(createdAt * 1000), expiresAt.
 class OrderItem {
   OrderItem({
     required this.id,

--- a/lib/features/order/screens/take_order_screen.dart
+++ b/lib/features/order/screens/take_order_screen.dart
@@ -284,8 +284,8 @@ class _TakeOrderScreenState extends ConsumerState<TakeOrderScreen> {
           const SizedBox(height: AppSpacing.sm),
 
           // Card 5: Creator reputation — hidden in full privacy mode.
-          // TODO(bridge): the rate_counterpart route should also be skipped
-          // when privacy mode is on (controlled via the trade flow, not here).
+          // Rating step is skipped in trade_detail_screen.dart when privacy
+          // mode is active.
           if (!privacyMode) ...[
             _InfoCard(
               color: cardBg,

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -9,7 +9,7 @@ import 'package:mostro/core/app_routes.dart';
 import 'package:mostro/core/app_theme.dart';
 import 'package:mostro/src/rust/api/disputes.dart' as disputes_api;
 import 'package:mostro/src/rust/api/orders.dart' as orders_api;
-import 'package:mostro/src/rust/api/settings.dart' as settings_api;
+import 'package:mostro/features/account/providers/privacy_mode_provider.dart';
 import 'package:mostro/features/disputes/providers/disputes_providers.dart';
 import 'package:mostro/features/home/providers/home_order_providers.dart';
 import 'package:mostro/features/order/providers/trade_state_provider.dart';
@@ -285,9 +285,7 @@ class _TradeDetailScreenState extends ConsumerState<TradeDetailScreen> {
         try {
           await orders_api.releaseOrder(orderId: widget.orderId);
           if (!context.mounted) return;
-          final settings = await settings_api.getSettings();
-          if (!context.mounted) return;
-          if (settings.privacyMode) {
+          if (ref.read(privacyModeProvider)) {
             context.go(AppRoute.home);
           } else {
             context.push(AppRoute.rateUserPath(widget.orderId));
@@ -760,10 +758,8 @@ class _TradeDetailScreenState extends ConsumerState<TradeDetailScreen> {
           // ── Pending rating — RATE + CLOSE ─────────────────────────────
           if (status == TradeStatus.pendingRating) ...[
             FilledButton.icon(
-              onPressed: () async {
-                final settings = await settings_api.getSettings();
-                if (!context.mounted) return;
-                if (settings.privacyMode) {
+              onPressed: () {
+                if (ref.read(privacyModeProvider)) {
                   context.go(AppRoute.home);
                 } else {
                   context.push(AppRoute.rateUserPath(widget.orderId));

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -9,6 +9,7 @@ import 'package:mostro/core/app_routes.dart';
 import 'package:mostro/core/app_theme.dart';
 import 'package:mostro/src/rust/api/disputes.dart' as disputes_api;
 import 'package:mostro/src/rust/api/orders.dart' as orders_api;
+import 'package:mostro/src/rust/api/settings.dart' as settings_api;
 import 'package:mostro/features/disputes/providers/disputes_providers.dart';
 import 'package:mostro/features/home/providers/home_order_providers.dart';
 import 'package:mostro/features/order/providers/trade_state_provider.dart';
@@ -283,7 +284,12 @@ class _TradeDetailScreenState extends ConsumerState<TradeDetailScreen> {
         if (confirmed != true || !context.mounted) return;
         try {
           await orders_api.releaseOrder(orderId: widget.orderId);
-          if (context.mounted) {
+          if (!context.mounted) return;
+          final settings = await settings_api.getSettings();
+          if (!context.mounted) return;
+          if (settings.privacyMode) {
+            context.go(AppRoute.home);
+          } else {
             context.push(AppRoute.rateUserPath(widget.orderId));
           }
         } catch (e, st) {
@@ -754,8 +760,15 @@ class _TradeDetailScreenState extends ConsumerState<TradeDetailScreen> {
           // ── Pending rating — RATE + CLOSE ─────────────────────────────
           if (status == TradeStatus.pendingRating) ...[
             FilledButton.icon(
-              onPressed: () =>
-                  context.push(AppRoute.rateUserPath(widget.orderId)),
+              onPressed: () async {
+                final settings = await settings_api.getSettings();
+                if (!context.mounted) return;
+                if (settings.privacyMode) {
+                  context.go(AppRoute.home);
+                } else {
+                  context.push(AppRoute.rateUserPath(widget.orderId));
+                }
+              },
               icon: const Icon(Icons.star_outline, size: 16),
               label: const Text('RATE'),
               style: FilledButton.styleFrom(

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -1002,6 +1002,17 @@ pub async fn subscribe_orders() {
     });
 }
 
+/// Force-restart the orders subscription.
+///
+/// Tears down the existing subscription (if any) by resetting the guard,
+/// then spawns a fresh subscription loop. Used by the UI "Refresh" action
+/// so users get a real re-subscribe instead of a silent no-op.
+pub async fn restart_orders_subscription() {
+    // Clear the guard so subscribe_orders can acquire it again.
+    SUBSCRIPTION_ACTIVE.store(false, Ordering::Release);
+    subscribe_orders().await;
+}
+
 async fn _run_order_subscription() {
     let Ok(pool) = crate::api::nostr::get_pool() else {
         log::error!("[orders] subscription failed: relay pool not initialized");

--- a/rust/src/api/settings.rs
+++ b/rust/src/api/settings.rs
@@ -9,6 +9,7 @@ use tokio::sync::{broadcast, RwLock};
 use tokio::sync::broadcast::error::RecvError;
 
 use crate::api::types::{AppSettings, ThemeMode};
+use crate::db::Storage;
 
 // ── SettingsStore ─────────────────────────────────────────────────────────────
 
@@ -198,6 +199,30 @@ pub fn set_mostro_pubkey(pubkey: Option<String>) -> Result<()> {
 /// Return the currently active Mostro node pubkey (override or default).
 pub fn get_mostro_pubkey() -> String {
     crate::config::active_mostro_pubkey()
+}
+
+/// Return the active Mostro node info, falling back to the compiled
+/// default if none has been persisted yet.
+pub async fn get_mostro_node() -> Result<crate::api::types::MostroNodeInfo> {
+    if let Some(db) = crate::db::app_db::db() {
+        if let Ok(Some(node)) = db.get_active_mostro_node().await {
+            return Ok(node);
+        }
+    }
+    Ok(crate::db::seeds::get_default_mostro_node())
+}
+
+/// Persist a new active Mostro node selection.
+///
+/// Also updates the in-memory pubkey override so the relay pool and
+/// outgoing events use the new node immediately.
+pub async fn set_mostro_node(node: crate::api::types::MostroNodeInfo) -> Result<()> {
+    let pubkey = node.pubkey.clone();
+    if let Some(db) = crate::db::app_db::db() {
+        db.save_mostro_node(&node).await?;
+    }
+    crate::config::set_active_mostro_pubkey(Some(pubkey));
+    Ok(())
 }
 
 /// Toggle the in-memory logging flag (not persisted to disk).

--- a/rust/src/api/settings.rs
+++ b/rust/src/api/settings.rs
@@ -216,6 +216,9 @@ pub async fn get_mostro_node() -> Result<crate::api::types::MostroNodeInfo> {
 ///
 /// Also updates the in-memory pubkey override so the relay pool and
 /// outgoing events use the new node immediately.
+///
+/// TODO(#93): After updating the pubkey, refresh relay subscriptions so
+/// `subscribe_order_and_dm_feeds` re-subscribes with the new node's key.
 pub async fn set_mostro_node(node: crate::api::types::MostroNodeInfo) -> Result<()> {
     let pubkey = node.pubkey.clone();
     if let Some(db) = crate::db::app_db::db() {

--- a/rust/src/db/indexeddb.rs
+++ b/rust/src/db/indexeddb.rs
@@ -89,6 +89,14 @@ impl Storage for IndexedDbStorage {
         Ok(None) // no persisted key: caller will treat absence correctly
     }
 
+    async fn save_mostro_node(&self, _node: &crate::api::types::MostroNodeInfo) -> Result<()> {
+        Ok(()) // WASM: not persisted
+    }
+
+    async fn get_active_mostro_node(&self) -> Result<Option<crate::api::types::MostroNodeInfo>> {
+        Ok(None) // WASM: not persisted
+    }
+
     async fn get_trade_by_order_id(
         &self,
         _order_id: &str,

--- a/rust/src/db/indexeddb.rs
+++ b/rust/src/db/indexeddb.rs
@@ -90,11 +90,15 @@ impl Storage for IndexedDbStorage {
     }
 
     async fn save_mostro_node(&self, _node: &crate::api::types::MostroNodeInfo) -> Result<()> {
-        Ok(()) // WASM: not persisted
+        log::warn!("save_mostro_node: IndexedDB backend not implemented — node selection will not survive reload");
+        // TODO(#93): implement IndexedDB persistence for Mostro node selection
+        Ok(())
     }
 
     async fn get_active_mostro_node(&self) -> Result<Option<crate::api::types::MostroNodeInfo>> {
-        Ok(None) // WASM: not persisted
+        log::warn!("get_active_mostro_node: IndexedDB backend not implemented — falling back to default");
+        // TODO(#93): implement IndexedDB persistence for Mostro node selection
+        Ok(None)
     }
 
     async fn get_trade_by_order_id(

--- a/rust/src/db/mod.rs
+++ b/rust/src/db/mod.rs
@@ -62,6 +62,14 @@ pub trait Storage: Send + Sync {
     /// Retrieve the BIP-32 key index for `order_id`, or `None` if not found.
     async fn get_trade_key(&self, order_id: &str) -> Result<Option<u32>>;
 
+    // ── Settings / Mostro node ────────────────────────────────────────────────
+
+    /// Persist a Mostro node info record, replacing any existing one.
+    async fn save_mostro_node(&self, node: &crate::api::types::MostroNodeInfo) -> Result<()>;
+
+    /// Return the currently active Mostro node, or `None` if none has been saved.
+    async fn get_active_mostro_node(&self) -> Result<Option<crate::api::types::MostroNodeInfo>>;
+
     /// Look up a persisted trade by the order ID it is associated with.
     async fn get_trade_by_order_id(
         &self,

--- a/rust/src/db/schema.rs
+++ b/rust/src/db/schema.rs
@@ -56,6 +56,12 @@ CREATE TABLE IF NOT EXISTS queued_messages (
     next_retry_at   INTEGER
 );
 
+-- Generic key-value settings store (Mostro node, preferences, etc.).
+CREATE TABLE IF NOT EXISTS settings (
+    key             TEXT PRIMARY KEY,
+    value           TEXT NOT NULL
+);
+
 -- Maps order_id → BIP-32 trade key index used when taking/creating that order.
 -- Persists across restarts so fiat-sent, release, and cancel can re-derive the
 -- correct signing key even after the app is killed between protocol steps.

--- a/rust/src/db/seeds.rs
+++ b/rust/src/db/seeds.rs
@@ -40,18 +40,13 @@ async fn seed_default_relays<S: Storage>(storage: &S) -> Result<()> {
 }
 
 /// Seed the default Mostro node if no active node is configured.
-///
-/// Stores the node info in the settings table. Since the `Storage` trait
-/// doesn't have Mostro-node-specific methods yet, we store it as a relay
-/// with a special source marker and use a separate settings key.
-///
-/// TODO: Add `save_mostro_node` / `get_active_mostro_node` to Storage
-/// trait when the settings/about screens are implemented (Phase 16-17).
 async fn seed_default_mostro_node<S: Storage>(storage: &S) -> Result<()> {
-    // For now, the default Mostro node info is served from the compiled
-    // constant via `get_default_mostro_node()`. Persistence will be added
-    // when the Storage trait gains Mostro-node methods.
-    let _ = storage;
+    if storage.get_active_mostro_node().await?.is_some() {
+        return Ok(());
+    }
+    let node = get_default_mostro_node();
+    storage.save_mostro_node(&node).await?;
+    log::info!("[seeds] default Mostro node seeded: {}", node.pubkey);
     Ok(())
 }
 

--- a/rust/src/db/sqlite.rs
+++ b/rust/src/db/sqlite.rs
@@ -283,6 +283,31 @@ impl Storage for SqliteStorage {
         Ok(row.map(|(idx,)| idx as u32))
     }
 
+    async fn save_mostro_node(&self, node: &crate::api::types::MostroNodeInfo) -> Result<()> {
+        let json = serde_json::to_string(node)?;
+        sqlx::query(
+            "INSERT OR REPLACE INTO settings (key, value) VALUES ('active_mostro_node', ?)",
+        )
+        .bind(&json)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn get_active_mostro_node(
+        &self,
+    ) -> Result<Option<crate::api::types::MostroNodeInfo>> {
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT value FROM settings WHERE key = 'active_mostro_node'",
+        )
+        .fetch_optional(&self.pool)
+        .await?;
+        match row {
+            None => Ok(None),
+            Some((json,)) => Ok(Some(serde_json::from_str(&json)?)),
+        }
+    }
+
     async fn get_trade_by_order_id(&self, order_id: &str) -> Result<Option<TradeInfo>> {
         // The `data` column holds the full JSON-serialised TradeInfo; use
         // SQLite's json_extract to filter by the nested order id without

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -45,7 +45,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -327029727;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 2073345198;
 
 // Section: executor
 
@@ -1724,6 +1724,41 @@ fn wire__crate__api__messages__get_messages_impl(
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
                     (move || async move {
                         let output_ok = crate::api::messages::get_messages(api_trade_id).await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__settings__get_mostro_node_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "get_mostro_node",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || async move {
+                        let output_ok = crate::api::settings::get_mostro_node().await?;
                         Ok(output_ok)
                     })()
                     .await,
@@ -3558,6 +3593,42 @@ fn wire__crate__api__settings__set_logging_enabled_impl(
         },
     )
 }
+fn wire__crate__api__settings__set_mostro_node_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "set_mostro_node",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_node = <crate::api::types::MostroNodeInfo>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || async move {
+                        let output_ok = crate::api::settings::set_mostro_node(api_node).await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
 fn wire__crate__api__settings__set_mostro_pubkey_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -4515,6 +4586,38 @@ impl SseDecode for crate::api::types::MessageType {
     }
 }
 
+impl SseDecode for crate::api::types::MostroNodeInfo {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_pubkey = <String>::sse_decode(deserializer);
+        let mut var_name = <Option<String>>::sse_decode(deserializer);
+        let mut var_version = <Option<String>>::sse_decode(deserializer);
+        let mut var_expirationHours = <u32>::sse_decode(deserializer);
+        let mut var_expirationSeconds = <u32>::sse_decode(deserializer);
+        let mut var_feePct = <Option<f64>>::sse_decode(deserializer);
+        let mut var_maxOrderAmount = <Option<u64>>::sse_decode(deserializer);
+        let mut var_minOrderAmount = <Option<u64>>::sse_decode(deserializer);
+        let mut var_supportedCurrencies = <Option<Vec<String>>>::sse_decode(deserializer);
+        let mut var_lnNodeId = <Option<String>>::sse_decode(deserializer);
+        let mut var_lnNodeAlias = <Option<String>>::sse_decode(deserializer);
+        let mut var_isActive = <bool>::sse_decode(deserializer);
+        return crate::api::types::MostroNodeInfo {
+            pubkey: var_pubkey,
+            name: var_name,
+            version: var_version,
+            expiration_hours: var_expirationHours,
+            expiration_seconds: var_expirationSeconds,
+            fee_pct: var_feePct,
+            max_order_amount: var_maxOrderAmount,
+            min_order_amount: var_minOrderAmount,
+            supported_currencies: var_supportedCurrencies,
+            ln_node_id: var_lnNodeId,
+            ln_node_alias: var_lnNodeAlias,
+            is_active: var_isActive,
+        };
+    }
+}
+
 impl SseDecode for crate::api::types::NewOrderParams {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -5314,135 +5417,137 @@ fn pde_ffi_dispatcher_primary_impl(
         35 => wire__crate__api__disputes__get_dispute_impl(port, ptr, rust_vec_len, data_len),
         36 => wire__crate__api__identity__get_identity_impl(port, ptr, rust_vec_len, data_len),
         37 => wire__crate__api__messages__get_messages_impl(port, ptr, rust_vec_len, data_len),
-        38 => wire__crate__api__settings__get_mostro_pubkey_impl(port, ptr, rust_vec_len, data_len),
-        39 => wire__crate__api__identity__get_nym_identity_impl(port, ptr, rust_vec_len, data_len),
-        40 => wire__crate__api__orders__get_order_impl(port, ptr, rust_vec_len, data_len),
-        41 => wire__crate__api__orders__get_orders_impl(port, ptr, rust_vec_len, data_len),
-        42 => {
+        38 => wire__crate__api__settings__get_mostro_node_impl(port, ptr, rust_vec_len, data_len),
+        39 => wire__crate__api__settings__get_mostro_pubkey_impl(port, ptr, rust_vec_len, data_len),
+        40 => wire__crate__api__identity__get_nym_identity_impl(port, ptr, rust_vec_len, data_len),
+        41 => wire__crate__api__orders__get_order_impl(port, ptr, rust_vec_len, data_len),
+        42 => wire__crate__api__orders__get_orders_impl(port, ptr, rust_vec_len, data_len),
+        43 => {
             wire__crate__api__reputation__get_privacy_mode_impl(port, ptr, rust_vec_len, data_len)
         }
-        43 => wire__crate__api__reputation__get_rating_for_trade_impl(
+        44 => wire__crate__api__reputation__get_rating_for_trade_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        44 => wire__crate__api__nostr__get_relays_impl(port, ptr, rust_vec_len, data_len),
-        45 => wire__crate__api__settings__get_settings_impl(port, ptr, rust_vec_len, data_len),
-        46 => wire__crate__api__identity__get_trade_key_impl(port, ptr, rust_vec_len, data_len),
-        47 => wire__crate__api__orders__get_trade_role_impl(port, ptr, rust_vec_len, data_len),
-        48 => wire__crate__api__messages__get_unread_count_impl(port, ptr, rust_vec_len, data_len),
-        49 => wire__crate__api__nwc__get_wallet_impl(port, ptr, rust_vec_len, data_len),
-        50 => wire__crate__api__disputes__handle_admin_canceled_impl(
+        45 => wire__crate__api__nostr__get_relays_impl(port, ptr, rust_vec_len, data_len),
+        46 => wire__crate__api__settings__get_settings_impl(port, ptr, rust_vec_len, data_len),
+        47 => wire__crate__api__identity__get_trade_key_impl(port, ptr, rust_vec_len, data_len),
+        48 => wire__crate__api__orders__get_trade_role_impl(port, ptr, rust_vec_len, data_len),
+        49 => wire__crate__api__messages__get_unread_count_impl(port, ptr, rust_vec_len, data_len),
+        50 => wire__crate__api__nwc__get_wallet_impl(port, ptr, rust_vec_len, data_len),
+        51 => wire__crate__api__disputes__handle_admin_canceled_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        51 => {
+        52 => {
             wire__crate__api__disputes__handle_admin_settled_impl(port, ptr, rust_vec_len, data_len)
         }
-        52 => wire__crate__api__disputes__handle_admin_took_dispute_impl(
+        53 => wire__crate__api__disputes__handle_admin_took_dispute_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        53 => wire__crate__api__reputation__handle_rating_received_impl(
+        54 => wire__crate__api__reputation__handle_rating_received_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        54 => {
+        55 => {
             wire__crate__api__identity__import_from_mnemonic_impl(port, ptr, rust_vec_len, data_len)
         }
-        55 => wire__crate__api__identity__import_from_nsec_impl(port, ptr, rust_vec_len, data_len),
-        56 => wire__crate__api__init_db_impl(port, ptr, rust_vec_len, data_len),
-        57 => wire__crate__api__nostr__initialize_impl(port, ptr, rust_vec_len, data_len),
-        58 => wire__crate__api__logging__install_log_bridge_impl(port, ptr, rust_vec_len, data_len),
-        59 => wire__crate__api__orders__list_trades_impl(port, ptr, rust_vec_len, data_len),
-        60 => wire__crate__api__identity__load_identity_from_mnemonic_impl(
+        56 => wire__crate__api__identity__import_from_nsec_impl(port, ptr, rust_vec_len, data_len),
+        57 => wire__crate__api__init_db_impl(port, ptr, rust_vec_len, data_len),
+        58 => wire__crate__api__nostr__initialize_impl(port, ptr, rust_vec_len, data_len),
+        59 => wire__crate__api__logging__install_log_bridge_impl(port, ptr, rust_vec_len, data_len),
+        60 => wire__crate__api__orders__list_trades_impl(port, ptr, rust_vec_len, data_len),
+        61 => wire__crate__api__identity__load_identity_from_mnemonic_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        61 => wire__crate__api__nwc__make_invoice_impl(port, ptr, rust_vec_len, data_len),
-        62 => wire__crate__api__messages__mark_as_read_impl(port, ptr, rust_vec_len, data_len),
-        63 => wire__crate__api__messages__on_attachment_progress_impl(
+        62 => wire__crate__api__nwc__make_invoice_impl(port, ptr, rust_vec_len, data_len),
+        63 => wire__crate__api__messages__mark_as_read_impl(port, ptr, rust_vec_len, data_len),
+        64 => wire__crate__api__messages__on_attachment_progress_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        64 => wire__crate__api__nostr__on_connection_state_changed_impl(
+        65 => wire__crate__api__nostr__on_connection_state_changed_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        65 => {
+        66 => {
             wire__crate__api__disputes__on_dispute_updated_impl(port, ptr, rust_vec_len, data_len)
         }
-        66 => wire__crate__api__logging__on_log_entry_impl(port, ptr, rust_vec_len, data_len),
-        67 => wire__crate__api__messages__on_new_message_impl(port, ptr, rust_vec_len, data_len),
-        68 => wire__crate__api__orders__on_orders_updated_impl(port, ptr, rust_vec_len, data_len),
-        69 => {
+        67 => wire__crate__api__logging__on_log_entry_impl(port, ptr, rust_vec_len, data_len),
+        68 => wire__crate__api__messages__on_new_message_impl(port, ptr, rust_vec_len, data_len),
+        69 => wire__crate__api__orders__on_orders_updated_impl(port, ptr, rust_vec_len, data_len),
+        70 => {
             wire__crate__api__reputation__on_rating_received_impl(port, ptr, rust_vec_len, data_len)
         }
-        70 => {
+        71 => {
             wire__crate__api__nostr__on_relay_status_changed_impl(port, ptr, rust_vec_len, data_len)
         }
-        71 => {
+        72 => {
             wire__crate__api__settings__on_settings_changed_impl(port, ptr, rust_vec_len, data_len)
         }
-        72 => wire__crate__api__messages__on_unread_count_changed_impl(
+        73 => wire__crate__api__messages__on_unread_count_changed_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        73 => {
+        74 => {
             wire__crate__api__nwc__on_wallet_status_changed_impl(port, ptr, rust_vec_len, data_len)
         }
-        74 => wire__crate__api__disputes__open_dispute_impl(port, ptr, rust_vec_len, data_len),
-        75 => {
+        75 => wire__crate__api__disputes__open_dispute_impl(port, ptr, rust_vec_len, data_len),
+        76 => {
             wire__crate__api__orders__order_filters_default_impl(port, ptr, rust_vec_len, data_len)
         }
-        76 => wire__crate__api__nwc__pay_invoice_impl(port, ptr, rust_vec_len, data_len),
-        77 => wire__crate__api__orders__release_order_impl(port, ptr, rust_vec_len, data_len),
-        78 => wire__crate__api__nostr__remove_relay_impl(port, ptr, rust_vec_len, data_len),
-        79 => wire__crate__api__orders__resolve_maker_order_impl(port, ptr, rust_vec_len, data_len),
-        80 => wire__crate__api__orders__send_fiat_sent_impl(port, ptr, rust_vec_len, data_len),
-        81 => wire__crate__api__messages__send_file_impl(port, ptr, rust_vec_len, data_len),
-        82 => wire__crate__api__orders__send_invoice_impl(port, ptr, rust_vec_len, data_len),
-        83 => wire__crate__api__messages__send_message_impl(port, ptr, rust_vec_len, data_len),
-        84 => wire__crate__api__settings__set_default_fiat_code_impl(
+        77 => wire__crate__api__nwc__pay_invoice_impl(port, ptr, rust_vec_len, data_len),
+        78 => wire__crate__api__orders__release_order_impl(port, ptr, rust_vec_len, data_len),
+        79 => wire__crate__api__nostr__remove_relay_impl(port, ptr, rust_vec_len, data_len),
+        80 => wire__crate__api__orders__resolve_maker_order_impl(port, ptr, rust_vec_len, data_len),
+        81 => wire__crate__api__orders__send_fiat_sent_impl(port, ptr, rust_vec_len, data_len),
+        82 => wire__crate__api__messages__send_file_impl(port, ptr, rust_vec_len, data_len),
+        83 => wire__crate__api__orders__send_invoice_impl(port, ptr, rust_vec_len, data_len),
+        84 => wire__crate__api__messages__send_message_impl(port, ptr, rust_vec_len, data_len),
+        85 => wire__crate__api__settings__set_default_fiat_code_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        85 => wire__crate__api__settings__set_default_lightning_address_impl(
+        86 => wire__crate__api__settings__set_default_lightning_address_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        86 => wire__crate__api__settings__set_language_impl(port, ptr, rust_vec_len, data_len),
-        87 => {
+        87 => wire__crate__api__settings__set_language_impl(port, ptr, rust_vec_len, data_len),
+        88 => {
             wire__crate__api__settings__set_logging_enabled_impl(port, ptr, rust_vec_len, data_len)
         }
-        88 => wire__crate__api__settings__set_mostro_pubkey_impl(port, ptr, rust_vec_len, data_len),
-        89 => {
+        89 => wire__crate__api__settings__set_mostro_node_impl(port, ptr, rust_vec_len, data_len),
+        90 => wire__crate__api__settings__set_mostro_pubkey_impl(port, ptr, rust_vec_len, data_len),
+        91 => {
             wire__crate__api__reputation__set_privacy_mode_impl(port, ptr, rust_vec_len, data_len)
         }
-        90 => wire__crate__api__settings__set_theme_impl(port, ptr, rust_vec_len, data_len),
-        91 => wire__crate__api__disputes__submit_evidence_impl(port, ptr, rust_vec_len, data_len),
-        92 => wire__crate__api__reputation__submit_rating_impl(port, ptr, rust_vec_len, data_len),
-        93 => wire__crate__api__orders__subscribe_orders_impl(port, ptr, rust_vec_len, data_len),
-        94 => wire__crate__api__orders__take_order_impl(port, ptr, rust_vec_len, data_len),
+        92 => wire__crate__api__settings__set_theme_impl(port, ptr, rust_vec_len, data_len),
+        93 => wire__crate__api__disputes__submit_evidence_impl(port, ptr, rust_vec_len, data_len),
+        94 => wire__crate__api__reputation__submit_rating_impl(port, ptr, rust_vec_len, data_len),
+        95 => wire__crate__api__orders__subscribe_orders_impl(port, ptr, rust_vec_len, data_len),
+        96 => wire__crate__api__orders__take_order_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -6037,6 +6142,37 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::types::MessageType>
     for crate::api::types::MessageType
 {
     fn into_into_dart(self) -> crate::api::types::MessageType {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::types::MostroNodeInfo {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.pubkey.into_into_dart().into_dart(),
+            self.name.into_into_dart().into_dart(),
+            self.version.into_into_dart().into_dart(),
+            self.expiration_hours.into_into_dart().into_dart(),
+            self.expiration_seconds.into_into_dart().into_dart(),
+            self.fee_pct.into_into_dart().into_dart(),
+            self.max_order_amount.into_into_dart().into_dart(),
+            self.min_order_amount.into_into_dart().into_dart(),
+            self.supported_currencies.into_into_dart().into_dart(),
+            self.ln_node_id.into_into_dart().into_dart(),
+            self.ln_node_alias.into_into_dart().into_dart(),
+            self.is_active.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::types::MostroNodeInfo
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::types::MostroNodeInfo>
+    for crate::api::types::MostroNodeInfo
+{
+    fn into_into_dart(self) -> crate::api::types::MostroNodeInfo {
         self
     }
 }
@@ -7126,6 +7262,24 @@ impl SseEncode for crate::api::types::MessageType {
             },
             serializer,
         );
+    }
+}
+
+impl SseEncode for crate::api::types::MostroNodeInfo {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.pubkey, serializer);
+        <Option<String>>::sse_encode(self.name, serializer);
+        <Option<String>>::sse_encode(self.version, serializer);
+        <u32>::sse_encode(self.expiration_hours, serializer);
+        <u32>::sse_encode(self.expiration_seconds, serializer);
+        <Option<f64>>::sse_encode(self.fee_pct, serializer);
+        <Option<u64>>::sse_encode(self.max_order_amount, serializer);
+        <Option<u64>>::sse_encode(self.min_order_amount, serializer);
+        <Option<Vec<String>>>::sse_encode(self.supported_currencies, serializer);
+        <Option<String>>::sse_encode(self.ln_node_id, serializer);
+        <Option<String>>::sse_encode(self.ln_node_alias, serializer);
+        <bool>::sse_encode(self.is_active, serializer);
     }
 }
 

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -45,7 +45,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 2073345198;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1165020131;
 
 // Section: executor
 
@@ -3285,6 +3285,43 @@ fn wire__crate__api__orders__resolve_maker_order_impl(
         },
     )
 }
+fn wire__crate__api__orders__restart_orders_subscription_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "restart_orders_subscription",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, ()>(
+                    (move || async move {
+                        let output_ok = Result::<_, ()>::Ok({
+                            crate::api::orders::restart_orders_subscription().await;
+                        })?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
 fn wire__crate__api__orders__send_fiat_sent_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -5518,36 +5555,42 @@ fn pde_ffi_dispatcher_primary_impl(
         78 => wire__crate__api__orders__release_order_impl(port, ptr, rust_vec_len, data_len),
         79 => wire__crate__api__nostr__remove_relay_impl(port, ptr, rust_vec_len, data_len),
         80 => wire__crate__api__orders__resolve_maker_order_impl(port, ptr, rust_vec_len, data_len),
-        81 => wire__crate__api__orders__send_fiat_sent_impl(port, ptr, rust_vec_len, data_len),
-        82 => wire__crate__api__messages__send_file_impl(port, ptr, rust_vec_len, data_len),
-        83 => wire__crate__api__orders__send_invoice_impl(port, ptr, rust_vec_len, data_len),
-        84 => wire__crate__api__messages__send_message_impl(port, ptr, rust_vec_len, data_len),
-        85 => wire__crate__api__settings__set_default_fiat_code_impl(
+        81 => wire__crate__api__orders__restart_orders_subscription_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        86 => wire__crate__api__settings__set_default_lightning_address_impl(
+        82 => wire__crate__api__orders__send_fiat_sent_impl(port, ptr, rust_vec_len, data_len),
+        83 => wire__crate__api__messages__send_file_impl(port, ptr, rust_vec_len, data_len),
+        84 => wire__crate__api__orders__send_invoice_impl(port, ptr, rust_vec_len, data_len),
+        85 => wire__crate__api__messages__send_message_impl(port, ptr, rust_vec_len, data_len),
+        86 => wire__crate__api__settings__set_default_fiat_code_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        87 => wire__crate__api__settings__set_language_impl(port, ptr, rust_vec_len, data_len),
-        88 => {
+        87 => wire__crate__api__settings__set_default_lightning_address_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        88 => wire__crate__api__settings__set_language_impl(port, ptr, rust_vec_len, data_len),
+        89 => {
             wire__crate__api__settings__set_logging_enabled_impl(port, ptr, rust_vec_len, data_len)
         }
-        89 => wire__crate__api__settings__set_mostro_node_impl(port, ptr, rust_vec_len, data_len),
-        90 => wire__crate__api__settings__set_mostro_pubkey_impl(port, ptr, rust_vec_len, data_len),
-        91 => {
+        90 => wire__crate__api__settings__set_mostro_node_impl(port, ptr, rust_vec_len, data_len),
+        91 => wire__crate__api__settings__set_mostro_pubkey_impl(port, ptr, rust_vec_len, data_len),
+        92 => {
             wire__crate__api__reputation__set_privacy_mode_impl(port, ptr, rust_vec_len, data_len)
         }
-        92 => wire__crate__api__settings__set_theme_impl(port, ptr, rust_vec_len, data_len),
-        93 => wire__crate__api__disputes__submit_evidence_impl(port, ptr, rust_vec_len, data_len),
-        94 => wire__crate__api__reputation__submit_rating_impl(port, ptr, rust_vec_len, data_len),
-        95 => wire__crate__api__orders__subscribe_orders_impl(port, ptr, rust_vec_len, data_len),
-        96 => wire__crate__api__orders__take_order_impl(port, ptr, rust_vec_len, data_len),
+        93 => wire__crate__api__settings__set_theme_impl(port, ptr, rust_vec_len, data_len),
+        94 => wire__crate__api__disputes__submit_evidence_impl(port, ptr, rust_vec_len, data_len),
+        95 => wire__crate__api__reputation__submit_rating_impl(port, ptr, rust_vec_len, data_len),
+        96 => wire__crate__api__orders__subscribe_orders_impl(port, ptr, rust_vec_len, data_len),
+        97 => wire__crate__api__orders__take_order_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }


### PR DESCRIPTION
…acy mode

Add save_mostro_node/get_active_mostro_node to Storage trait with SQLite and IndexedDB implementations. Create settings key-value table in schema. Wire order book refresh in account screen and skip rating step when privacy mode is active.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Order book refresh now performs a real runtime refresh and shows success/failure feedback.
  * Privacy mode now routes users to home and skips the rating step after trade completion.
  * Added persistent Mostro node support so a chosen node is saved and restored.
  * Manual restart of order subscriptions enabled (used by refresh flow).

* **Documentation**
  * Removed/updated TODOs and comments clarifying privacy/rating behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->