### PR TITLE
feat(nip59): migrate gift-wrap transport to mostro-core 0.10

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1616,9 +1616,9 @@ dependencies = [
 
 [[package]]
 name = "mostro-core"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e323335185f1cd0ea3369d03b431fb36c6fa6aa864e20fc647d1195ff26bb22"
+checksum = "d76f4936f520e410ba2abf47113548ae231322209261a9b3a8aefbd10a869082"
 dependencies = [
  "bitcoin",
  "chrono",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,7 +11,7 @@ flutter_rust_bridge = "=2.11.1"
 
 # Nostr & Mostro protocol
 nostr-sdk = { version = "0.44", default-features = false, features = ["nip44", "nip47", "nip59"] }
-mostro-core = "0.9"
+mostro-core = "0.10"
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/rust/src/api/disputes.rs
+++ b/rust/src/api/disputes.rs
@@ -133,11 +133,19 @@ pub async fn open_dispute(trade_id: String, reason: Option<String>) -> Result<Di
     let event_json: String = async {
         let sender_keys =
             crate::api::identity::get_active_trade_keys(trade_index).await?;
+        let identity_keys =
+            crate::api::identity::get_transport_identity_keys(&sender_keys).await?;
         let mostro_pubkey =
             nostr_sdk::PublicKey::from_hex(&crate::config::active_mostro_pubkey())
                 .map_err(|e| anyhow!("invalid mostro pubkey: {e}"))?;
-        crate::mostro::actions::dispute(&sender_keys, &mostro_pubkey, &trade_id, trade_index)
-            .await
+        crate::mostro::actions::dispute(
+            &identity_keys,
+            &sender_keys,
+            &mostro_pubkey,
+            &trade_id,
+            trade_index,
+        )
+        .await
     }
     .await
     .map_err(|e| anyhow!("ProtocolError: could not build Dispute message: {e}"))?;

--- a/rust/src/api/identity.rs
+++ b/rust/src/api/identity.rs
@@ -321,3 +321,23 @@ pub(crate) async fn get_active_trade_keys(index: u32) -> Result<Keys> {
     }
     key_ops::derive_trade_key(&state.mnemonic_words, index)
 }
+
+/// Choose the identity keys that will sign the NIP-59 seal for messages
+/// addressed to the Mostro node.
+///
+/// * **Reputation mode** (default) — returns the long-lived identity keys
+///   (index 0). The node links trades to a stable pubkey and the user
+///   accumulates reputation.
+/// * **Full-privacy mode** — returns a clone of `trade_keys`, so the seal is
+///   signed by the same key that authors the rumor. The node cannot link the
+///   trade to any long-lived identity, and no reputation can accrue
+///   (see <https://mostro.network/protocol/key_management.html>).
+///
+/// The toggle source is the in-memory runtime switch in `api::reputation`,
+/// which is what the UI updates via `set_privacy_mode`.
+pub(crate) async fn get_transport_identity_keys(trade_keys: &Keys) -> Result<Keys> {
+    if crate::api::reputation::get_privacy_mode() {
+        return Ok(trade_keys.clone());
+    }
+    get_active_keys().await
+}

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -488,7 +488,10 @@ pub async fn create_order(params: NewOrderParams) -> Result<OrderInfo> {
     // This avoids a phantom "pending" order when the daemon rejects (CantDo).
 
     let mostro_pubkey = nostr_sdk::PublicKey::from_hex(&active_mostro_pubkey())?;
+    let identity_keys =
+        crate::api::identity::get_transport_identity_keys(&sender_keys).await?;
     let event_json = actions::new_order(
+        &identity_keys,
         &sender_keys,
         &mostro_pubkey,
         &params_for_dispatch,
@@ -691,9 +694,23 @@ pub async fn take_order(
                         .and_then(|s| s.default_lightning_address);
                     let ln_address_ref = ln_address.as_deref();
 
+                    let identity_keys = match crate::api::identity::get_transport_identity_keys(
+                        &sender_keys,
+                    )
+                    .await
+                    {
+                        Ok(k) => k,
+                        Err(e) => {
+                            log::error!(
+                                "[orders] take_order: could not resolve identity keys: {e}"
+                            );
+                            return Ok(trade);
+                        }
+                    };
                     let action_result = match dispatch_role {
                         TradeRole::Buyer => {
                             actions::take_sell(
+                                &identity_keys,
                                 &sender_keys,
                                 &mostro_pubkey,
                                 &order_id,
@@ -705,6 +722,7 @@ pub async fn take_order(
                         }
                         TradeRole::Seller => {
                             actions::take_buy(
+                                &identity_keys,
                                 &sender_keys,
                                 &mostro_pubkey,
                                 &order_id,
@@ -792,8 +810,11 @@ pub async fn send_invoice(
         .await
         .ok_or_else(|| anyhow::anyhow!("no persisted trade key for order {order_id}"))?;
     let sender_keys = crate::api::identity::get_active_trade_keys(trade_index).await?;
+    let identity_keys =
+        crate::api::identity::get_transport_identity_keys(&sender_keys).await?;
     let mostro_pubkey = nostr_sdk::PublicKey::from_hex(&active_mostro_pubkey())?;
     let event_json = actions::add_invoice(
+        &identity_keys,
         &sender_keys,
         &mostro_pubkey,
         &order_id,
@@ -821,9 +842,17 @@ pub async fn send_fiat_sent(order_id: String) -> Result<()> {
         .await
         .ok_or_else(|| anyhow::anyhow!("no persisted trade key for order {order_id}"))?;
     let sender_keys = crate::api::identity::get_active_trade_keys(trade_index).await?;
+    let identity_keys =
+        crate::api::identity::get_transport_identity_keys(&sender_keys).await?;
     let mostro_pubkey = nostr_sdk::PublicKey::from_hex(&active_mostro_pubkey())?;
-    let event_json =
-        actions::fiat_sent(&sender_keys, &mostro_pubkey, &order_id, trade_index).await?;
+    let event_json = actions::fiat_sent(
+        &identity_keys,
+        &sender_keys,
+        &mostro_pubkey,
+        &order_id,
+        trade_index,
+    )
+    .await?;
     publish_event_json(&event_json).await?;
     log::info!("[orders] fiat_sent published for order={order_id} trade_index={trade_index}");
     Ok(())
@@ -838,8 +867,17 @@ pub async fn release_order(order_id: String) -> Result<()> {
         .await
         .ok_or_else(|| anyhow::anyhow!("no persisted trade key for order {order_id}"))?;
     let sender_keys = crate::api::identity::get_active_trade_keys(trade_index).await?;
+    let identity_keys =
+        crate::api::identity::get_transport_identity_keys(&sender_keys).await?;
     let mostro_pubkey = nostr_sdk::PublicKey::from_hex(&active_mostro_pubkey())?;
-    let event_json = actions::release(&sender_keys, &mostro_pubkey, &order_id, trade_index).await?;
+    let event_json = actions::release(
+        &identity_keys,
+        &sender_keys,
+        &mostro_pubkey,
+        &order_id,
+        trade_index,
+    )
+    .await?;
     publish_event_json(&event_json).await?;
     log::info!("[orders] release published for order={order_id} trade_index={trade_index}");
     Ok(())
@@ -855,8 +893,17 @@ pub async fn cancel_order(order_id: String) -> Result<()> {
         .await
         .ok_or_else(|| anyhow::anyhow!("no persisted trade key for order {order_id}"))?;
     let sender_keys = crate::api::identity::get_active_trade_keys(trade_index).await?;
+    let identity_keys =
+        crate::api::identity::get_transport_identity_keys(&sender_keys).await?;
     let mostro_pubkey = nostr_sdk::PublicKey::from_hex(&active_mostro_pubkey())?;
-    let event_json = actions::cancel(&sender_keys, &mostro_pubkey, &order_id, trade_index).await?;
+    let event_json = actions::cancel(
+        &identity_keys,
+        &sender_keys,
+        &mostro_pubkey,
+        &order_id,
+        trade_index,
+    )
+    .await?;
     publish_event_json(&event_json).await?;
 
     // Optimistic update: mark the trade as Canceled in the local DB immediately
@@ -1011,9 +1058,16 @@ async fn dispatch_mostro_message(
 ) {
     use mostro_core::message::Action;
 
+    // mostro-core 0.10 adds `identity` (seal signer, long-lived) alongside
+    // `sender` (rumor author, per-trade). A Mostro node that opts out of the
+    // identity/trade split — the current daemon — reuses the same key for
+    // both, so `identity == sender`. We keep the existing sender-based
+    // authentication check below; the extra `identity` field is deliberately
+    // ignored here.
     let mostro_core::nip59::UnwrappedMessage {
         message: msg,
         sender,
+        identity: _,
         signature: _,
         created_at: _,
     } = unwrapped;

--- a/rust/src/api/reputation.rs
+++ b/rust/src/api/reputation.rs
@@ -160,10 +160,17 @@ pub async fn submit_rating(trade_id: String, score: u8) -> Result<()> {
         let dispatch_result: anyhow::Result<()> = async {
             let sender_keys =
                 crate::api::identity::get_active_trade_keys(trade_index).await?;
+            // Rating is the one action that must land under the long-lived
+            // identity key: the privacy-mode check above already refuses to
+            // submit when the user opted out of reputation, so here we
+            // resolve identity keys unconditionally via the same helper.
+            let identity_keys =
+                crate::api::identity::get_transport_identity_keys(&sender_keys).await?;
             let mostro_pubkey =
                 nostr_sdk::PublicKey::from_hex(&crate::config::active_mostro_pubkey())
                     .map_err(|e| anyhow::anyhow!("invalid mostro pubkey: {e}"))?;
             let event_json = crate::mostro::actions::rate_user(
+                &identity_keys,
                 &sender_keys,
                 &mostro_pubkey,
                 &trade_id,

--- a/rust/src/mostro/actions.rs
+++ b/rust/src/mostro/actions.rs
@@ -3,6 +3,14 @@
 /// Each function constructs a `Message` using the `mostro-core` types,
 /// wraps it via NIP-59 Gift Wrap using `mostro_core::nip59::wrap_message`,
 /// and returns the event JSON ready for publication.
+///
+/// **Key split.** Mostro-core 0.10 requires two `Keys` values per wrap:
+/// `identity_keys` sign the Seal (Kind 13) so the node can tie the rumor to
+/// a long-lived pubkey for reputation purposes, while `trade_keys` author
+/// the rumor (Kind 1) and produce the inner tuple signature. Callers who
+/// want "full-privacy mode" (no reputation) pass `trade_keys` for both
+/// arguments — see `api::identity::get_transport_identity_keys`, which
+/// applies the runtime privacy toggle.
 use anyhow::Result;
 use mostro_core::message::{Action, Message, Payload};
 use nostr_sdk::prelude::*;
@@ -17,7 +25,8 @@ use crate::nostr::gift_wrap;
 ///
 /// Returns the NIP-59 Gift Wrap event JSON ready for publication.
 pub async fn new_order(
-    sender_keys: &Keys,
+    identity_keys: &Keys,
+    trade_keys: &Keys,
     mostro_pubkey: &PublicKey,
     params: &NewOrderParams,
     trade_index: u32,
@@ -54,19 +63,21 @@ pub async fn new_order(
 
     let payload = Some(Payload::Order(small_order));
     let msg = Message::new_order(None, None, Some(trade_index as i64), Action::NewOrder, payload);
-    wrap_message(sender_keys, mostro_pubkey, &msg).await
+    wrap_message(identity_keys, trade_keys, mostro_pubkey, &msg).await
 }
 
 /// Build and wrap a TakeBuy MostroMessage.
 pub async fn take_buy(
-    sender_keys: &Keys,
+    identity_keys: &Keys,
+    trade_keys: &Keys,
     mostro_pubkey: &PublicKey,
     order_id: &str,
     trade_index: u32,
     amount: Option<f64>,
 ) -> Result<String> {
     take_order_impl(
-        sender_keys,
+        identity_keys,
+        trade_keys,
         mostro_pubkey,
         order_id,
         trade_index,
@@ -82,7 +93,8 @@ pub async fn take_buy(
 /// If `ln_address` is `Some`, it is included in the payload so Mostro can
 /// pay the buyer directly (take-sell-ln-address variant).
 pub async fn take_sell(
-    sender_keys: &Keys,
+    identity_keys: &Keys,
+    trade_keys: &Keys,
     mostro_pubkey: &PublicKey,
     order_id: &str,
     trade_index: u32,
@@ -90,7 +102,8 @@ pub async fn take_sell(
     ln_address: Option<&str>,
 ) -> Result<String> {
     take_order_impl(
-        sender_keys,
+        identity_keys,
+        trade_keys,
         mostro_pubkey,
         order_id,
         trade_index,
@@ -103,42 +116,78 @@ pub async fn take_sell(
 
 /// Build and wrap a FiatSent MostroMessage.
 pub async fn fiat_sent(
-    sender_keys: &Keys,
+    identity_keys: &Keys,
+    trade_keys: &Keys,
     mostro_pubkey: &PublicKey,
     order_id: &str,
     trade_index: u32,
 ) -> Result<String> {
-    simple_action(sender_keys, mostro_pubkey, order_id, trade_index, Action::FiatSent).await
+    simple_action(
+        identity_keys,
+        trade_keys,
+        mostro_pubkey,
+        order_id,
+        trade_index,
+        Action::FiatSent,
+    )
+    .await
 }
 
 /// Build and wrap a Release MostroMessage.
 pub async fn release(
-    sender_keys: &Keys,
+    identity_keys: &Keys,
+    trade_keys: &Keys,
     mostro_pubkey: &PublicKey,
     order_id: &str,
     trade_index: u32,
 ) -> Result<String> {
-    simple_action(sender_keys, mostro_pubkey, order_id, trade_index, Action::Release).await
+    simple_action(
+        identity_keys,
+        trade_keys,
+        mostro_pubkey,
+        order_id,
+        trade_index,
+        Action::Release,
+    )
+    .await
 }
 
 /// Build and wrap a Cancel MostroMessage.
 pub async fn cancel(
-    sender_keys: &Keys,
+    identity_keys: &Keys,
+    trade_keys: &Keys,
     mostro_pubkey: &PublicKey,
     order_id: &str,
     trade_index: u32,
 ) -> Result<String> {
-    simple_action(sender_keys, mostro_pubkey, order_id, trade_index, Action::Cancel).await
+    simple_action(
+        identity_keys,
+        trade_keys,
+        mostro_pubkey,
+        order_id,
+        trade_index,
+        Action::Cancel,
+    )
+    .await
 }
 
 /// Build and wrap a Dispute MostroMessage.
 pub async fn dispute(
-    sender_keys: &Keys,
+    identity_keys: &Keys,
+    trade_keys: &Keys,
     mostro_pubkey: &PublicKey,
     order_id: &str,
     trade_index: u32,
 ) -> Result<String> {
-    simple_action(sender_keys, mostro_pubkey, order_id, trade_index, Action::Dispute).await
+    simple_action(
+        identity_keys,
+        trade_keys,
+        mostro_pubkey,
+        order_id,
+        trade_index,
+        Action::Dispute,
+    )
+    .await
 }
 
 /// Build and wrap a RateUser MostroMessage.
@@ -146,7 +195,8 @@ pub async fn dispute(
 /// Sends a 1–5 star rating for the counterparty to the Mostro daemon via
 /// NIP-59 Gift Wrap after a trade completes.
 pub async fn rate_user(
-    sender_keys: &Keys,
+    identity_keys: &Keys,
+    trade_keys: &Keys,
     mostro_pubkey: &PublicKey,
     order_id: &str,
     trade_index: u32,
@@ -161,7 +211,7 @@ pub async fn rate_user(
         Action::RateUser,
         payload,
     );
-    wrap_message(sender_keys, mostro_pubkey, &msg).await
+    wrap_message(identity_keys, trade_keys, mostro_pubkey, &msg).await
 }
 
 /// Build and wrap an AddInvoice MostroMessage (buyer submits Lightning invoice
@@ -172,7 +222,8 @@ pub async fn rate_user(
 /// sats amount in the payload so it can resolve the address and generate the
 /// invoice on behalf of the buyer — pass it via `amount_sats`.
 pub async fn add_invoice(
-    sender_keys: &Keys,
+    identity_keys: &Keys,
+    trade_keys: &Keys,
     mostro_pubkey: &PublicKey,
     order_id: &str,
     trade_index: u32,
@@ -195,14 +246,16 @@ pub async fn add_invoice(
         Action::AddInvoice,
         payload,
     );
-    wrap_message(sender_keys, mostro_pubkey, &msg).await
+    wrap_message(identity_keys, trade_keys, mostro_pubkey, &msg).await
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 /// Internal helper for take-buy / take-sell actions.
+#[allow(clippy::too_many_arguments)]
 async fn take_order_impl(
-    sender_keys: &Keys,
+    identity_keys: &Keys,
+    trade_keys: &Keys,
     mostro_pubkey: &PublicKey,
     order_id: &str,
     trade_index: u32,
@@ -232,12 +285,13 @@ async fn take_order_impl(
         action,
         payload,
     );
-    wrap_message(sender_keys, mostro_pubkey, &msg).await
+    wrap_message(identity_keys, trade_keys, mostro_pubkey, &msg).await
 }
 
 /// Helper for actions that only need an order ID and no additional payload.
 async fn simple_action(
-    sender_keys: &Keys,
+    identity_keys: &Keys,
+    trade_keys: &Keys,
     mostro_pubkey: &PublicKey,
     order_id: &str,
     trade_index: u32,
@@ -245,17 +299,19 @@ async fn simple_action(
 ) -> Result<String> {
     let id = Uuid::parse_str(order_id)?;
     let msg = Message::new_order(Some(id), None, Some(trade_index as i64), action, None);
-    wrap_message(sender_keys, mostro_pubkey, &msg).await
+    wrap_message(identity_keys, trade_keys, mostro_pubkey, &msg).await
 }
 
 /// Wrap `msg` as a NIP-59 Gift Wrap via `mostro_core::nip59::wrap_message`,
 /// applying the daemon-advertised PoW difficulty, and return the event JSON.
 async fn wrap_message(
-    sender_keys: &Keys,
+    identity_keys: &Keys,
+    trade_keys: &Keys,
     mostro_pubkey: &PublicKey,
     msg: &Message,
 ) -> Result<String> {
     let pow = crate::mostro::pow::get_pow();
-    let event = gift_wrap::wrap_mostro_message(sender_keys, mostro_pubkey, msg, pow).await?;
+    let event =
+        gift_wrap::wrap_mostro_message(identity_keys, trade_keys, mostro_pubkey, msg, pow).await?;
     Ok(event.as_json())
 }

--- a/rust/src/nostr/gift_wrap.rs
+++ b/rust/src/nostr/gift_wrap.rs
@@ -22,9 +22,16 @@ use nostr_sdk::prelude::*;
 
 /// Wrap a `Message` destined for `receiver` (typically the Mostro node).
 ///
-/// `trade_keys` author the rumor, sign the Seal, and produce the inner-tuple
-/// signature. `pow` is applied to the outer Kind 1059 only.
+/// `identity_keys` sign the Seal (Kind 13) and encrypt it to `receiver` via
+/// NIP-44; they are the long-lived identity the node uses to accumulate
+/// reputation. `trade_keys` author the rumor (Kind 1) and produce the inner
+/// tuple signature. For full-privacy mode (no reputation), callers pass the
+/// same value for both parameters — see
+/// <https://mostro.network/protocol/key_management.html>.
+///
+/// `pow` is applied to the outer Kind 1059 only.
 pub async fn wrap_mostro_message(
+    identity_keys: &Keys,
     trade_keys: &Keys,
     receiver: &PublicKey,
     message: &Message,
@@ -35,7 +42,7 @@ pub async fn wrap_mostro_message(
         expiration: None,
         signed: true,
     };
-    core_wrap(message, trade_keys, *receiver, opts)
+    core_wrap(message, identity_keys, trade_keys, *receiver, opts)
         .await
         .map_err(|e| anyhow!("wrap_message failed: {e}"))
 }
@@ -46,11 +53,14 @@ pub async fn wrap_mostro_message(
 /// with the given key — the canonical "not addressed to me" signal, used by
 /// the global subscription to trial-decrypt across all derived trade keys.
 ///
-/// Transport-level checks performed here: outer decryption, seal structure,
-/// seal/rumor author consistency (NIP-59 `SenderMismatch`), and — when the
-/// sender set `signed = true` — the inner-tuple Schnorr signature against
-/// the seal author's pubkey. Anything beyond those (corrupt seal, malformed
-/// rumor, bad/missing inner signature) surfaces as `Err`.
+/// Transport-level checks performed here: outer decryption, seal structure
+/// and signature, and — when the sender set `signed = true` — the
+/// inner-tuple Schnorr signature against the rumor author's pubkey. Note
+/// that mostro-core 0.10 deliberately does **not** enforce
+/// `seal.pubkey == rumor.pubkey` — Mostro signs the seal with the identity
+/// key and authors the rumor with the per-trade key, so the two legitimately
+/// differ. The returned `UnwrappedMessage` exposes both (`identity` vs.
+/// `sender`) so callers can route and authorize accordingly.
 ///
 /// Daemon authentication — verifying that `UnwrappedMessage.sender` equals
 /// the active Mostro pubkey — is NOT performed here. The seal author is
@@ -151,13 +161,20 @@ mod tests {
 
     #[tokio::test]
     async fn roundtrip_preserves_message_and_sender() {
+        let identity_keys = Keys::generate();
         let trade_keys = Keys::generate();
         let receiver_keys = Keys::generate();
         let msg = sample_message(Some(42));
 
-        let event = wrap_mostro_message(&trade_keys, &receiver_keys.public_key(), &msg, 0)
-            .await
-            .expect("wrap");
+        let event = wrap_mostro_message(
+            &identity_keys,
+            &trade_keys,
+            &receiver_keys.public_key(),
+            &msg,
+            0,
+        )
+        .await
+        .expect("wrap");
 
         assert_eq!(event.kind, Kind::GiftWrap);
 
@@ -167,6 +184,7 @@ mod tests {
             .expect("addressed to us");
 
         assert_eq!(unwrapped.sender, trade_keys.public_key());
+        assert_eq!(unwrapped.identity, identity_keys.public_key());
         assert_eq!(
             unwrapped.message.as_json().unwrap(),
             msg.as_json().unwrap(),
@@ -175,15 +193,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn full_privacy_mode_reuses_trade_key_as_identity() {
+        let trade_keys = Keys::generate();
+        let receiver_keys = Keys::generate();
+
+        let event = wrap_mostro_message(
+            &trade_keys,
+            &trade_keys,
+            &receiver_keys.public_key(),
+            &sample_message(Some(1)),
+            0,
+        )
+        .await
+        .expect("wrap");
+
+        let unwrapped = unwrap_mostro_message(&receiver_keys, &event)
+            .await
+            .expect("unwrap")
+            .expect("addressed to us");
+
+        assert_eq!(unwrapped.sender, trade_keys.public_key());
+        assert_eq!(unwrapped.identity, trade_keys.public_key());
+    }
+
+    #[tokio::test]
     async fn unwrap_with_wrong_recipient_returns_none() {
+        let identity_keys = Keys::generate();
         let trade_keys = Keys::generate();
         let receiver_keys = Keys::generate();
         let stranger_keys = Keys::generate();
 
-        let event =
-            wrap_mostro_message(&trade_keys, &receiver_keys.public_key(), &sample_message(None), 0)
-                .await
-                .expect("wrap");
+        let event = wrap_mostro_message(
+            &identity_keys,
+            &trade_keys,
+            &receiver_keys.public_key(),
+            &sample_message(None),
+            0,
+        )
+        .await
+        .expect("wrap");
 
         let result = unwrap_mostro_message(&stranger_keys, &event)
             .await
@@ -196,6 +244,7 @@ mod tests {
     async fn pow_is_applied_to_outer_event() {
         use std::time::Duration;
 
+        let identity_keys = Keys::generate();
         let trade_keys = Keys::generate();
         let receiver_keys = Keys::generate();
         let difficulty: u8 = 4; // low to keep the test fast (avg ~16 tries)
@@ -205,6 +254,7 @@ mod tests {
         let event = tokio::time::timeout(
             Duration::from_secs(30),
             wrap_mostro_message(
+                &identity_keys,
                 &trade_keys,
                 &receiver_keys.public_key(),
                 &sample_message(None),


### PR DESCRIPTION
## Summary

mostro-core 0.10 reshapes [`nip59::wrap_message`](https://github.com/MostroP2P/mostro-core/blob/main/docs/NIP59_TRANSPORT.md) to take the **identity key** and the **trade key** as separate arguments, matching the key-management protocol at <https://mostro.network/protocol/key_management.html>:

- `identity_keys` (BIP-32 index 0, long-lived) sign the Seal (Kind 13) so the node can accumulate reputation under a stable pubkey.
- `trade_keys` (BIP-32 index ≥1, per-order) author the rumor (Kind 1) and produce the inner tuple signature.

Callers that opt out of reputation (privacy mode) pass `trade_keys` for both parameters — the "full-privacy" variant described in the protocol doc.

## Changes

- **Bump** `rust/Cargo.toml`: `mostro-core` 0.9 → 0.10.
- **`rust/src/nostr/gift_wrap.rs`** — `wrap_mostro_message` now takes `identity_keys` and `trade_keys` separately, forwarding both to `mostro_core::nip59::wrap_message`. Roundtrip test asserts both `sender` and `identity`; new `full_privacy_mode_reuses_trade_key_as_identity` case covers the one-key path.
- **`rust/src/mostro/actions.rs`** — every public action builder (`new_order`, `take_buy`, `take_sell`, `fiat_sent`, `release`, `cancel`, `dispute`, `rate_user`, `add_invoice`) plus the internal `wrap_message` helper gain the `identity_keys: &Keys` parameter.
- **`rust/src/api/identity.rs`** — new `get_transport_identity_keys(&trade_keys)` helper returns the master identity keys in reputation mode, or a clone of `trade_keys` when `api::reputation::get_privacy_mode()` is on. This is the single entry point every dispatcher uses to apply the runtime privacy toggle.
- **Dispatchers** (`rust/src/api/orders.rs`, `rust/src/api/disputes.rs`, `rust/src/api/reputation.rs`) — resolve identity keys via the new helper before building each action.
- **`rust/src/api/orders.rs`** (receive path) — destructure the new `identity` field on `UnwrappedMessage`; authentication continues to match on `sender` because the current daemon reuses its pubkey for both, but the change is ready for a node that later splits them.

## Test plan

- [x] `cargo test --lib` — 81 passed, 0 failed (new `full_privacy_mode_reuses_trade_key_as_identity` passes; existing roundtrip and PoW tests updated).
- [x] `cargo build` — clean.
- [x] `cargo clippy --lib --all-targets` — no new warnings introduced by this PR (remaining warnings in `api/settings.rs` are pre-existing on `main`).
- [ ] Manual smoke: create + take + release an order against a 0.10-compatible Mostro node in reputation mode (`privacy_mode = false`) and verify the daemon links the trade to the identity key.
- [ ] Manual smoke: repeat with privacy mode on (`set_privacy_mode(true)`) and verify the seal pubkey matches the rumor pubkey.

## References

- [NIP-59 transport doc (mostro-core 0.10)](https://github.com/MostroP2P/mostro-core/blob/main/docs/NIP59_TRANSPORT.md)
- [Mostro key-management protocol](https://mostro.network/protocol/key_management.html)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated mostro-core dependency to version 0.10

* **New Features**
  * Enhanced privacy support with improved cryptographic key management for trades, disputes, orders, and reputation operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->