### PR TITLE
feat(nip59): migrate gift-wrap transport to mostro-core 0.9

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1616,13 +1616,13 @@ dependencies = [
 
 [[package]]
 name = "mostro-core"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced1a5f76ef1eba9d0203ec0389598fcbdb3b683cd08131be232e9371f2d8054"
+checksum = "8e323335185f1cd0ea3369d03b431fb36c6fa6aa864e20fc647d1195ff26bb22"
 dependencies = [
  "bitcoin",
  "chrono",
- "nostr-sdk 0.43.0",
+ "nostr-sdk",
  "serde",
  "serde_json",
  "uuid",
@@ -1634,29 +1634,6 @@ name = "negentropy"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0efe882e02d206d8d279c20eb40e03baf7cb5136a1476dc084a324fbc3ec42d"
-
-[[package]]
-name = "nostr"
-version = "0.43.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62a97d745f1bd8d5e05a978632bbb87b0614567d5142906fe7c86fb2440faac6"
-dependencies = [
- "base64",
- "bech32",
- "bip39",
- "bitcoin_hashes",
- "cbc",
- "chacha20 0.9.1",
- "chacha20poly1305",
- "getrandom 0.2.17",
- "instant",
- "scrypt",
- "secp256k1 0.29.1",
- "serde",
- "serde_json",
- "unicode-normalization",
- "url",
-]
 
 [[package]]
 name = "nostr"
@@ -1685,23 +1662,12 @@ dependencies = [
 
 [[package]]
 name = "nostr-database"
-version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c75a8c2175d2785ba73cfddef21d1e30da5fbbdf158569b6808ba44973a15b"
-dependencies = [
- "lru",
- "nostr 0.43.1",
- "tokio",
-]
-
-[[package]]
-name = "nostr-database"
 version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7462c9d8ae5ef6a28d66a192d399ad2530f1f2130b13186296dbb11bdef5b3d1"
 dependencies = [
  "lru",
- "nostr 0.44.2",
+ "nostr",
  "tokio",
 ]
 
@@ -1711,24 +1677,7 @@ version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade30de16869618919c6b5efc8258f47b654a98b51541eb77f85e8ec5e3c83a6"
 dependencies = [
- "nostr 0.44.2",
-]
-
-[[package]]
-name = "nostr-relay-pool"
-version = "0.43.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2f43b70d13dfc50508a13cd902e11f4625312b2ce0e4b7c4c2283fd04001bd"
-dependencies = [
- "async-utility",
- "async-wsocket",
- "atomic-destructor",
- "lru",
- "negentropy",
- "nostr 0.43.1",
- "nostr-database 0.43.0",
- "tokio",
- "tracing",
+ "nostr",
 ]
 
 [[package]]
@@ -1743,23 +1692,10 @@ dependencies = [
  "hex",
  "lru",
  "negentropy",
- "nostr 0.44.2",
- "nostr-database 0.44.0",
+ "nostr",
+ "nostr-database",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "nostr-sdk"
-version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "599f8963d6a1522a13b1a2b0ea6e168acfc367706606f1d33fa595e91fa22db0"
-dependencies = [
- "async-utility",
- "nostr 0.43.1",
- "nostr-database 0.43.0",
- "nostr-relay-pool 0.43.1",
- "tokio",
 ]
 
 [[package]]
@@ -1769,10 +1705,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "471732576710e779b64f04c55e3f8b5292f865fea228436daf19694f0bf70393"
 dependencies = [
  "async-utility",
- "nostr 0.44.2",
- "nostr-database 0.44.0",
+ "nostr",
+ "nostr-database",
  "nostr-gossip",
- "nostr-relay-pool 0.44.0",
+ "nostr-relay-pool",
  "tokio",
  "tracing",
 ]
@@ -2335,7 +2271,7 @@ dependencies = [
  "k256",
  "log",
  "mostro-core",
- "nostr-sdk 0.44.1",
+ "nostr-sdk",
  "rand 0.8.5",
  "reqwest",
  "serde",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,7 +11,7 @@ flutter_rust_bridge = "=2.11.1"
 
 # Nostr & Mostro protocol
 nostr-sdk = { version = "0.44", default-features = false, features = ["nip44", "nip47", "nip59"] }
-mostro-core = "0.8.0"
+mostro-core = "0.9.0"
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,7 +11,7 @@ flutter_rust_bridge = "=2.11.1"
 
 # Nostr & Mostro protocol
 nostr-sdk = { version = "0.44", default-features = false, features = ["nip44", "nip47", "nip59"] }
-mostro-core = "0.9.0"
+mostro-core = "0.9"
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -973,10 +973,11 @@ pub(crate) async fn subscribe_gift_wraps(trade_pubkey: nostr_sdk::PublicKey, tra
                             last_activity = tokio::time::Instant::now();
                         }
                         Ok(None) => {
-                            // Wrap was not addressed to this trade key — the per-trade
-                            // filter already matched, so this is either a relay echo
-                            // or a legitimate "wrong key" after a p-tag collision.
-                            crate::api::logging::blog_warn("gift-wrap", format!(
+                            // The per-trade filter already narrowed by p-tag, so this
+                            // only fires if a relay delivers a wrap whose outer NIP-44
+                            // layer doesn't decrypt under our key — not actionable, and
+                            // cheap for a hostile relay to spam. Keep it at debug.
+                            crate::api::logging::blog_debug("gift-wrap", format!(
                                 "decrypt returned None for trade={}", &trade_pubkey_hex[..8]
                             ));
                         }

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -967,17 +967,18 @@ pub(crate) async fn subscribe_gift_wraps(trade_pubkey: nostr_sdk::PublicKey, tra
                         &event.pubkey.to_hex()[..8],
                         &eid[..16],
                     ));
-                    let event_json = match serde_json::to_string(&*event) {
-                        Ok(j) => j,
-                        Err(e) => {
-                            crate::api::logging::blog_warn("gift-wrap", format!("event serialize failed: {e}"));
-                            continue;
-                        }
-                    };
-                    match crate::nostr::gift_wrap::unwrap(&recipient_keys, &event_json).await {
-                        Ok(rumor_json) => {
-                            process_gift_wrap_rumor(&rumor_json, &trade_pubkey_hex, trade_index).await;
+                    match crate::nostr::gift_wrap::unwrap_mostro_message(&recipient_keys, &event).await {
+                        Ok(Some(unwrapped)) => {
+                            dispatch_mostro_message(unwrapped, &trade_pubkey_hex, trade_index).await;
                             last_activity = tokio::time::Instant::now();
+                        }
+                        Ok(None) => {
+                            // Wrap was not addressed to this trade key — the per-trade
+                            // filter already matched, so this is either a relay echo
+                            // or a legitimate "wrong key" after a p-tag collision.
+                            crate::api::logging::blog_warn("gift-wrap", format!(
+                                "decrypt returned None for trade={}", &trade_pubkey_hex[..8]
+                            ));
                         }
                         Err(e) => crate::api::logging::blog_warn("gift-wrap", format!(
                             "decrypt failed for trade={}: {e}", &trade_pubkey_hex[..8]
@@ -997,40 +998,57 @@ pub(crate) async fn subscribe_gift_wraps(trade_pubkey: nostr_sdk::PublicKey, tra
     });
 }
 
-/// Parse the inner rumor JSON from a decrypted gift-wrap and dispatch by action.
-async fn process_gift_wrap_rumor(rumor_json: &str, trade_pubkey_hex: &str, trade_index: u32) {
-    use mostro_core::message::{Action, Message};
+/// Dispatch a Mostro `Message` recovered from a gift-wrap.
+///
+/// Authenticates the sender against the active Mostro pubkey, runs the
+/// centralized `validate_response` check (catches `CantDo` responses and
+/// malformed `request_id` fields), then routes by action.
+async fn dispatch_mostro_message(
+    unwrapped: mostro_core::nip59::UnwrappedMessage,
+    trade_pubkey_hex: &str,
+    trade_index: u32,
+) {
+    use mostro_core::message::Action;
 
-    // The rumor is a serialised UnsignedEvent; extract its content string.
-    let content = match serde_json::from_str::<serde_json::Value>(rumor_json) {
-        Ok(v) => match v.get("content").and_then(|c| c.as_str()) {
-            Some(s) => s.to_string(),
-            None => {
-                crate::api::logging::blog_warn("gift-wrap", format!(
-                    "rumor has no content field for trade={}", &trade_pubkey_hex[..8]
-                ));
-                return;
-            }
-        },
-        Err(e) => {
+    let mostro_core::nip59::UnwrappedMessage {
+        message: msg,
+        sender,
+        signature: _,
+        created_at: _,
+    } = unwrapped;
+
+    // Daemon authentication: the active Mostro pubkey is the only legitimate
+    // sender for protocol responses. Reject anything else loudly — previously
+    // we trusted whatever decrypted under our trade key.
+    match nostr_sdk::PublicKey::from_hex(&crate::config::active_mostro_pubkey()) {
+        Ok(expected) if expected == sender => {}
+        Ok(expected) => {
             crate::api::logging::blog_warn("gift-wrap", format!(
-                "rumor JSON parse failed for trade={}: {e}", &trade_pubkey_hex[..8]
+                "rejecting gift-wrap: sender={} != active mostro={} (trade={})",
+                &sender.to_hex()[..8],
+                &expected.to_hex()[..8],
+                &trade_pubkey_hex[..8],
             ));
             return;
         }
-    };
+        Err(e) => {
+            crate::api::logging::blog_warn("gift-wrap", format!(
+                "active mostro pubkey is invalid: {e} — cannot authenticate gift-wrap"
+            ));
+            return;
+        }
+    }
 
-    // Mostro wire format: [message, null_or_peer]
-    let (msg, _peer): (Message, Option<mostro_core::message::Peer>) =
-        match serde_json::from_str(&content) {
-            Ok(p) => p,
-            Err(e) => {
-                crate::api::logging::blog_warn("gift-wrap", format!(
-                    "content deserialize failed for trade={}: {e}", &trade_pubkey_hex[..8]
-                ));
-                return;
-            }
-        };
+    // Centralized response validation: short-circuits `CantDo` and enforces
+    // `request_id` rules. We pass `None` because the app does not yet track
+    // outstanding request_ids per action (see issue #101 §5 follow-up).
+    if let Err(e) = mostro_core::nip59::validate_response(&msg, None) {
+        crate::api::logging::blog_warn("gift-wrap", format!(
+            "validate_response rejected message for trade={}: {e:?}",
+            &trade_pubkey_hex[..8]
+        ));
+        return;
+    }
 
     let kind = msg.get_inner_message_kind();
 
@@ -1715,8 +1733,9 @@ async fn build_trade_key_map() -> HashMap<String, (nostr_sdk::Keys, u32)> {
 
 /// Handle a Kind 1059 event received on the global subscription.
 ///
-/// Finds which trade key the event is addressed to (via `p` tag), decrypts,
-/// logs the full content, and dispatches to `process_gift_wrap_rumor`.
+/// Finds which trade key the event is addressed to (via `p` tag), decrypts
+/// via `mostro_core::nip59::unwrap_message`, and dispatches the recovered
+/// `Message` through `dispatch_mostro_message`.
 async fn handle_global_gift_wrap(
     event: &nostr_sdk::Event,
     trade_key_map: &HashMap<String, (nostr_sdk::Keys, u32)>,
@@ -1755,16 +1774,15 @@ async fn handle_global_gift_wrap(
         &eid[..16],
     ));
 
-    let event_json = match serde_json::to_string(event) {
-        Ok(j) => j,
-        Err(e) => {
-            crate::api::logging::blog_warn("gift-wrap", format!("event serialize failed: {e}"));
-            return;
+    match crate::nostr::gift_wrap::unwrap_mostro_message(&recipient_keys, event).await {
+        Ok(Some(unwrapped)) => {
+            dispatch_mostro_message(unwrapped, &recipient_hex, trade_idx).await;
         }
-    };
-    match crate::nostr::gift_wrap::unwrap(&recipient_keys, &event_json).await {
-        Ok(rumor_json) => {
-            process_gift_wrap_rumor(&rumor_json, &recipient_hex, trade_idx).await;
+        Ok(None) => {
+            // `Ok(None)` = NIP-44 outer decrypt failed. On the global path
+            // this is expected whenever trade_key_map contains multiple
+            // entries and the event is addressed to a different key; here
+            // the p-tag already matched so it only happens on p-tag collisions.
         }
         Err(e) => crate::api::logging::blog_warn("gift-wrap", format!(
             "decrypt failed for trade={}: {e}", &recipient_hex[..8]

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -1039,15 +1039,28 @@ async fn dispatch_mostro_message(
         }
     }
 
-    // Centralized response validation: short-circuits `CantDo` and enforces
-    // `request_id` rules. We pass `None` because the app does not yet track
-    // outstanding request_ids per action (see issue #101 §5 follow-up).
-    if let Err(e) = mostro_core::nip59::validate_response(&msg, None) {
-        crate::api::logging::blog_warn("gift-wrap", format!(
-            "validate_response rejected message for trade={}: {e:?}",
-            &trade_pubkey_hex[..8]
-        ));
-        return;
+    // Centralized response validation: catches malformed `request_id` fields
+    // and flags `CantDo` responses. We pass `None` because the app does not
+    // yet track outstanding request_ids per action (see issue #101 §5).
+    //
+    // `MostroCantDo` is NOT a reason to drop the message — the `Action::CantDo`
+    // arm below is what unblocks `create_order` callers waiting on a
+    // `pending_confirmations` oneshot. Without propagating it, rejected orders
+    // time out and fall back to the optimistic local-ID path, leaving phantom
+    // pending orders in the book.
+    match mostro_core::nip59::validate_response(&msg, None) {
+        Ok(()) => {}
+        Err(mostro_core::prelude::MostroError::MostroCantDo(_)) => {
+            // Fall through to dispatch so the Action::CantDo arm can resolve
+            // any waiting `create_order` confirmation.
+        }
+        Err(e) => {
+            crate::api::logging::blog_warn("gift-wrap", format!(
+                "validate_response rejected message for trade={}: {e:?}",
+                &trade_pubkey_hex[..8]
+            ));
+            return;
+        }
     }
 
     let kind = msg.get_inner_message_kind();

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -33,6 +33,11 @@ pub fn active_mostro_pubkey() -> String {
 }
 
 /// Set (or clear) the active Mostro pubkey override.
+///
+/// Any gift-wrapped responses still in flight from a previously active
+/// daemon will be rejected by `dispatch_mostro_message` once this changes
+/// — callers that care about clean handoff should quiesce pending trades
+/// before swapping the override.
 pub fn set_active_mostro_pubkey(pubkey: Option<String>) {
     *ACTIVE_MOSTRO_PUBKEY.write().unwrap() = pubkey;
 }

--- a/rust/src/mostro/actions.rs
+++ b/rust/src/mostro/actions.rs
@@ -1,12 +1,8 @@
-/// Mostro action dispatch — builds and wraps MostroMessages.
+/// Mostro action dispatch — builds and wraps `mostro_core::Message` values.
 ///
-/// Each function constructs a `MostroMessage` JSON payload using the
-/// `mostro-core` types and wraps it via NIP-59 Gift Wrap, returning the
-/// event JSON ready for publication.
-///
-/// Wire format: `[{"order":{...}}, null]` — a JSON-serialised
-/// `(Message, Option<Peer>)` tuple where the second element is always `null`
-/// (no peer info is sent by the client).
+/// Each function constructs a `Message` using the `mostro-core` types,
+/// wraps it via NIP-59 Gift Wrap using `mostro_core::nip59::wrap_message`,
+/// and returns the event JSON ready for publication.
 use anyhow::Result;
 use mostro_core::message::{Action, Message, Payload};
 use nostr_sdk::prelude::*;
@@ -14,7 +10,6 @@ use uuid::Uuid;
 
 use crate::api::types::{NewOrderParams, OrderKind};
 use crate::nostr::gift_wrap;
-use crate::nostr::order_events::KIND_ORDER;
 
 // ── Public action builders ────────────────────────────────────────────────────
 
@@ -59,7 +54,7 @@ pub async fn new_order(
 
     let payload = Some(Payload::Order(small_order));
     let msg = Message::new_order(None, None, Some(trade_index as i64), Action::NewOrder, payload);
-    wrap_message(sender_keys, mostro_pubkey, msg).await
+    wrap_for_mostro(sender_keys, mostro_pubkey, &msg).await
 }
 
 /// Build and wrap a TakeBuy MostroMessage.
@@ -166,7 +161,7 @@ pub async fn rate_user(
         Action::RateUser,
         payload,
     );
-    wrap_message(sender_keys, mostro_pubkey, msg).await
+    wrap_for_mostro(sender_keys, mostro_pubkey, &msg).await
 }
 
 /// Build and wrap an AddInvoice MostroMessage (buyer submits Lightning invoice
@@ -200,7 +195,7 @@ pub async fn add_invoice(
         Action::AddInvoice,
         payload,
     );
-    wrap_message(sender_keys, mostro_pubkey, msg).await
+    wrap_for_mostro(sender_keys, mostro_pubkey, &msg).await
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -237,7 +232,7 @@ async fn take_order_impl(
         action,
         payload,
     );
-    wrap_message(sender_keys, mostro_pubkey, msg).await
+    wrap_for_mostro(sender_keys, mostro_pubkey, &msg).await
 }
 
 /// Helper for actions that only need an order ID and no additional payload.
@@ -250,16 +245,17 @@ async fn simple_action(
 ) -> Result<String> {
     let id = Uuid::parse_str(order_id)?;
     let msg = Message::new_order(Some(id), None, Some(trade_index as i64), action, None);
-    wrap_message(sender_keys, mostro_pubkey, msg).await
+    wrap_for_mostro(sender_keys, mostro_pubkey, &msg).await
 }
 
-/// Serialise `msg` as `[message, null]` (Mostro wire format), then wrap via
-/// NIP-59 Gift Wrap.
-async fn wrap_message(
+/// Wrap `msg` as a NIP-59 Gift Wrap via `mostro_core::nip59::wrap_message`,
+/// applying the daemon-advertised PoW difficulty, and return the event JSON.
+async fn wrap_for_mostro(
     sender_keys: &Keys,
     mostro_pubkey: &PublicKey,
-    msg: Message,
+    msg: &Message,
 ) -> Result<String> {
-    let json = serde_json::to_string(&(msg, Option::<mostro_core::message::Peer>::None))?;
-    gift_wrap::wrap(sender_keys, mostro_pubkey, &json, Kind::from(KIND_ORDER)).await
+    let pow = crate::mostro::pow::get_pow();
+    let event = gift_wrap::wrap_mostro_message(sender_keys, mostro_pubkey, msg, pow).await?;
+    Ok(event.as_json())
 }

--- a/rust/src/mostro/actions.rs
+++ b/rust/src/mostro/actions.rs
@@ -54,7 +54,7 @@ pub async fn new_order(
 
     let payload = Some(Payload::Order(small_order));
     let msg = Message::new_order(None, None, Some(trade_index as i64), Action::NewOrder, payload);
-    wrap_for_mostro(sender_keys, mostro_pubkey, &msg).await
+    wrap_message(sender_keys, mostro_pubkey, &msg).await
 }
 
 /// Build and wrap a TakeBuy MostroMessage.
@@ -161,7 +161,7 @@ pub async fn rate_user(
         Action::RateUser,
         payload,
     );
-    wrap_for_mostro(sender_keys, mostro_pubkey, &msg).await
+    wrap_message(sender_keys, mostro_pubkey, &msg).await
 }
 
 /// Build and wrap an AddInvoice MostroMessage (buyer submits Lightning invoice
@@ -195,7 +195,7 @@ pub async fn add_invoice(
         Action::AddInvoice,
         payload,
     );
-    wrap_for_mostro(sender_keys, mostro_pubkey, &msg).await
+    wrap_message(sender_keys, mostro_pubkey, &msg).await
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -232,7 +232,7 @@ async fn take_order_impl(
         action,
         payload,
     );
-    wrap_for_mostro(sender_keys, mostro_pubkey, &msg).await
+    wrap_message(sender_keys, mostro_pubkey, &msg).await
 }
 
 /// Helper for actions that only need an order ID and no additional payload.
@@ -245,12 +245,12 @@ async fn simple_action(
 ) -> Result<String> {
     let id = Uuid::parse_str(order_id)?;
     let msg = Message::new_order(Some(id), None, Some(trade_index as i64), action, None);
-    wrap_for_mostro(sender_keys, mostro_pubkey, &msg).await
+    wrap_message(sender_keys, mostro_pubkey, &msg).await
 }
 
 /// Wrap `msg` as a NIP-59 Gift Wrap via `mostro_core::nip59::wrap_message`,
 /// applying the daemon-advertised PoW difficulty, and return the event JSON.
-async fn wrap_for_mostro(
+async fn wrap_message(
     sender_keys: &Keys,
     mostro_pubkey: &PublicKey,
     msg: &Message,

--- a/rust/src/nostr/gift_wrap.rs
+++ b/rust/src/nostr/gift_wrap.rs
@@ -45,8 +45,18 @@ pub async fn wrap_mostro_message(
 /// Returns `Ok(None)` only when the outer NIP-44 layer cannot be decrypted
 /// with the given key — the canonical "not addressed to me" signal, used by
 /// the global subscription to trial-decrypt across all derived trade keys.
-/// Every other failure (corrupted seal, malformed rumor, bad signature,
-/// sender mismatch) surfaces as `Err`.
+///
+/// Transport-level checks performed here: outer decryption, seal structure,
+/// seal/rumor author consistency (NIP-59 `SenderMismatch`), and — when the
+/// sender set `signed = true` — the inner-tuple Schnorr signature against
+/// the seal author's pubkey. Anything beyond those (corrupt seal, malformed
+/// rumor, bad/missing inner signature) surfaces as `Err`.
+///
+/// Daemon authentication — verifying that `UnwrappedMessage.sender` equals
+/// the active Mostro pubkey — is NOT performed here. The seal author is
+/// proven via the inner signature but could in principle be any key; the
+/// upstream dispatcher in `api/orders.rs` enforces the Mostro-pubkey check
+/// before routing the message.
 pub async fn unwrap_mostro_message(
     trade_keys: &Keys,
     event: &Event,
@@ -184,27 +194,48 @@ mod tests {
 
     #[tokio::test]
     async fn pow_is_applied_to_outer_event() {
+        use std::time::Duration;
+
         let trade_keys = Keys::generate();
         let receiver_keys = Keys::generate();
-        let difficulty = 4; // low to keep the test fast
+        let difficulty: u8 = 4; // low to keep the test fast (avg ~16 tries)
 
-        let event =
-            wrap_mostro_message(&trade_keys, &receiver_keys.public_key(), &sample_message(None), difficulty)
-                .await
-                .expect("wrap with pow");
+        // Mining is probabilistic — cap wall time so a regression that
+        // stalls or loops does not hang CI indefinitely.
+        let event = tokio::time::timeout(
+            Duration::from_secs(30),
+            wrap_mostro_message(
+                &trade_keys,
+                &receiver_keys.public_key(),
+                &sample_message(None),
+                difficulty,
+            ),
+        )
+        .await
+        .expect("wrap with pow timed out")
+        .expect("wrap with pow failed");
 
-        let id_bytes = event.id.to_bytes();
-        let mut leading_zero_bits: u8 = 0;
-        for byte in id_bytes.iter() {
-            if *byte == 0 {
-                leading_zero_bits += 8;
-                continue;
-            }
-            leading_zero_bits += byte.leading_zeros() as u8;
-            break;
-        }
+        let leading_zero_bits: u32 = event
+            .id
+            .to_bytes()
+            .iter()
+            .map(|b| {
+                let lz = b.leading_zeros();
+                (lz, *b == 0)
+            })
+            .scan(true, |still_leading, (lz, is_zero)| {
+                if !*still_leading {
+                    return Some(0u32);
+                }
+                if !is_zero {
+                    *still_leading = false;
+                }
+                Some(lz)
+            })
+            .sum();
+
         assert!(
-            leading_zero_bits >= difficulty,
+            leading_zero_bits >= u32::from(difficulty),
             "event id {} has {} leading zero bits, expected >= {}",
             event.id.to_hex(),
             leading_zero_bits,

--- a/rust/src/nostr/gift_wrap.rs
+++ b/rust/src/nostr/gift_wrap.rs
@@ -1,18 +1,71 @@
-/// NIP-59 Gift Wrap encode/decode.
+/// NIP-59 Gift Wrap transport.
 ///
-/// Wrapping layers:
-///   1. Rumor    — unsigned content event
-///   2. Seal     — Kind 13, NIP-44 encrypted rumor, signed by sender key
-///   3. Gift Wrap — Kind 1059, NIP-44 encrypted seal, signed by ephemeral key
+/// Two entry points:
+///
+/// * `wrap_mostro_message` / `unwrap_mostro_message` — typed Mostro protocol
+///   traffic, delegated to `mostro_core::nip59` so every Mostro client shares
+///   one NIP-59 implementation (seal construction, ephemeral keys, timestamp
+///   tweak, PoW, inner-tuple signing/verification).
+///
+/// * `wrap` / `unwrap` — raw JSON content wrapped in a Kind 14 rumor, used
+///   for NIP-17-style text DMs (P2P chat, dispute admin messages). These
+///   payloads are not `mostro_core::Message` values, so they stay on the
+///   local helper — see issue #101, "Scope".
 use anyhow::{anyhow, Result};
+use mostro_core::message::Message;
+use mostro_core::nip59::{
+    unwrap_message as core_unwrap, wrap_message as core_wrap, UnwrappedMessage, WrapOptions,
+};
 use nostr_sdk::prelude::*;
 
-/// Wrap a plaintext message as a NIP-59 Gift Wrap event addressed to
+// ── Mostro protocol traffic (typed `Message`) ────────────────────────────────
+
+/// Wrap a `Message` destined for `receiver` (typically the Mostro node).
+///
+/// `trade_keys` author the rumor, sign the Seal, and produce the inner-tuple
+/// signature. `pow` is applied to the outer Kind 1059 only.
+pub async fn wrap_mostro_message(
+    trade_keys: &Keys,
+    receiver: &PublicKey,
+    message: &Message,
+    pow: u8,
+) -> Result<Event> {
+    let opts = WrapOptions {
+        pow,
+        expiration: None,
+        signed: true,
+    };
+    core_wrap(message, trade_keys, *receiver, opts)
+        .await
+        .map_err(|e| anyhow!("wrap_message failed: {e}"))
+}
+
+/// Try to open an incoming Kind 1059 event using `trade_keys`.
+///
+/// Returns `Ok(None)` only when the outer NIP-44 layer cannot be decrypted
+/// with the given key — the canonical "not addressed to me" signal, used by
+/// the global subscription to trial-decrypt across all derived trade keys.
+/// Every other failure (corrupted seal, malformed rumor, bad signature,
+/// sender mismatch) surfaces as `Err`.
+pub async fn unwrap_mostro_message(
+    trade_keys: &Keys,
+    event: &Event,
+) -> Result<Option<UnwrappedMessage>> {
+    core_unwrap(event, trade_keys)
+        .await
+        .map_err(|e| anyhow!("unwrap_message failed: {e}"))
+}
+
+// ── NIP-17 text DMs (P2P chat, dispute admin) ────────────────────────────────
+//
+// These wrap arbitrary JSON content in a Kind 14 rumor. Kept as local glue
+// until `mostro-core` grows a DM helper or we migrate these off NIP-59.
+
+/// Wrap a plaintext JSON payload as a NIP-59 Gift Wrap event addressed to
 /// `recipient_pubkey`, signed by `sender_keys`.
 ///
 /// When the connected Mostro requires NIP-13 Proof of Work the difficulty
-/// is applied to the **gift wrap** (the outer Kind 1059 event).  The daemon
-/// validates `event.check_pow(pow)` on the gift wrap before unwrapping.
+/// is applied to the **gift wrap** (the outer Kind 1059 event).
 ///
 /// Returns the serialised `Event` JSON ready for publication.
 pub async fn wrap(
@@ -68,4 +121,94 @@ pub async fn unwrap(recipient_keys: &Keys, gift_wrap_json: &str) -> Result<Strin
         .map_err(|e| anyhow!("NIP-59 unwrap failed: {e}"))?;
 
     Ok(unwrapped.rumor.as_json())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mostro_core::message::{Action, MessageKind};
+    use uuid::Uuid;
+
+    fn sample_message(request_id: Option<u64>) -> Message {
+        Message::Order(MessageKind::new(
+            Some(Uuid::parse_str("308e1272-d5f4-47e6-bd97-3504baea9c23").unwrap()),
+            request_id,
+            Some(1),
+            Action::FiatSent,
+            None,
+        ))
+    }
+
+    #[tokio::test]
+    async fn roundtrip_preserves_message_and_sender() {
+        let trade_keys = Keys::generate();
+        let receiver_keys = Keys::generate();
+        let msg = sample_message(Some(42));
+
+        let event = wrap_mostro_message(&trade_keys, &receiver_keys.public_key(), &msg, 0)
+            .await
+            .expect("wrap");
+
+        assert_eq!(event.kind, Kind::GiftWrap);
+
+        let unwrapped = unwrap_mostro_message(&receiver_keys, &event)
+            .await
+            .expect("unwrap result")
+            .expect("addressed to us");
+
+        assert_eq!(unwrapped.sender, trade_keys.public_key());
+        assert_eq!(
+            unwrapped.message.as_json().unwrap(),
+            msg.as_json().unwrap(),
+        );
+        assert!(unwrapped.signature.is_some(), "signed=true by default");
+    }
+
+    #[tokio::test]
+    async fn unwrap_with_wrong_recipient_returns_none() {
+        let trade_keys = Keys::generate();
+        let receiver_keys = Keys::generate();
+        let stranger_keys = Keys::generate();
+
+        let event =
+            wrap_mostro_message(&trade_keys, &receiver_keys.public_key(), &sample_message(None), 0)
+                .await
+                .expect("wrap");
+
+        let result = unwrap_mostro_message(&stranger_keys, &event)
+            .await
+            .expect("wrong-recipient must not error");
+
+        assert!(result.is_none(), "Ok(None) signals 'not for us'");
+    }
+
+    #[tokio::test]
+    async fn pow_is_applied_to_outer_event() {
+        let trade_keys = Keys::generate();
+        let receiver_keys = Keys::generate();
+        let difficulty = 4; // low to keep the test fast
+
+        let event =
+            wrap_mostro_message(&trade_keys, &receiver_keys.public_key(), &sample_message(None), difficulty)
+                .await
+                .expect("wrap with pow");
+
+        let id_bytes = event.id.to_bytes();
+        let mut leading_zero_bits: u8 = 0;
+        for byte in id_bytes.iter() {
+            if *byte == 0 {
+                leading_zero_bits += 8;
+                continue;
+            }
+            leading_zero_bits += byte.leading_zeros() as u8;
+            break;
+        }
+        assert!(
+            leading_zero_bits >= difficulty,
+            "event id {} has {} leading zero bits, expected >= {}",
+            event.id.to_hex(),
+            leading_zero_bits,
+            difficulty,
+        );
+    }
 }


### PR DESCRIPTION
Replace the hand-rolled NIP-59 wrap/unwrap in `rust/src/nostr/gift_wrap.rs` with thin shims over `mostro_core::nip59::{wrap_message, unwrap_message, validate_response}`, so every Mostro client shares one implementation of seal construction, ephemeral keys, timestamp tweak, PoW, and inner-tuple signing/verification.

Scope is limited to typed `Message` traffic with the Mostro daemon. The Kind 14 text DM paths in `messages.rs` (P2P chat) and `disputes.rs` (admin escalation) wrap raw `{"text": …}` JSON and stay on the legacy local helper until `mostro-core` grows a DM variant.

Notable behavior changes on the inbound path:

- Gift-wraps now authenticate the sender: responses whose `sender` is not the configured active Mostro pubkey are rejected and logged. Previously the only check was "it decrypted under one of our trade keys".
- `validate_response(&msg, None)` runs on every unwrapped message, short-circuiting `CantDo` responses centrally. `request_id` tracking is a follow-up (see issue #101 §5).
- The per-trade and global subscriptions can now distinguish "wrap was not addressed to this key" (`Ok(None)`) from "corrupted wrap" (`Err`).

Outbound `actions.rs` builders keep their `Result<String>` signature via `event.as_json()` so call sites in `orders.rs` / `disputes.rs` are unchanged; the `(Message, Option<Peer>)` tuple (de)serialization that used to straddle the wrap and unwrap paths is gone.

Adds unit tests covering round-trip, `Ok(None)` on wrong recipient, and PoW difficulty propagation to the outer 1059 event.

Refs: https://github.com/MostroP2P/app/issues/101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `mostro-core` dependency from 0.8.0 to 0.9.0.

* **Bug Fixes**
  * Refactored gift-wrap message processing for improved validation and error handling.
  * Enhanced message authentication and centralized validation routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->