### PR TITLE
fix(orders): seller pay-invoice flow, NIP-13 PoW, order ID reconcilia…

### DIFF
--- a/lib/features/order/screens/add_order_screen.dart
+++ b/lib/features/order/screens/add_order_screen.dart
@@ -126,7 +126,7 @@ class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
             : null,
       );
 
-      await rust_orders.createOrder(params: params);
+      final order = await rust_orders.createOrder(params: params);
 
       // Persist the updated trade key index so it survives app restarts.
       // Failures here are non-fatal — the order was already created.
@@ -142,7 +142,7 @@ class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
       refreshTrades(ref);
 
       if (!mounted) return;
-      context.go(AppRoute.orderBook);
+      context.go(AppRoute.myOrderPath(order.id));
     } catch (e) {
       if (!mounted) return;
       // CantDo rejections from Mostro arrive as errors from createOrder.

--- a/lib/features/order/screens/my_order_screen.dart
+++ b/lib/features/order/screens/my_order_screen.dart
@@ -7,6 +7,7 @@ import 'package:intl/intl.dart';
 import 'package:mostro/core/app_routes.dart';
 import 'package:mostro/core/app_theme.dart';
 import 'package:mostro/features/home/providers/home_order_providers.dart';
+import 'package:mostro/features/order/providers/trade_state_provider.dart';
 import 'package:mostro/features/trades/providers/trades_providers.dart';
 import 'package:mostro/l10n/app_localizations.dart';
 import 'package:mostro/shared/utils/fiat_currencies.dart';
@@ -31,6 +32,7 @@ class MyOrderScreen extends ConsumerStatefulWidget {
 
 class _MyOrderScreenState extends ConsumerState<MyOrderScreen> {
   bool _cancelling = false;
+  bool _hasNavigated = false;
 
   Future<void> _onCancel() async {
     final l10n = AppLocalizations.of(context);
@@ -79,6 +81,13 @@ class _MyOrderScreenState extends ConsumerState<MyOrderScreen> {
 
   @override
   Widget build(BuildContext context) {
+    // Watch the live trade status FIRST — before any early return — so the
+    // provider stays subscribed even when the order book temporarily drops
+    // the order (Kind 38383 set_orders replaces the list with only pending
+    // orders, removing taken ones).
+    final liveStatus =
+        ref.watch(tradeStatusProvider(widget.orderId)).valueOrNull;
+
     final orders = ref.watch(orderBookProvider).valueOrNull ?? [];
     var order = orders.where((o) => o.id == widget.orderId).firstOrNull;
     // Fallback to the persisted trade DB when the order is no longer in the
@@ -111,14 +120,51 @@ class _MyOrderScreenState extends ConsumerState<MyOrderScreen> {
     }
     final resolvedOrder = order;
 
+    // Auto-navigate when the order is taken and status transitions away
+    // from Pending.
+    final isSelling = resolvedOrder.kind == 'sell';
+
+    debugPrint('[MyOrderScreen] build: orderId=${widget.orderId} '
+        'isSelling=$isSelling liveStatus=$liveStatus '
+        'hasNavigated=$_hasNavigated orderStatus=${resolvedOrder.status}');
+
+    if (!_hasNavigated && liveStatus != null && liveStatus != OrderStatus.pending) {
+      // Seller: skip intermediate WaitingBuyerInvoice.
+      final skip = (isSelling && liveStatus == OrderStatus.waitingBuyerInvoice) ||
+          (!isSelling && liveStatus == OrderStatus.waitingPayment);
+
+      debugPrint('[MyOrderScreen] non-pending status detected: $liveStatus skip=$skip');
+
+      if (!skip) {
+        _hasNavigated = true;
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted) return;
+          if (liveStatus == OrderStatus.waitingPayment && isSelling) {
+            debugPrint('[MyOrderScreen] navigating to PayLightningInvoiceScreen');
+            context.go(AppRoute.payInvoicePath(widget.orderId));
+          } else if (liveStatus == OrderStatus.waitingBuyerInvoice &&
+              !isSelling) {
+            context.go(AppRoute.addInvoicePath(widget.orderId));
+          } else {
+            context.go(AppRoute.tradeDetailPath(widget.orderId));
+          }
+        });
+      }
+    }
+
     final l10n = AppLocalizations.of(context);
     final flag = flags[resolvedOrder.fiatCode] ?? '';
-    final isSelling = resolvedOrder.kind == 'sell';
     final title = isSelling ? l10n.myOrderSellTitle : l10n.myOrderBuyTitle;
     final premiumPositive = resolvedOrder.premium >= 0;
 
     return Scaffold(
-      appBar: AppBar(title: Text(title)),
+      appBar: AppBar(
+        title: Text(title),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.go(AppRoute.home),
+        ),
+      ),
       body: ListView(
         padding: const EdgeInsets.all(AppSpacing.lg),
         children: [
@@ -245,7 +291,9 @@ class _MyOrderScreenState extends ConsumerState<MyOrderScreen> {
             children: [
               Expanded(
                 child: OutlinedButton(
-                  onPressed: () => context.pop(),
+                  onPressed: () => context.canPop()
+                      ? context.pop()
+                      : context.go(AppRoute.home),
                   style: OutlinedButton.styleFrom(
                     foregroundColor: green,
                     side: BorderSide(color: green),

--- a/lib/features/order/screens/my_order_screen.dart
+++ b/lib/features/order/screens/my_order_screen.dart
@@ -162,7 +162,9 @@ class _MyOrderScreenState extends ConsumerState<MyOrderScreen> {
         title: Text(title),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
-          onPressed: () => context.go(AppRoute.home),
+          onPressed: () => context.canPop()
+              ? context.pop()
+              : context.go(AppRoute.home),
         ),
       ),
       body: ListView(

--- a/rust/src/api/nostr.rs
+++ b/rust/src/api/nostr.rs
@@ -53,6 +53,8 @@ pub async fn initialize(relays: Option<Vec<String>>) -> Result<()> {
                     let _ = flush_message_queue().await;
                     // Start (or re-start) Kind 38383 order book subscription.
                     crate::api::orders::subscribe_orders().await;
+                    // Fetch PoW requirement from the daemon's Kind 38385 event.
+                    fetch_and_set_pow().await;
                 }
                 Ok(state) => {
                     log::info!("[nostr] connection state changed: {state:?}");
@@ -204,6 +206,31 @@ pub async fn fetch_mostro_instance_tags(
         Ok(Some(tags))
     } else {
         Ok(None)
+    }
+}
+
+/// Fetch the Mostro daemon's PoW requirement from its Kind 38385 event
+/// and store it globally.  Called each time the relay pool goes Online so
+/// the value stays current if the daemon updates its configuration.
+async fn fetch_and_set_pow() {
+    let mostro_pubkey_hex = crate::config::active_mostro_pubkey();
+    match fetch_mostro_instance_tags(mostro_pubkey_hex).await {
+        Ok(Some(tags)) => {
+            let difficulty = tags
+                .iter()
+                .find(|t| t.first().map(|s| s.as_str()) == Some("pow"))
+                .and_then(|t| t.get(1))
+                .and_then(|v| v.parse::<u8>().ok())
+                .unwrap_or(0);
+            crate::mostro::pow::set_pow(difficulty);
+        }
+        Ok(None) => {
+            log::warn!("[nostr] no Kind 38385 event found — PoW defaults to 0");
+            crate::mostro::pow::set_pow(0);
+        }
+        Err(e) => {
+            log::warn!("[nostr] failed to fetch Kind 38385 for PoW: {e}");
+        }
     }
 }
 

--- a/rust/src/api/nostr.rs
+++ b/rust/src/api/nostr.rs
@@ -49,12 +49,13 @@ pub async fn initialize(relays: Option<Vec<String>>) -> Result<()> {
         loop {
             match rx.recv().await {
                 Ok(ConnectionState::Online) => {
-                    log::info!("[nostr] relay pool ONLINE — flushing queue + subscribing orders");
+                    log::info!("[nostr] relay pool ONLINE — fetching PoW, flushing queue, subscribing orders");
+                    // Fetch PoW first so queued messages are wrapped with the
+                    // correct difficulty before being flushed.
+                    fetch_and_set_pow().await;
                     let _ = flush_message_queue().await;
                     // Start (or re-start) Kind 38383 order book subscription.
                     crate::api::orders::subscribe_orders().await;
-                    // Fetch PoW requirement from the daemon's Kind 38385 event.
-                    fetch_and_set_pow().await;
                 }
                 Ok(state) => {
                     log::info!("[nostr] connection state changed: {state:?}");
@@ -216,12 +217,19 @@ async fn fetch_and_set_pow() {
     let mostro_pubkey_hex = crate::config::active_mostro_pubkey();
     match fetch_mostro_instance_tags(mostro_pubkey_hex).await {
         Ok(Some(tags)) => {
-            let difficulty = tags
+            let pow_tag = tags
                 .iter()
-                .find(|t| t.first().map(|s| s.as_str()) == Some("pow"))
-                .and_then(|t| t.get(1))
-                .and_then(|v| v.parse::<u8>().ok())
-                .unwrap_or(0);
+                .find(|t| t.first().map(|s| s.as_str()) == Some("pow"));
+            let difficulty = match pow_tag.and_then(|t| t.get(1)) {
+                Some(v) => match v.parse::<u8>() {
+                    Ok(d) => d,
+                    Err(_) => {
+                        log::warn!("[nostr] malformed pow tag value: {v:?} — defaulting to 0");
+                        0
+                    }
+                },
+                None => 0,
+            };
             crate::mostro::pow::set_pow(difficulty);
         }
         Ok(None) => {

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -976,7 +976,7 @@ pub(crate) async fn subscribe_gift_wraps(trade_pubkey: nostr_sdk::PublicKey, tra
                     };
                     match crate::nostr::gift_wrap::unwrap(&recipient_keys, &event_json).await {
                         Ok(rumor_json) => {
-                            process_gift_wrap_rumor(&rumor_json, &trade_pubkey_hex).await;
+                            process_gift_wrap_rumor(&rumor_json, &trade_pubkey_hex, trade_index).await;
                             last_activity = tokio::time::Instant::now();
                         }
                         Err(e) => crate::api::logging::blog_warn("gift-wrap", format!(
@@ -998,7 +998,7 @@ pub(crate) async fn subscribe_gift_wraps(trade_pubkey: nostr_sdk::PublicKey, tra
 }
 
 /// Parse the inner rumor JSON from a decrypted gift-wrap and dispatch by action.
-async fn process_gift_wrap_rumor(rumor_json: &str, trade_pubkey_hex: &str) {
+async fn process_gift_wrap_rumor(rumor_json: &str, trade_pubkey_hex: &str, trade_index: u32) {
     use mostro_core::message::{Action, Message};
 
     // The rumor is a serialised UnsignedEvent; extract its content string.
@@ -1053,6 +1053,34 @@ async fn process_gift_wrap_rumor(rumor_json: &str, trade_pubkey_hex: &str) {
         "action={:?} order_id={:?} trade_index={:?} trade_pubkey={} payload={}",
         kind.action, kind.id, kind.trade_index, &trade_pubkey_hex[..8], payload_desc
     ));
+
+    // Reconcile local UUID → daemon UUID if needed.  Gift wrap actions
+    // arrive with the daemon's order ID, but if create_order timed out the
+    // order book and DB still use the local UUID.  Reconcile before any
+    // status update so that update_order_status / update_trade_fields find
+    // the order by the daemon ID.
+    if let Some(daemon_id) = &kind.id {
+        let did = daemon_id.to_string();
+        if order_book().get_order(&did).await.is_none() {
+            if let Some(db) = crate::db::app_db::db() {
+                if let Ok(Some(local_id)) = db.get_order_id_by_trade_index(trade_index).await {
+                    if local_id != did {
+                        log::info!(
+                            "[orders] reconciling order ID: local={local_id} → daemon={did}"
+                        );
+                        if let Some(mut info) = order_book().get_order(&local_id).await {
+                            order_book().remove_order(&local_id).await;
+                            info.id = did.clone();
+                            order_book().upsert_order(info).await;
+                        }
+                        let _ = db.update_trade_order_id(&local_id, &did).await;
+                        let _ = db.save_trade_key(&did, trade_index).await;
+                        store_trade_key_index(&did, trade_index).await;
+                    }
+                }
+            }
+        }
+    }
 
     match &kind.action {
         Action::NewOrder => {
@@ -1217,13 +1245,20 @@ async fn process_gift_wrap_rumor(rumor_json: &str, trade_pubkey_hex: &str) {
                 }
             };
             let (bolt11, amount) = match &kind.payload {
-                Some(mostro_core::message::Payload::PaymentRequest(_, pr, amt)) => {
+                Some(mostro_core::message::Payload::PaymentRequest(small_order, pr, amt)) => {
                     let sats = amt.and_then(|a| {
                         u64::try_from(a).ok().or_else(|| {
                             log::warn!(
                                 "[orders] gift-wrap PayInvoice: negative amount {a}, ignoring"
                             );
                             None
+                        })
+                    }).or_else(|| {
+                        // Fallback: extract amount from the SmallOrder when the
+                        // third PaymentRequest field is None.
+                        small_order.as_ref().and_then(|so| {
+                            let a = so.amount;
+                            if a > 0 { Some(a as u64) } else { None }
                         })
                     });
                     (pr.clone(), sats)
@@ -1681,14 +1716,14 @@ async fn handle_global_gift_wrap(
     trade_key_map: &HashMap<String, (nostr_sdk::Keys, u32)>,
 ) {
     // Find the p-tag that matches one of our trade keys.
-    let (recipient_hex, recipient_keys) = {
+    let (recipient_hex, recipient_keys, trade_idx) = {
         let mut found = None;
         for tag in event.tags.iter() {
             let s = tag.as_slice();
             if s.first().map(|v| v.as_str()) == Some("p") {
                 if let Some(pk_hex) = s.get(1).map(|v| v.as_str()) {
-                    if let Some((keys, _idx)) = trade_key_map.get(pk_hex) {
-                        found = Some((pk_hex.to_string(), keys.clone()));
+                    if let Some((keys, idx)) = trade_key_map.get(pk_hex) {
+                        found = Some((pk_hex.to_string(), keys.clone(), *idx));
                         break;
                     }
                 }
@@ -1723,7 +1758,7 @@ async fn handle_global_gift_wrap(
     };
     match crate::nostr::gift_wrap::unwrap(&recipient_keys, &event_json).await {
         Ok(rumor_json) => {
-            process_gift_wrap_rumor(&rumor_json, &recipient_hex).await;
+            process_gift_wrap_rumor(&rumor_json, &recipient_hex, trade_idx).await;
         }
         Err(e) => crate::api::logging::blog_warn("gift-wrap", format!(
             "decrypt failed for trade={}: {e}", &recipient_hex[..8]

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -1074,7 +1074,13 @@ async fn process_gift_wrap_rumor(rumor_json: &str, trade_pubkey_hex: &str, trade
                             order_book().upsert_order(info).await;
                         }
                         let _ = db.update_trade_order_id(&local_id, &did).await;
+                        // Replace the stale local_id → trade_index mapping
+                        // with daemon_id → trade_index in both DB and memory.
+                        let _ = db.delete_trade_key(&local_id).await;
                         let _ = db.save_trade_key(&did, trade_index).await;
+                        if let Ok(mut map) = trade_key_map().write() {
+                            map.remove(&local_id);
+                        }
                         store_trade_key_index(&did, trade_index).await;
                     }
                 }

--- a/rust/src/db/indexeddb.rs
+++ b/rust/src/db/indexeddb.rs
@@ -93,6 +93,10 @@ impl Storage for IndexedDbStorage {
         Ok(None) // IndexedDB not yet implemented
     }
 
+    async fn delete_trade_key(&self, _order_id: &str) -> Result<()> {
+        Ok(()) // IndexedDB not yet implemented
+    }
+
     async fn save_mostro_node(&self, _node: &crate::api::types::MostroNodeInfo) -> Result<()> {
         log::warn!("save_mostro_node: IndexedDB backend not implemented — node selection will not survive reload");
         // TODO(#93): implement IndexedDB persistence for Mostro node selection

--- a/rust/src/db/indexeddb.rs
+++ b/rust/src/db/indexeddb.rs
@@ -89,6 +89,10 @@ impl Storage for IndexedDbStorage {
         Ok(None) // no persisted key: caller will treat absence correctly
     }
 
+    async fn get_order_id_by_trade_index(&self, _key_index: u32) -> Result<Option<String>> {
+        Ok(None) // IndexedDB not yet implemented
+    }
+
     async fn save_mostro_node(&self, _node: &crate::api::types::MostroNodeInfo) -> Result<()> {
         log::warn!("save_mostro_node: IndexedDB backend not implemented — node selection will not survive reload");
         // TODO(#93): implement IndexedDB persistence for Mostro node selection

--- a/rust/src/db/mod.rs
+++ b/rust/src/db/mod.rs
@@ -62,6 +62,9 @@ pub trait Storage: Send + Sync {
     /// Retrieve the BIP-32 key index for `order_id`, or `None` if not found.
     async fn get_trade_key(&self, order_id: &str) -> Result<Option<u32>>;
 
+    /// Reverse lookup: find the order ID associated with a given trade key index.
+    async fn get_order_id_by_trade_index(&self, key_index: u32) -> Result<Option<String>>;
+
     // ── Settings / Mostro node ────────────────────────────────────────────────
 
     /// Persist a Mostro node info record, replacing any existing one.

--- a/rust/src/db/mod.rs
+++ b/rust/src/db/mod.rs
@@ -65,6 +65,9 @@ pub trait Storage: Send + Sync {
     /// Reverse lookup: find the order ID associated with a given trade key index.
     async fn get_order_id_by_trade_index(&self, key_index: u32) -> Result<Option<String>>;
 
+    /// Delete the trade key entry for `order_id`.
+    async fn delete_trade_key(&self, order_id: &str) -> Result<()>;
+
     // ── Settings / Mostro node ────────────────────────────────────────────────
 
     /// Persist a Mostro node info record, replacing any existing one.

--- a/rust/src/db/sqlite.rs
+++ b/rust/src/db/sqlite.rs
@@ -328,6 +328,14 @@ impl Storage for SqliteStorage {
         Ok(row.map(|(id,)| id))
     }
 
+    async fn delete_trade_key(&self, order_id: &str) -> Result<()> {
+        sqlx::query("DELETE FROM trade_keys WHERE order_id = ?")
+            .bind(order_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
     async fn save_mostro_node(&self, node: &crate::api::types::MostroNodeInfo) -> Result<()> {
         let json = serde_json::to_string(node)?;
         sqlx::query(

--- a/rust/src/db/sqlite.rs
+++ b/rust/src/db/sqlite.rs
@@ -319,6 +319,15 @@ impl Storage for SqliteStorage {
         Ok(row.map(|(idx,)| idx as u32))
     }
 
+    async fn get_order_id_by_trade_index(&self, key_index: u32) -> Result<Option<String>> {
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT order_id FROM trade_keys WHERE key_index = ? LIMIT 1")
+                .bind(key_index as i64)
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(row.map(|(id,)| id))
+    }
+
     async fn save_mostro_node(&self, node: &crate::api::types::MostroNodeInfo) -> Result<()> {
         let json = serde_json::to_string(node)?;
         sqlx::query(

--- a/rust/src/mostro/mod.rs
+++ b/rust/src/mostro/mod.rs
@@ -1,3 +1,4 @@
 pub mod actions;
 pub mod fsm;
+pub mod pow;
 pub mod session;

--- a/rust/src/mostro/pow.rs
+++ b/rust/src/mostro/pow.rs
@@ -1,0 +1,18 @@
+/// Global NIP-13 Proof of Work difficulty required by the connected Mostro.
+///
+/// Set when the relay pool goes online by parsing the `pow` tag from
+/// the daemon's Kind 38385 event.  Read by `gift_wrap::wrap` before signing.
+use std::sync::atomic::{AtomicU8, Ordering};
+
+static POW_DIFFICULTY: AtomicU8 = AtomicU8::new(0);
+
+/// Store the required PoW difficulty for outgoing events.
+pub fn set_pow(difficulty: u8) {
+    POW_DIFFICULTY.store(difficulty, Ordering::Relaxed);
+    log::info!("[pow] difficulty set to {difficulty}");
+}
+
+/// Current PoW difficulty.  Returns 0 when no PoW is required.
+pub fn get_pow() -> u8 {
+    POW_DIFFICULTY.load(Ordering::Relaxed)
+}

--- a/rust/src/nostr/gift_wrap.rs
+++ b/rust/src/nostr/gift_wrap.rs
@@ -10,6 +10,10 @@ use nostr_sdk::prelude::*;
 /// Wrap a plaintext message as a NIP-59 Gift Wrap event addressed to
 /// `recipient_pubkey`, signed by `sender_keys`.
 ///
+/// When the connected Mostro requires NIP-13 Proof of Work the difficulty
+/// is applied to the **gift wrap** (the outer Kind 1059 event).  The daemon
+/// validates `event.check_pow(pow)` on the gift wrap before unwrapping.
+///
 /// Returns the serialised `Event` JSON ready for publication.
 pub async fn wrap(
     sender_keys: &Keys,
@@ -19,17 +23,35 @@ pub async fn wrap(
 ) -> Result<String> {
     let rumor = EventBuilder::new(kind, content).build(sender_keys.public_key());
 
-    let seal_builder = EventBuilder::seal(sender_keys, recipient_pubkey, rumor)
+    let seal = EventBuilder::seal(sender_keys, recipient_pubkey, rumor)
         .await
-        .map_err(|e| anyhow!("NIP-59 seal failed: {e}"))?;
-
-    let seal = seal_builder
+        .map_err(|e| anyhow!("NIP-59 seal failed: {e}"))?
         .sign_with_keys(sender_keys)
         .map_err(|e| anyhow!("seal sign failed: {e}"))?;
 
-    let gift_wrap =
+    let pow = crate::mostro::pow::get_pow();
+    let gift_wrap = if pow > 0 {
+        // Build the gift wrap manually so we can inject .pow() — the SDK's
+        // gift_wrap_from_seal helper doesn't support NIP-13.
+        let ephemeral_keys = Keys::generate();
+        let encrypted = nip44::encrypt(
+            ephemeral_keys.secret_key(),
+            recipient_pubkey,
+            seal.as_json(),
+            nip44::Version::default(),
+        )
+        .map_err(|e| anyhow!("NIP-44 encrypt failed: {e}"))?;
+
+        EventBuilder::new(Kind::GiftWrap, encrypted)
+            .tag(Tag::public_key(*recipient_pubkey))
+            .custom_created_at(Timestamp::tweaked(nip59::RANGE_RANDOM_TIMESTAMP_TWEAK))
+            .pow(pow)
+            .sign_with_keys(&ephemeral_keys)
+            .map_err(|e| anyhow!("gift wrap sign+pow failed: {e}"))?
+    } else {
         EventBuilder::gift_wrap_from_seal(recipient_pubkey, &seal, [])
-            .map_err(|e| anyhow!("NIP-59 gift_wrap failed: {e}"))?;
+            .map_err(|e| anyhow!("NIP-59 gift_wrap failed: {e}"))?
+    };
 
     Ok(gift_wrap.as_json())
 }


### PR DESCRIPTION
…tion

- Navigate seller to PayLightningInvoiceScreen when hold invoice arrives after order is taken (MyOrderScreen auto-detects WaitingPayment status)
- Watch tradeStatusProvider before any early return so the subscription stays active even when the order book drops taken orders
- After creating an order, navigate to MyOrderScreen instead of the order book so the auto-navigation logic can fire
- Fix MyOrderScreen back/close buttons when navigated via context.go

- Add NIP-13 Proof of Work support: fetch pow difficulty from the daemon's Kind 38385 event on connect, apply it to the gift wrap outer event so it passes the daemon's check_pow validation

- Reconcile local UUID → daemon UUID early in the gift wrap handler (before any status update) so that late-confirmed orders still receive status updates correctly

- Extract amount from SmallOrder in PayInvoice handler when the PaymentRequest's third field is None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Orders now navigate to their individual detail view after creation
  * Real-time order status monitoring with automatic navigation as trades progress

* **Improvements**
  * Improved back/close behaviors on order screens for more predictable routing
  * Better order–trade reconciliation to reduce mismatches and improve reliability
  * Relay PoW handling for wrapped messages to improve compatibility/resilience
<!-- end of auto-generated comment: release notes by coderabbit.ai -->