### PR TITLE
fix(trades): sync maker trade status and hold invoice from daemon

### DIFF
--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -959,6 +959,123 @@ async fn process_gift_wrap_rumor(rumor_json: &str, trade_pubkey_hex: &str) {
             // can encrypt/decrypt P2P messages and subscribe to the right p-tag.
             on_peer_pubkey_received(&order_id, trade_pubkey_hex, &peer_pubkey_hex).await;
         }
+        // Mostro sends PayInvoice to the seller with the hold invoice bolt11
+        // when a buyer takes a sell order (or a seller takes a buy order).
+        Action::PayInvoice => {
+            let order_id = match &kind.id {
+                Some(id) => id.to_string(),
+                None => {
+                    log::warn!("[orders] gift-wrap PayInvoice has no order id");
+                    return;
+                }
+            };
+            let (bolt11, amount) = match &kind.payload {
+                Some(mostro_core::message::Payload::PaymentRequest(_, pr, amt)) => {
+                    (pr.clone(), amt.map(|a| a as u64))
+                }
+                _ => {
+                    log::warn!(
+                        "[orders] gift-wrap PayInvoice payload is not a PaymentRequest"
+                    );
+                    return;
+                }
+            };
+            log::info!(
+                "[orders] gift-wrap PayInvoice: order={order_id} invoice_len={} amount={:?}",
+                bolt11.len(),
+                amount
+            );
+            // Save the hold invoice and update status to WaitingPayment in the DB.
+            if let Some(db) = crate::db::app_db::db() {
+                if let Err(e) = db
+                    .update_trade_fields(
+                        &order_id,
+                        Some(crate::api::types::OrderStatus::WaitingPayment),
+                        Some(bolt11),
+                        amount,
+                    )
+                    .await
+                {
+                    log::warn!(
+                        "[orders] failed to save hold invoice for order={order_id}: {e}"
+                    );
+                }
+            }
+        }
+        // Handle remaining status-update actions from the daemon by syncing
+        // the trade status in the DB so My Trades reflects the current state.
+        Action::WaitingSellerToPay
+        | Action::WaitingBuyerInvoice
+        | Action::BuyerInvoiceAccepted
+        | Action::FiatSentOk
+        | Action::HoldInvoicePaymentSettled
+        | Action::HoldInvoicePaymentCanceled
+        | Action::Released
+        | Action::PurchaseCompleted
+        | Action::CooperativeCancelAccepted
+        | Action::CooperativeCancelInitiatedByPeer
+        | Action::CooperativeCancelInitiatedByYou
+        | Action::DisputeInitiatedByYou
+        | Action::DisputeInitiatedByPeer
+        | Action::AdminSettled
+        | Action::AdminCanceled => {
+            let order_id = match &kind.id {
+                Some(id) => id.to_string(),
+                None => {
+                    log::debug!("[orders] gift-wrap {:?} has no order id", kind.action);
+                    return;
+                }
+            };
+            // Map action → OrderStatus for DB sync.
+            let new_status = match kind.action {
+                Action::WaitingSellerToPay => Some(crate::api::types::OrderStatus::WaitingPayment),
+                Action::WaitingBuyerInvoice => {
+                    Some(crate::api::types::OrderStatus::WaitingBuyerInvoice)
+                }
+                Action::BuyerInvoiceAccepted | Action::FiatSentOk => {
+                    Some(crate::api::types::OrderStatus::Active)
+                }
+                Action::HoldInvoicePaymentSettled | Action::Released | Action::PurchaseCompleted => {
+                    Some(crate::api::types::OrderStatus::SettledHoldInvoice)
+                }
+                Action::HoldInvoicePaymentCanceled => {
+                    Some(crate::api::types::OrderStatus::Canceled)
+                }
+                Action::CooperativeCancelAccepted => {
+                    Some(crate::api::types::OrderStatus::CooperativelyCanceled)
+                }
+                Action::CooperativeCancelInitiatedByPeer
+                | Action::CooperativeCancelInitiatedByYou => None, // status doesn't change yet
+                Action::DisputeInitiatedByYou | Action::DisputeInitiatedByPeer => {
+                    Some(crate::api::types::OrderStatus::Dispute)
+                }
+                Action::AdminSettled => Some(crate::api::types::OrderStatus::SettledByAdmin),
+                Action::AdminCanceled => Some(crate::api::types::OrderStatus::CanceledByAdmin),
+                _ => None,
+            };
+            if let Some(status) = new_status {
+                log::info!(
+                    "[orders] gift-wrap {:?}: syncing order={order_id} status={:?}",
+                    kind.action,
+                    status
+                );
+                if let Some(db) = crate::db::app_db::db() {
+                    if let Err(e) = db
+                        .update_trade_fields(&order_id, Some(status), None, None)
+                        .await
+                    {
+                        log::warn!(
+                            "[orders] failed to sync trade status for order={order_id}: {e}"
+                        );
+                    }
+                }
+            } else {
+                log::debug!(
+                    "[orders] gift-wrap {:?}: order={order_id} (no status change)",
+                    kind.action
+                );
+            }
+        }
         action => {
             log::debug!("[orders] gift-wrap unhandled action={action:?}");
         }
@@ -1108,6 +1225,23 @@ async fn subscribe_single_order(order_id: &str) {
                                 order.status
                             );
                             last_activity = tokio::time::Instant::now();
+                            // Sync trade status in DB so My Trades reflects it.
+                            if let Some(db) = crate::db::app_db::db() {
+                                if let Err(e) = db
+                                    .update_trade_fields(
+                                        &order.id,
+                                        Some(order.status.clone()),
+                                        None,
+                                        order.amount_sats,
+                                    )
+                                    .await
+                                {
+                                    log::warn!(
+                                        "[orders] failed to sync d-tag trade status for order={}: {e}",
+                                        order.id
+                                    );
+                                }
+                            }
                             order_book().upsert_order(order).await;
                         }
                     }
@@ -1270,6 +1404,21 @@ async fn _run_order_subscription() {
                                 // order book only contains the daemon's real UUID.
                                 if let Some(local_id) = take_pending_local_id(&ck) {
                                     order_book().remove_order(&local_id).await;
+                                    // Update the DB trade record so it references the
+                                    // daemon UUID — otherwise tradeStatusProvider polls
+                                    // with the stale local UUID and never finds the order.
+                                    if let Some(db) = crate::db::app_db::db() {
+                                        if let Err(e) = db
+                                            .update_trade_order_id(&local_id, &info.id)
+                                            .await
+                                        {
+                                            log::warn!(
+                                                "[orders] failed to update trade order_id \
+                                                 {local_id} → {}: {e}",
+                                                info.id
+                                            );
+                                        }
+                                    }
                                     log::info!(
                                         "[orders] replaced local order={local_id} with daemon order={}",
                                         info.id
@@ -1277,6 +1426,26 @@ async fn _run_order_subscription() {
                                 } else {
                                     log::info!(
                                         "[orders] own order={} detected via content match trade_index={trade_idx}",
+                                        info.id
+                                    );
+                                }
+                            }
+                        }
+                        // Sync trade status in DB for own orders so My Trades
+                        // reflects status changes even without gift-wrap delivery.
+                        if info.is_mine && info.status != crate::api::types::OrderStatus::Pending {
+                            if let Some(db) = crate::db::app_db::db() {
+                                if let Err(e) = db
+                                    .update_trade_fields(
+                                        &info.id,
+                                        Some(info.status.clone()),
+                                        None,
+                                        info.amount_sats,
+                                    )
+                                    .await
+                                {
+                                    log::warn!(
+                                        "[orders] failed to sync trade status for order={}: {e}",
                                         info.id
                                     );
                                 }

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -971,7 +971,15 @@ async fn process_gift_wrap_rumor(rumor_json: &str, trade_pubkey_hex: &str) {
             };
             let (bolt11, amount) = match &kind.payload {
                 Some(mostro_core::message::Payload::PaymentRequest(_, pr, amt)) => {
-                    (pr.clone(), amt.map(|a| a as u64))
+                    let sats = amt.and_then(|a| {
+                        u64::try_from(a).ok().or_else(|| {
+                            log::warn!(
+                                "[orders] gift-wrap PayInvoice: negative amount {a}, ignoring"
+                            );
+                            None
+                        })
+                    });
+                    (pr.clone(), sats)
                 }
                 _ => {
                     log::warn!(

--- a/rust/src/db/indexeddb.rs
+++ b/rust/src/db/indexeddb.rs
@@ -113,7 +113,8 @@ impl Storage for IndexedDbStorage {
         _old_order_id: &str,
         _new_order_id: &str,
     ) -> Result<()> {
-        Ok(()) // no-op: IndexedDB persistence not yet implemented
+        log::warn!("update_trade_order_id: IndexedDB backend not implemented — trade order ID will not persist");
+        Ok(())
     }
 
     async fn update_trade_fields(
@@ -123,6 +124,7 @@ impl Storage for IndexedDbStorage {
         _hold_invoice: Option<String>,
         _amount_sats: Option<u64>,
     ) -> Result<()> {
-        Ok(()) // no-op: IndexedDB persistence not yet implemented
+        log::warn!("update_trade_fields: IndexedDB backend not implemented — trade fields will not persist");
+        Ok(())
     }
 }

--- a/rust/src/db/indexeddb.rs
+++ b/rust/src/db/indexeddb.rs
@@ -107,4 +107,22 @@ impl Storage for IndexedDbStorage {
     ) -> Result<Option<crate::api::types::TradeInfo>> {
         Ok(None) // no persisted trade: role lookup returns None
     }
+
+    async fn update_trade_order_id(
+        &self,
+        _old_order_id: &str,
+        _new_order_id: &str,
+    ) -> Result<()> {
+        Ok(()) // no-op: IndexedDB persistence not yet implemented
+    }
+
+    async fn update_trade_fields(
+        &self,
+        _order_id: &str,
+        _status: Option<crate::api::types::OrderStatus>,
+        _hold_invoice: Option<String>,
+        _amount_sats: Option<u64>,
+    ) -> Result<()> {
+        Ok(()) // no-op: IndexedDB persistence not yet implemented
+    }
 }

--- a/rust/src/db/mod.rs
+++ b/rust/src/db/mod.rs
@@ -75,4 +75,26 @@ pub trait Storage: Send + Sync {
         &self,
         order_id: &str,
     ) -> Result<Option<crate::api::types::TradeInfo>>;
+
+    /// Update the order ID inside a persisted trade (e.g. local UUID → daemon UUID).
+    ///
+    /// Loads the trade whose `order.id == old_order_id`, replaces `order.id`
+    /// with `new_order_id`, and re-saves it. No-op when no matching trade exists.
+    async fn update_trade_order_id(
+        &self,
+        old_order_id: &str,
+        new_order_id: &str,
+    ) -> Result<()>;
+
+    /// Update fields on a persisted trade identified by `order.id`.
+    ///
+    /// Applies the provided mutations and re-saves. No-op when no matching
+    /// trade exists.
+    async fn update_trade_fields(
+        &self,
+        order_id: &str,
+        status: Option<crate::api::types::OrderStatus>,
+        hold_invoice: Option<String>,
+        amount_sats: Option<u64>,
+    ) -> Result<()>;
 }

--- a/rust/src/db/sqlite.rs
+++ b/rust/src/db/sqlite.rs
@@ -357,13 +357,17 @@ impl Storage for SqliteStorage {
         old_order_id: &str,
         new_order_id: &str,
     ) -> Result<()> {
-        let Some(mut trade) = self.get_trade_by_order_id(old_order_id).await? else {
-            return Ok(());
-        };
-        trade.order.id = new_order_id.to_string();
-        // Delete the old row (keyed by trade.id which hasn't changed) and re-save
-        // with the updated order.id embedded in the JSON blob.
-        self.save_trade(&trade).await
+        // Atomic single-statement update via json_set — no read-modify-write race.
+        sqlx::query(
+            "UPDATE trades \
+             SET data = json_set(data, '$.order.id', ?) \
+             WHERE json_extract(data, '$.order.id') = ?",
+        )
+        .bind(new_order_id)
+        .bind(old_order_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
     }
 
     async fn update_trade_fields(
@@ -373,18 +377,50 @@ impl Storage for SqliteStorage {
         hold_invoice: Option<String>,
         amount_sats: Option<u64>,
     ) -> Result<()> {
-        let Some(mut trade) = self.get_trade_by_order_id(order_id).await? else {
-            return Ok(());
-        };
-        if let Some(s) = status {
-            trade.order.status = s;
+        // Build the update atomically with json_set to avoid read-modify-write races.
+        // Start from `data` and layer each mutation.
+        let mut set_expr = String::from("data");
+        let mut binds: Vec<String> = Vec::new();
+
+        if let Some(ref s) = status {
+            let status_json = serde_json::to_string(s)?;
+            set_expr = format!("json_set({set_expr}, '$.order.status', json(?))");
+            binds.push(status_json);
         }
-        if hold_invoice.is_some() {
-            trade.hold_invoice = hold_invoice;
+        if let Some(ref inv) = hold_invoice {
+            set_expr = format!("json_set({set_expr}, '$.hold_invoice', ?)");
+            binds.push(inv.clone());
         }
         if let Some(sats) = amount_sats {
-            trade.order.amount_sats = Some(sats);
+            set_expr = format!("json_set({set_expr}, '$.order.amount_sats', ?)");
+            binds.push(sats.to_string());
         }
-        self.save_trade(&trade).await
+
+        if binds.is_empty() {
+            return Ok(());
+        }
+
+        // Also update the denormalised `status` column when status changes.
+        let status_col_update = if status.is_some() {
+            ", status = ?"
+        } else {
+            ""
+        };
+
+        let sql = format!(
+            "UPDATE trades SET data = {set_expr}{status_col_update} \
+             WHERE json_extract(data, '$.order.id') = ?"
+        );
+
+        let mut query = sqlx::query(&sql);
+        for val in &binds {
+            query = query.bind(val);
+        }
+        if let Some(ref s) = status {
+            query = query.bind(format!("{s:?}"));
+        }
+        query = query.bind(order_id);
+        query.execute(&self.pool).await?;
+        Ok(())
     }
 }

--- a/rust/src/db/sqlite.rs
+++ b/rust/src/db/sqlite.rs
@@ -351,4 +351,40 @@ impl Storage for SqliteStorage {
         .await?;
         Ok(row.map(|(data,)| serde_json::from_str(&data)).transpose()?)
     }
+
+    async fn update_trade_order_id(
+        &self,
+        old_order_id: &str,
+        new_order_id: &str,
+    ) -> Result<()> {
+        let Some(mut trade) = self.get_trade_by_order_id(old_order_id).await? else {
+            return Ok(());
+        };
+        trade.order.id = new_order_id.to_string();
+        // Delete the old row (keyed by trade.id which hasn't changed) and re-save
+        // with the updated order.id embedded in the JSON blob.
+        self.save_trade(&trade).await
+    }
+
+    async fn update_trade_fields(
+        &self,
+        order_id: &str,
+        status: Option<crate::api::types::OrderStatus>,
+        hold_invoice: Option<String>,
+        amount_sats: Option<u64>,
+    ) -> Result<()> {
+        let Some(mut trade) = self.get_trade_by_order_id(order_id).await? else {
+            return Ok(());
+        };
+        if let Some(s) = status {
+            trade.order.status = s;
+        }
+        if hold_invoice.is_some() {
+            trade.hold_invoice = hold_invoice;
+        }
+        if let Some(sats) = amount_sats {
+            trade.order.amount_sats = Some(sats);
+        }
+        self.save_trade(&trade).await
+    }
 }


### PR DESCRIPTION
The maker's TradeInfo in the DB was never updated after creation:

- The local UUID was not replaced with the daemon-assigned UUID, so tradeStatusProvider polled with a stale ID and never found the order in the order book cache — status stayed "Pending" forever.

- Action::PayInvoice gift wraps were unhandled, so the hold invoice was never extracted or saved — the seller never saw the payment screen when a buyer took their order.

- Kind 38383 status changes were reflected in the order book cache but never persisted to the trades DB, causing stale status on app restart.

Adds update_trade_order_id and update_trade_fields to the Storage trait and wires them into the order subscription loop, single-order subscription, and gift-wrap rumor dispatch for PayInvoice and other status actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of payment requests to capture invoice and amount details and reflect them in order records.
  * Broader automatic synchronization of trade statuses across queued actions and subscriptions, keeping local order views up to date.

* **Bug Fixes**
  * Prevents stale order identifiers by updating mappings when daemon IDs replace local IDs.
  * Browser storage backend now explicitly no-ops unsupported updates and logs warnings instead of failing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->