### PR TITLE
feat(ui): apply Mostro UX redesign from design handoff

### DIFF
--- a/lib/core/app_theme.dart
+++ b/lib/core/app_theme.dart
@@ -27,6 +27,7 @@ class AppColors extends ThemeExtension<AppColors> {
     required this.messageReceived,
     required this.systemMessage,
     required this.badgeGold,
+    required this.warningAmber,
   });
 
   final Color backgroundDark;
@@ -50,6 +51,8 @@ class AppColors extends ThemeExtension<AppColors> {
   final Color systemMessage;
   /// Dark-gold color used for the notification count badge.
   final Color badgeGold;
+  /// Amber used for time-sensitive warnings (running timers, backup nags).
+  final Color warningAmber;
 
   /// Status chip colors — [background, text].
   static const statusPending = (Color(0xFF854D0E), Color(0xFFFCD34D));
@@ -82,6 +85,7 @@ class AppColors extends ThemeExtension<AppColors> {
     Color? messageReceived,
     Color? systemMessage,
     Color? badgeGold,
+    Color? warningAmber,
   }) {
     return AppColors(
       backgroundDark: backgroundDark ?? this.backgroundDark,
@@ -104,6 +108,7 @@ class AppColors extends ThemeExtension<AppColors> {
       messageReceived: messageReceived ?? this.messageReceived,
       systemMessage: systemMessage ?? this.systemMessage,
       badgeGold: badgeGold ?? this.badgeGold,
+      warningAmber: warningAmber ?? this.warningAmber,
     );
   }
 
@@ -133,6 +138,7 @@ class AppColors extends ThemeExtension<AppColors> {
       messageReceived: Color.lerp(messageReceived, other.messageReceived, t)!,
       systemMessage: Color.lerp(systemMessage, other.systemMessage, t)!,
       badgeGold: Color.lerp(badgeGold, other.badgeGold, t)!,
+      warningAmber: Color.lerp(warningAmber, other.warningAmber, t)!,
     );
   }
 }
@@ -193,6 +199,7 @@ const _dark = AppColors(
   messageReceived: Color(0xFF4B6349),
   systemMessage: Color(0xFF2A2D35),
   badgeGold: Color(0xFFB8860B),
+  warningAmber: Color(0xFFE89C3C),
 );
 
 const _light = AppColors(
@@ -216,6 +223,7 @@ const _light = AppColors(
   messageReceived: Color(0xFF4B6349),
   systemMessage: Color(0xFFE0E0E0),
   badgeGold: Color(0xFFB8860B),
+  warningAmber: Color(0xFFC97B1F),
 );
 
 // ── ThemeData factories ────────────────────────────────────────────────────────

--- a/lib/features/account/providers/backup_reminder_provider.dart
+++ b/lib/features/account/providers/backup_reminder_provider.dart
@@ -4,19 +4,115 @@ import 'package:shared_preferences/shared_preferences.dart';
 const kBackupReminderDismissedKey = 'backupReminderDismissed';
 const kBackupReminderActiveKey = 'backupReminderActive';
 
+/// Set to `true` once the user completes the backup ritual (or the legacy
+/// "I have written down my secret words" checkbox).
+const kBackupCompletedKey = 'backupCompleted';
+
+/// Epoch millis until which the backup reminder is snoozed
+/// ("Remind me tomorrow" in the backup trigger sheet).
+const kBackupSnoozedUntilKey = 'backupSnoozedUntilMillis';
+
 /// Tracks whether the backup reminder (red dot on notification bell) is active.
 ///
-/// Active = user has not yet viewed and confirmed their secret words.
+/// Active = user has not yet confirmed their secret words are backed up and
+/// the reminder is not currently snoozed.
 /// Dismissed permanently after `confirmBackupComplete()` is called.
 final backupReminderProvider =
     StateNotifierProvider<BackupReminderNotifier, bool>(
   (ref) => BackupReminderNotifier(),
 );
 
+/// Whether the user has ever completed a backup of the current identity.
+///
+/// Drives the "Backed up" badge on the Account screen. Reset when a new
+/// identity is generated or imported.
+final backupCompletedProvider =
+    StateNotifierProvider<BackupCompletedNotifier, bool>(
+  (ref) => BackupCompletedNotifier(),
+);
+
 class BackupReminderNotifier extends StateNotifier<bool> {
   /// When [initialValue] is provided the notifier starts with the correct
   /// state synchronously so the bell badge renders correctly on first frame.
   BackupReminderNotifier({bool? initialValue}) : super(initialValue ?? false) {
+    if (initialValue == null) {
+      load();
+    } else {
+      _loaded = true;
+      // The synchronous boot value (main.dart) only knows active/dismissed.
+      // Asynchronously clear the badge if a snooze is still in effect.
+      if (initialValue) _reconcileSnooze();
+    }
+  }
+
+  bool _loaded = false;
+
+  static bool _isSnoozed(SharedPreferences prefs) {
+    final until = prefs.getInt(kBackupSnoozedUntilKey) ?? 0;
+    return until > DateTime.now().millisecondsSinceEpoch;
+  }
+
+  Future<void> _reconcileSnooze() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      if (_isSnoozed(prefs)) state = false;
+    } catch (_) {
+      // Prefs unavailable (e.g. tests without a platform channel) — keep
+      // the synchronous initial value.
+    }
+  }
+
+  Future<void> load() async {
+    if (_loaded) return;
+    final prefs = await SharedPreferences.getInstance();
+    final dismissed = prefs.getBool(kBackupReminderDismissedKey) ?? false;
+    final active = prefs.getBool(kBackupReminderActiveKey) ?? false;
+    state = active && !dismissed && !_isSnoozed(prefs);
+    _loaded = true;
+  }
+
+  /// Activate the backup reminder badge. Called after the walkthrough
+  /// completes and whenever a new identity is generated or imported.
+  ///
+  /// Re-arms the reminder even if a previous identity's backup was confirmed:
+  /// a fresh mnemonic is, by definition, not backed up yet.
+  Future<void> showBackupReminder() async {
+    // Ensure load() has finished before writing so a pending load() can't
+    // overwrite the state we are about to set.
+    await load();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(kBackupReminderActiveKey, true);
+    await prefs.setBool(kBackupReminderDismissedKey, false);
+    await prefs.setBool(kBackupCompletedKey, false);
+    await prefs.remove(kBackupSnoozedUntilKey);
+    state = true;
+  }
+
+  /// Snooze the reminder for ~24 hours ("Remind me tomorrow").
+  ///
+  /// The reminder stays active in storage and reappears once the snooze
+  /// window has elapsed.
+  Future<void> snoozeUntilTomorrow() async {
+    await load();
+    final prefs = await SharedPreferences.getInstance();
+    final until = DateTime.now().add(const Duration(days: 1));
+    await prefs.setInt(kBackupSnoozedUntilKey, until.millisecondsSinceEpoch);
+    state = false;
+  }
+
+  /// Permanently dismiss the reminder. Called when the user confirms their
+  /// secret words are backed up (ritual verification or legacy checkbox).
+  Future<void> confirmBackupComplete() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(kBackupReminderDismissedKey, true);
+    await prefs.setBool(kBackupCompletedKey, true);
+    await prefs.remove(kBackupSnoozedUntilKey);
+    state = false;
+  }
+}
+
+class BackupCompletedNotifier extends StateNotifier<bool> {
+  BackupCompletedNotifier({bool? initialValue}) : super(initialValue ?? false) {
     if (initialValue == null) {
       load();
     } else {
@@ -29,27 +125,28 @@ class BackupReminderNotifier extends StateNotifier<bool> {
   Future<void> load() async {
     if (_loaded) return;
     final prefs = await SharedPreferences.getInstance();
-    final dismissed = prefs.getBool(kBackupReminderDismissedKey) ?? false;
-    final active = prefs.getBool(kBackupReminderActiveKey) ?? false;
-    state = active && !dismissed;
+    // Legacy installs only have the dismissed flag, which was set exclusively
+    // by the explicit "I have written down my secret words" confirmation —
+    // treat it as a completed backup.
+    state = prefs.getBool(kBackupCompletedKey) ??
+        prefs.getBool(kBackupReminderDismissedKey) ??
+        false;
     _loaded = true;
   }
 
-  /// Activate the backup reminder badge. Called after walkthrough completes.
-  Future<void> showBackupReminder() async {
-    // Ensure load() has finished before reading the dismissed flag to avoid
-    // a race where load() overwrites the state we are about to set.
+  /// Persist that the current identity has been backed up.
+  Future<void> markCompleted() async {
     await load();
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(kBackupReminderActiveKey, true);
-    final dismissed = prefs.getBool(kBackupReminderDismissedKey) ?? false;
-    if (!dismissed) state = true;
+    await prefs.setBool(kBackupCompletedKey, true);
+    state = true;
   }
 
-  /// Permanently dismiss the reminder. Called when user views their secret words.
-  Future<void> confirmBackupComplete() async {
+  /// Clear the backed-up flag (new identity generated or imported).
+  Future<void> reset() async {
+    await load();
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(kBackupReminderDismissedKey, true);
+    await prefs.setBool(kBackupCompletedKey, false);
     state = false;
   }
 }

--- a/lib/features/account/screens/account_screen.dart
+++ b/lib/features/account/screens/account_screen.dart
@@ -8,6 +8,7 @@ import 'package:mostro/core/app_theme.dart';
 import 'package:mostro/core/services/identity_service.dart';
 import 'package:mostro/features/account/providers/backup_reminder_provider.dart';
 import 'package:mostro/features/account/providers/privacy_mode_provider.dart';
+import 'package:mostro/features/account/widgets/backup_trigger_sheet.dart';
 import 'package:mostro/l10n/app_localizations.dart';
 import 'package:mostro/shared/providers/session_provider.dart';
 import 'package:mostro/src/rust/api/orders.dart' as orders_api;
@@ -77,6 +78,7 @@ class _AccountScreenState extends ConsumerState<AccountScreen> {
   Future<void> _confirmBackup() async {
     try {
       await ref.read(backupReminderProvider.notifier).confirmBackupComplete();
+      await ref.read(backupCompletedProvider.notifier).markCompleted();
       if (mounted) setState(() => _showBackupCheckbox = false);
     } catch (e) {
       debugPrint('[account] _confirmBackup error: $e');
@@ -106,12 +108,23 @@ class _AccountScreenState extends ConsumerState<AccountScreen> {
     final inputBg = colors?.backgroundInput ?? const Color(0xFF252A3A);
     final textSec = colors?.textSecondary ?? const Color(0xFFB0B3C6);
     final privacyMode = ref.watch(privacyModeProvider);
+    final backupPending = ref.watch(backupReminderProvider);
+    final backupDone = ref.watch(backupCompletedProvider);
 
     return Scaffold(
       appBar: AppBar(title: const Text('Account')),
       body: ListView(
         padding: const EdgeInsets.all(AppSpacing.lg),
         children: [
+          // ── Backup ritual banner — entry point for the 3-step backup
+          // flow while the backup reminder is active.
+          if (backupPending) ...[
+            _BackupRitualBanner(
+              onTap: () => showBackupTriggerSheet(context),
+            ),
+            const SizedBox(height: AppSpacing.lg),
+          ],
+
           // ── Secret Words Card ──────────────────────────────────────────
           _SectionCard(
             color: cardBg,
@@ -122,6 +135,7 @@ class _AccountScreenState extends ConsumerState<AccountScreen> {
                   icon: Icons.key,
                   iconColor: green,
                   title: 'Secret Words',
+                  badge: backupDone ? _BackedUpBadge(green: green) : null,
                   onInfo:
                       () => _showInfoDialog(
                         context,
@@ -370,6 +384,7 @@ class _AccountScreenState extends ConsumerState<AccountScreen> {
                     await ref
                         .read(backupReminderProvider.notifier)
                         .showBackupReminder();
+                    await ref.read(backupCompletedProvider.notifier).reset();
                     // Only clear UI state and navigate once the new identity exists.
                     if (!context.mounted) return;
                     setState(() {
@@ -414,6 +429,7 @@ class _AccountScreenState extends ConsumerState<AccountScreen> {
       await IdentityService.importAndStore(words);
       ref.read(sessionProvider.notifier).clearSession();
       await ref.read(backupReminderProvider.notifier).showBackupReminder();
+      await ref.read(backupCompletedProvider.notifier).reset();
       if (!context.mounted) return;
       setState(() {
         _wordsVisible = false;
@@ -509,12 +525,16 @@ class _CardHeader extends StatelessWidget {
     required this.iconColor,
     required this.title,
     required this.onInfo,
+    this.badge,
   });
 
   final IconData icon;
   final Color iconColor;
   final String title;
   final VoidCallback onInfo;
+
+  /// Optional badge shown right after the title (e.g. "Backed up").
+  final Widget? badge;
 
   @override
   Widget build(BuildContext context) {
@@ -528,6 +548,10 @@ class _CardHeader extends StatelessWidget {
             context,
           ).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w600),
         ),
+        if (badge != null) ...[
+          const SizedBox(width: AppSpacing.sm),
+          badge!,
+        ],
         const Spacer(),
         IconButton(
           onPressed: onInfo,
@@ -537,6 +561,102 @@ class _CardHeader extends StatelessWidget {
           constraints: const BoxConstraints(),
         ),
       ],
+    );
+  }
+}
+
+// ── Backup ritual banner + badge ──────────────────────────────────────────────
+
+/// Banner shown while the backup reminder is active. Tapping it opens the
+/// backup ritual trigger sheet.
+class _BackupRitualBanner extends StatelessWidget {
+  const _BackupRitualBanner({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = theme.extension<AppColors>();
+    final cardBg = colors?.backgroundCard ?? const Color(0xFF1E2230);
+    final amber = colors?.warningAmber ?? const Color(0xFFE89C3C);
+    final textSec = colors?.textSecondary ?? const Color(0xFFB0B3C6);
+
+    return Material(
+      color: cardBg,
+      borderRadius: BorderRadius.circular(AppRadius.card),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(AppRadius.card),
+        child: Container(
+          padding: const EdgeInsets.all(AppSpacing.lg),
+          decoration: BoxDecoration(
+            border: Border.all(color: amber.withValues(alpha: 0.5)),
+            borderRadius: BorderRadius.circular(AppRadius.card),
+          ),
+          child: Row(
+            children: [
+              Icon(Icons.shield_outlined, color: amber, size: 24),
+              const SizedBox(width: AppSpacing.md),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Secure your reputation',
+                      style: theme.textTheme.bodyMedium!.copyWith(
+                        fontWeight: FontWeight.w600,
+                        color: amber,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      'Back up your 12 words — it takes 60 seconds.',
+                      style:
+                          theme.textTheme.bodySmall!.copyWith(color: textSec),
+                    ),
+                  ],
+                ),
+              ),
+              const Icon(Icons.chevron_right, size: 20),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Small green "Backed up" chip shown in the Secret Words card header once
+/// the backup ritual (or legacy checkbox) has been completed.
+class _BackedUpBadge extends StatelessWidget {
+  const _BackedUpBadge({required this.green});
+
+  final Color green;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: green.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(AppRadius.chip),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.check, size: 12, color: green),
+          const SizedBox(width: 3),
+          Text(
+            'Backed up',
+            style: TextStyle(
+              color: green,
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/features/account/screens/backup_ritual_screen.dart
+++ b/lib/features/account/screens/backup_ritual_screen.dart
@@ -1,0 +1,841 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:mostro/core/app_theme.dart';
+import 'package:mostro/core/services/identity_service.dart';
+import 'package:mostro/features/account/providers/backup_reminder_provider.dart';
+
+/// Fallback decoy words for the verification step, used only in the
+/// (degenerate) case where the mnemonic itself does not contain enough
+/// distinct words to build a 4-option grid.
+const _fallbackDecoys = [
+  'mountain',
+  'river',
+  'orange',
+  'planet',
+  'silver',
+  'garden',
+  'rocket',
+  'candle',
+];
+
+/// 3-step backup ritual (pushed via Navigator from the trigger sheet):
+///
+///   1. Show the 12 secret words (write them on paper).
+///   2. Verify 3 words at random.
+///   3. Done — backup confirmed and persisted.
+///
+/// The words live only in this screen's state and are discarded when the
+/// screen is left, restoring the masked behavior of the Account screen.
+class BackupRitualScreen extends ConsumerStatefulWidget {
+  const BackupRitualScreen({super.key});
+
+  @override
+  ConsumerState<BackupRitualScreen> createState() => _BackupRitualScreenState();
+}
+
+class _BackupRitualScreenState extends ConsumerState<BackupRitualScreen> {
+  final _random = math.Random();
+
+  int _step = 0;
+  List<String>? _words;
+
+  // ── Verification state ──
+  /// The 3 challenged word positions (0-based, sorted ascending).
+  List<int> _challenge = const [];
+
+  /// User answers per challenge slot; null = not answered yet.
+  List<String?> _filled = [null, null, null];
+
+  /// Index into [_challenge] of the slot currently being answered.
+  int _activeSlot = 0;
+
+  /// 4 shuffled options for the active slot.
+  List<String> _options = const [];
+
+  /// Option the user last tapped incorrectly (cleared on next tap).
+  String? _wrongPick;
+
+  bool _confirming = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadWords();
+  }
+
+  @override
+  void dispose() {
+    // Drop the mnemonic from memory as soon as the ritual is left.
+    _words = null;
+    super.dispose();
+  }
+
+  Future<void> _loadWords() async {
+    try {
+      final words = await IdentityService.getMnemonicWords();
+      if (!mounted) return;
+      if (words.isEmpty) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('No identity found — try restarting the app.'),
+          ),
+        );
+        Navigator.of(context).pop();
+        return;
+      }
+      setState(() => _words = words);
+    } catch (e) {
+      // Never log the words themselves; the error alone is safe.
+      debugPrint('[backup-ritual] failed to load words: $e');
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Failed to load secret words. Please try again.'),
+        ),
+      );
+      Navigator.of(context).pop();
+    }
+  }
+
+  // ── Challenge generation ────────────────────────────────────────────────
+
+  void _startVerification() {
+    final words = _words;
+    if (words == null) return;
+    final indices = <int>{};
+    while (indices.length < 3 && indices.length < words.length) {
+      indices.add(_random.nextInt(words.length));
+    }
+    setState(() {
+      _challenge = indices.toList()..sort();
+      _filled = [null, null, null];
+      _activeSlot = 0;
+      _wrongPick = null;
+      _options = _buildOptions(_challenge[0]);
+      _step = 1;
+    });
+  }
+
+  List<String> _buildOptions(int wordIndex) {
+    final words = _words!;
+    final correct = words[wordIndex];
+    final decoys = <String>{};
+    final pool = List<String>.of(words)..shuffle(_random);
+    for (final w in pool) {
+      if (decoys.length == 3) break;
+      if (w != correct) decoys.add(w);
+    }
+    // Degenerate mnemonics (repeated words) — pad from a static pool.
+    for (final w in _fallbackDecoys) {
+      if (decoys.length == 3) break;
+      if (w != correct) decoys.add(w);
+    }
+    return [correct, ...decoys]..shuffle(_random);
+  }
+
+  void _onOptionTap(String word) {
+    final words = _words;
+    if (words == null || _activeSlot >= _challenge.length) return;
+    final correct = words[_challenge[_activeSlot]];
+    if (word == correct) {
+      setState(() {
+        _filled[_activeSlot] = word;
+        _wrongPick = null;
+        final next = _filled.indexWhere((w) => w == null);
+        if (next != -1) {
+          _activeSlot = next;
+          _options = _buildOptions(_challenge[next]);
+        } else {
+          _activeSlot = _challenge.length; // all done
+          _options = const [];
+        }
+      });
+    } else {
+      setState(() => _wrongPick = word);
+    }
+  }
+
+  bool get _allCorrect =>
+      _challenge.isNotEmpty && _filled.every((w) => w != null);
+
+  Future<void> _confirm() async {
+    if (!_allCorrect || _confirming) return;
+    setState(() => _confirming = true);
+    try {
+      await ref.read(backupReminderProvider.notifier).confirmBackupComplete();
+      await ref.read(backupCompletedProvider.notifier).markCompleted();
+      if (mounted) setState(() => _step = 2);
+    } catch (e) {
+      debugPrint('[backup-ritual] confirm error: $e');
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Failed to save backup status. Please try again.'),
+          ),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _confirming = false);
+    }
+  }
+
+  void _backToWords() {
+    setState(() {
+      _step = 0;
+      _challenge = const [];
+      _filled = [null, null, null];
+      _activeSlot = 0;
+      _options = const [];
+      _wrongPick = null;
+    });
+  }
+
+  // ── Build ───────────────────────────────────────────────────────────────
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = theme.extension<AppColors>();
+    final green = colors?.mostroGreen ?? const Color(0xFF8CC63F);
+    final elevated = colors?.backgroundElevated ?? const Color(0xFF2A2D35);
+
+    final title = switch (_step) {
+      0 => 'Step 1 of 3 · Write down your words',
+      1 => 'Step 2 of 3 · Verify',
+      _ => 'Step 3 of 3 · Done',
+    };
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(title, style: const TextStyle(fontSize: 15)),
+        automaticallyImplyLeading: false,
+        leading: _step == 2
+            ? null
+            : BackButton(
+                onPressed: () {
+                  if (_step == 1) {
+                    _backToWords();
+                  } else {
+                    Navigator.of(context).pop();
+                  }
+                },
+              ),
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(
+            AppSpacing.lg,
+            AppSpacing.lg,
+            AppSpacing.lg,
+            AppSpacing.xl,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              _ProgressBar(step: _step, green: green, elevated: elevated),
+              const SizedBox(height: AppSpacing.md),
+              Expanded(
+                child: switch (_step) {
+                  0 => _buildShowWords(theme, colors),
+                  1 => _buildVerify(theme, colors),
+                  _ => _buildDone(theme, colors),
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  // ── Step 1: show words ──────────────────────────────────────────────────
+
+  Widget _buildShowWords(ThemeData theme, AppColors? colors) {
+    final green = colors?.mostroGreen ?? const Color(0xFF8CC63F);
+    final cardBg = colors?.backgroundCard ?? const Color(0xFF1E2230);
+    final elevated = colors?.backgroundElevated ?? const Color(0xFF2A2D35);
+    final textSec = colors?.textSecondary ?? const Color(0xFFB0B3C6);
+    final textSubtle = colors?.textSubtle ?? const Color(0xFF9A9A9C);
+    final amber = colors?.warningAmber ?? const Color(0xFFE89C3C);
+
+    final words = _words;
+    if (words == null) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    return _ScrollableStep(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // Amber warning card
+        Container(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.md,
+            vertical: AppSpacing.md,
+          ),
+          decoration: BoxDecoration(
+            color: amber.withValues(alpha: 0.12),
+            border: Border.all(color: amber.withValues(alpha: 0.27)),
+            borderRadius: BorderRadius.circular(AppRadius.card),
+          ),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(Icons.warning_amber_rounded, color: amber, size: 20),
+              const SizedBox(width: AppSpacing.sm),
+              Expanded(
+                child: Text.rich(
+                  const TextSpan(
+                    text: 'Write them on paper. ',
+                    style: TextStyle(fontWeight: FontWeight.w700),
+                    children: [
+                      TextSpan(
+                        text:
+                            "Don't store them in photos, screenshots or the "
+                            'cloud — anyone with these 12 words can steal '
+                            'your reputation.',
+                        style: TextStyle(fontWeight: FontWeight.w400),
+                      ),
+                    ],
+                  ),
+                  style: theme.textTheme.bodySmall!
+                      .copyWith(color: amber, height: 1.5),
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: AppSpacing.md),
+
+        // Words grid card
+        Container(
+          padding: const EdgeInsets.all(AppSpacing.lg),
+          decoration: BoxDecoration(
+            color: cardBg,
+            borderRadius: BorderRadius.circular(AppRadius.card),
+          ),
+          child: Column(
+            children: [
+              for (var row = 0; row < (words.length + 1) ~/ 2; row++) ...[
+                if (row > 0) const SizedBox(height: AppSpacing.sm),
+                Row(
+                  children: [
+                    for (var col = 0; col < 2; col++) ...[
+                      if (col > 0) const SizedBox(width: AppSpacing.sm),
+                      Expanded(
+                        child: row * 2 + col < words.length
+                            ? _WordCell(
+                                index: row * 2 + col,
+                                word: words[row * 2 + col],
+                                background: elevated,
+                                indexColor: textSubtle,
+                              )
+                            : const SizedBox.shrink(),
+                      ),
+                    ],
+                  ],
+                ),
+              ],
+              const SizedBox(height: AppSpacing.md),
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(AppSpacing.sm + 2),
+                decoration: BoxDecoration(
+                  color: elevated,
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(Icons.visibility_off_outlined,
+                        size: 14, color: textSec),
+                    const SizedBox(width: AppSpacing.xs),
+                    Flexible(
+                      child: Text(
+                        'These words will be hidden when you leave this screen',
+                        style: theme.textTheme.bodySmall!
+                            .copyWith(color: textSec, fontSize: 12),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+
+        const Spacer(),
+
+        FilledButton.icon(
+          onPressed: _startVerification,
+          icon: const Text(
+            'I wrote them down — verify',
+            style: TextStyle(fontSize: 15, fontWeight: FontWeight.w700),
+          ),
+          label: const Icon(Icons.arrow_forward, size: 18),
+          style: FilledButton.styleFrom(
+            backgroundColor: green,
+            foregroundColor: Colors.black,
+            minimumSize: const Size.fromHeight(54),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(14),
+            ),
+          ),
+        ),
+        ],
+      ),
+    );
+  }
+
+  // ── Step 2: verify ──────────────────────────────────────────────────────
+
+  Widget _buildVerify(ThemeData theme, AppColors? colors) {
+    final green = colors?.mostroGreen ?? const Color(0xFF8CC63F);
+    final cardBg = colors?.backgroundCard ?? const Color(0xFF1E2230);
+    final elevated = colors?.backgroundElevated ?? const Color(0xFF2A2D35);
+    final textSec = colors?.textSecondary ?? const Color(0xFFB0B3C6);
+    final textSubtle = colors?.textSubtle ?? const Color(0xFF9A9A9C);
+    final textDisabled = colors?.textDisabled ?? const Color(0xFF6C757D);
+    final red = colors?.destructiveRed ?? const Color(0xFFD84D4D);
+
+    final hasActiveSlot = _activeSlot < _challenge.length;
+
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const SizedBox(height: AppSpacing.sm),
+          Text(
+            'Tap the correct words',
+            style: theme.textTheme.titleLarge!
+                .copyWith(fontWeight: FontWeight.w700),
+          ),
+          const SizedBox(height: AppSpacing.xs),
+          Text(
+            'We ask for 3 at random. If you get them right, we know '
+            "they're safely written down.",
+            style:
+                theme.textTheme.bodySmall!.copyWith(color: textSec, height: 1.5),
+          ),
+          const SizedBox(height: AppSpacing.md),
+
+          // Slot rows
+          Container(
+            padding: const EdgeInsets.all(AppSpacing.md),
+            decoration: BoxDecoration(
+              color: cardBg,
+              borderRadius: BorderRadius.circular(AppRadius.card),
+            ),
+            child: Column(
+              children: [
+                for (var i = 0; i < _challenge.length; i++) ...[
+                  if (i > 0) const SizedBox(height: AppSpacing.sm),
+                  _SlotRow(
+                    wordNumber: _challenge[i] + 1,
+                    value: _filled[i],
+                    isActive: i == _activeSlot,
+                    green: green,
+                    elevated: elevated,
+                    textSubtle: textSubtle,
+                    borderColor: textDisabled,
+                  ),
+                ],
+              ],
+            ),
+          ),
+          const SizedBox(height: AppSpacing.lg),
+
+          // Options for the active slot
+          if (hasActiveSlot) ...[
+            Text(
+              'OPTIONS FOR WORD #${_challenge[_activeSlot] + 1}',
+              style: theme.textTheme.bodySmall!.copyWith(
+                color: textSubtle,
+                fontSize: 12,
+                letterSpacing: 1,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            for (var row = 0; row < (_options.length + 1) ~/ 2; row++) ...[
+              if (row > 0) const SizedBox(height: AppSpacing.sm),
+              Row(
+                children: [
+                  for (var col = 0; col < 2; col++) ...[
+                    if (col > 0) const SizedBox(width: AppSpacing.sm),
+                    Expanded(
+                      child: row * 2 + col < _options.length
+                          ? _OptionButton(
+                              word: _options[row * 2 + col],
+                              isWrong: _options[row * 2 + col] == _wrongPick,
+                              cardBg: cardBg,
+                              red: red,
+                              borderColor: textDisabled.withValues(alpha: 0.4),
+                              onTap: () =>
+                                  _onOptionTap(_options[row * 2 + col]),
+                            )
+                          : const SizedBox.shrink(),
+                    ),
+                  ],
+                ],
+              ),
+            ],
+            if (_wrongPick != null) ...[
+              const SizedBox(height: AppSpacing.sm),
+              Text(
+                'Not quite — check your paper and try again.',
+                style: theme.textTheme.bodySmall!
+                    .copyWith(color: red, fontSize: 12),
+              ),
+            ],
+          ] else ...[
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(Icons.check_circle_outline, size: 16, color: green),
+                const SizedBox(width: AppSpacing.xs),
+                Text(
+                  'All 3 words correct!',
+                  style: theme.textTheme.bodySmall!.copyWith(color: green),
+                ),
+              ],
+            ),
+          ],
+          const SizedBox(height: AppSpacing.xl),
+
+          // Footer
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: _backToWords,
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: textSec,
+                    side: BorderSide(color: textDisabled),
+                    minimumSize: const Size.fromHeight(50),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(AppRadius.card),
+                    ),
+                  ),
+                  child: const Text(
+                    'Show words again',
+                    style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
+                  ),
+                ),
+              ),
+              const SizedBox(width: AppSpacing.sm),
+              Expanded(
+                child: FilledButton(
+                  onPressed: _allCorrect && !_confirming ? _confirm : null,
+                  style: FilledButton.styleFrom(
+                    backgroundColor: green,
+                    foregroundColor: Colors.black,
+                    disabledBackgroundColor: elevated,
+                    disabledForegroundColor: textDisabled,
+                    minimumSize: const Size.fromHeight(50),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(AppRadius.card),
+                    ),
+                  ),
+                  child: _confirming
+                      ? const SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Text(
+                          'Confirm',
+                          style: TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ── Step 3: done ────────────────────────────────────────────────────────
+
+  Widget _buildDone(ThemeData theme, AppColors? colors) {
+    final green = colors?.mostroGreen ?? const Color(0xFF8CC63F);
+    final textSec = colors?.textSecondary ?? const Color(0xFFB0B3C6);
+
+    return _ScrollableStep(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+        const Spacer(),
+        Center(
+          child: Container(
+            width: 112,
+            height: 112,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: green.withValues(alpha: 0.15),
+            ),
+            child: Icon(Icons.check_rounded, size: 64, color: green),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.xl),
+        Text(
+          'Your account is backed up',
+          textAlign: TextAlign.center,
+          style:
+              theme.textTheme.titleLarge!.copyWith(fontWeight: FontWeight.w700),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        Text(
+          'Your reputation is safe. If you ever lose your phone, '
+          'restore your account with your 12 words.',
+          textAlign: TextAlign.center,
+          style:
+              theme.textTheme.bodyMedium!.copyWith(color: textSec, height: 1.5),
+        ),
+        const Spacer(),
+        FilledButton(
+          onPressed: () => Navigator.of(context).pop(),
+          style: FilledButton.styleFrom(
+            backgroundColor: green,
+            foregroundColor: Colors.black,
+            minimumSize: const Size.fromHeight(54),
+            textStyle:
+                const TextStyle(fontSize: 15, fontWeight: FontWeight.w700),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(14),
+            ),
+          ),
+          child: const Text('Done'),
+        ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── Internal widgets ──────────────────────────────────────────────────────────
+
+/// Makes a step body scrollable on small screens while still letting
+/// [Spacer]s push the CTA to the bottom on tall screens.
+class _ScrollableStep extends StatelessWidget {
+  const _ScrollableStep({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return SingleChildScrollView(
+          child: ConstrainedBox(
+            constraints: BoxConstraints(minHeight: constraints.maxHeight),
+            child: IntrinsicHeight(child: child),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _ProgressBar extends StatelessWidget {
+  const _ProgressBar({
+    required this.step,
+    required this.green,
+    required this.elevated,
+  });
+
+  final int step;
+  final Color green;
+  final Color elevated;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        for (var i = 0; i < 3; i++) ...[
+          if (i > 0) const SizedBox(width: 6),
+          Expanded(
+            child: Container(
+              height: 4,
+              decoration: BoxDecoration(
+                color: i <= step ? green : elevated,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _WordCell extends StatelessWidget {
+  const _WordCell({
+    required this.index,
+    required this.word,
+    required this.background,
+    required this.indexColor,
+  });
+
+  final int index;
+  final String word;
+  final Color background;
+  final Color indexColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Row(
+        children: [
+          Text(
+            (index + 1).toString().padLeft(2, '0'),
+            style: TextStyle(
+              fontFamily: 'monospace',
+              fontSize: 11,
+              color: indexColor,
+            ),
+          ),
+          const SizedBox(width: AppSpacing.sm),
+          Expanded(
+            child: Text(
+              word,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(
+                fontFamily: 'monospace',
+                fontSize: 14,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SlotRow extends StatelessWidget {
+  const _SlotRow({
+    required this.wordNumber,
+    required this.value,
+    required this.isActive,
+    required this.green,
+    required this.elevated,
+    required this.textSubtle,
+    required this.borderColor,
+  });
+
+  /// 1-based position of the word in the mnemonic.
+  final int wordNumber;
+  final String? value;
+  final bool isActive;
+  final Color green;
+  final Color elevated;
+  final Color textSubtle;
+  final Color borderColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final filled = value != null;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+      decoration: BoxDecoration(
+        color: filled ? green.withValues(alpha: 0.12) : elevated,
+        border: Border.all(
+          color: filled
+              ? green.withValues(alpha: 0.4)
+              : isActive
+                  ? green.withValues(alpha: 0.5)
+                  : borderColor.withValues(alpha: 0.4),
+        ),
+        borderRadius: BorderRadius.circular(AppRadius.card),
+      ),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 64,
+            child: Text(
+              'Word #$wordNumber',
+              style: TextStyle(
+                fontFamily: 'monospace',
+                fontSize: 12,
+                color: textSubtle,
+              ),
+            ),
+          ),
+          const SizedBox(width: AppSpacing.sm),
+          Expanded(
+            child: Text(
+              value ?? '—',
+              style: TextStyle(
+                fontFamily: 'monospace',
+                fontSize: 15,
+                fontWeight: FontWeight.w600,
+                color: filled ? green : textSubtle,
+              ),
+            ),
+          ),
+          if (filled) Icon(Icons.check, size: 18, color: green),
+        ],
+      ),
+    );
+  }
+}
+
+class _OptionButton extends StatelessWidget {
+  const _OptionButton({
+    required this.word,
+    required this.isWrong,
+    required this.cardBg,
+    required this.red,
+    required this.borderColor,
+    required this.onTap,
+  });
+
+  final String word;
+  final bool isWrong;
+  final Color cardBg;
+  final Color red;
+  final Color borderColor;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: cardBg,
+      borderRadius: BorderRadius.circular(AppRadius.card),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(AppRadius.card),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 14),
+          decoration: BoxDecoration(
+            border: Border.all(color: isWrong ? red : borderColor),
+            borderRadius: BorderRadius.circular(AppRadius.card),
+          ),
+          child: Text(
+            word,
+            textAlign: TextAlign.center,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              fontFamily: 'monospace',
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+              color: isWrong ? red : null,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/account/widgets/backup_trigger_sheet.dart
+++ b/lib/features/account/widgets/backup_trigger_sheet.dart
@@ -1,0 +1,201 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:mostro/core/app_theme.dart';
+import 'package:mostro/features/account/providers/backup_reminder_provider.dart';
+import 'package:mostro/features/account/screens/backup_ritual_screen.dart';
+
+/// Opens the backup ritual trigger bottom sheet.
+///
+/// "Back up now" launches the 3-step [BackupRitualScreen];
+/// "Remind me tomorrow" snoozes the reminder for ~24 hours.
+Future<void> showBackupTriggerSheet(BuildContext context) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.transparent,
+    builder: (_) => const BackupTriggerSheet(),
+  );
+}
+
+/// Bottom sheet inviting the user to start the backup ritual.
+class BackupTriggerSheet extends ConsumerWidget {
+  const BackupTriggerSheet({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final colors = theme.extension<AppColors>();
+    final green = colors?.mostroGreen ?? const Color(0xFF8CC63F);
+    final cardBg = colors?.backgroundCard ?? const Color(0xFF1E2230);
+    final elevated = colors?.backgroundElevated ?? const Color(0xFF2A2D35);
+    final textSec = colors?.textSecondary ?? const Color(0xFFB0B3C6);
+    final textDisabled = colors?.textDisabled ?? const Color(0xFF6C757D);
+    final amber = colors?.warningAmber ?? const Color(0xFFE89C3C);
+
+    return Container(
+      decoration: BoxDecoration(
+        color: cardBg,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.xl,
+        AppSpacing.lg,
+        AppSpacing.xl,
+        AppSpacing.xl,
+      ),
+      child: SafeArea(
+        top: false,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            // Drag handle
+            Center(
+              child: Container(
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: textDisabled,
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+            ),
+            const SizedBox(height: AppSpacing.lg),
+
+            // Hero circle
+            Center(
+              child: Container(
+                width: 96,
+                height: 96,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  gradient: RadialGradient(
+                    colors: [
+                      green.withValues(alpha: 0.33),
+                      green.withValues(alpha: 0.10),
+                    ],
+                  ),
+                ),
+                child: Icon(Icons.star_rounded, size: 40, color: amber),
+              ),
+            ),
+            const SizedBox(height: AppSpacing.lg),
+
+            Text(
+              'Secure your reputation',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.titleLarge!
+                  .copyWith(fontWeight: FontWeight.w700),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Text.rich(
+              TextSpan(
+                text: 'Your reputation lives in a key only you hold. '
+                    'If you lose your phone, you lose that reputation — ',
+                children: [
+                  TextSpan(
+                    text: 'back it up in 60 seconds.',
+                    style:
+                        TextStyle(color: green, fontWeight: FontWeight.w600),
+                  ),
+                ],
+              ),
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium!
+                  .copyWith(color: textSec, height: 1.5),
+            ),
+            const SizedBox(height: AppSpacing.lg),
+
+            // 3-step preview
+            Container(
+              padding: const EdgeInsets.all(AppSpacing.md),
+              decoration: BoxDecoration(
+                color: elevated,
+                borderRadius: BorderRadius.circular(AppRadius.card),
+              ),
+              child: Column(
+                children: [
+                  for (final (n, label) in const [
+                    (1, 'Write your 12 words down on paper'),
+                    (2, 'We ask for 3 at random to confirm'),
+                    (3, 'Done — your account is secured'),
+                  ]) ...[
+                    if (n > 1) const SizedBox(height: AppSpacing.sm),
+                    Row(
+                      children: [
+                        Container(
+                          width: 24,
+                          height: 24,
+                          decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            color: green.withValues(alpha: 0.15),
+                          ),
+                          alignment: Alignment.center,
+                          child: Text(
+                            '$n',
+                            style: TextStyle(
+                              color: green,
+                              fontSize: 12,
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: AppSpacing.md),
+                        Expanded(
+                          child: Text(label, style: theme.textTheme.bodySmall),
+                        ),
+                      ],
+                    ),
+                  ],
+                ],
+              ),
+            ),
+            const SizedBox(height: AppSpacing.lg),
+
+            // Primary CTA
+            FilledButton(
+              onPressed: () {
+                final navigator = Navigator.of(context);
+                navigator.pop();
+                navigator.push(
+                  MaterialPageRoute<void>(
+                    builder: (_) => const BackupRitualScreen(),
+                  ),
+                );
+              },
+              style: FilledButton.styleFrom(
+                backgroundColor: green,
+                foregroundColor: Colors.black,
+                minimumSize: const Size.fromHeight(54),
+                textStyle:
+                    const TextStyle(fontSize: 15, fontWeight: FontWeight.w700),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(14),
+                ),
+              ),
+              child: const Text('Back up now'),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+
+            // Ghost CTA
+            TextButton(
+              onPressed: () {
+                ref
+                    .read(backupReminderProvider.notifier)
+                    .snoozeUntilTomorrow();
+                Navigator.of(context).pop();
+              },
+              style: TextButton.styleFrom(
+                foregroundColor: textSec,
+                minimumSize: const Size.fromHeight(44),
+                textStyle: const TextStyle(fontSize: 13),
+              ),
+              child: const Text('Remind me tomorrow'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/chat/screens/chat_room_screen.dart
+++ b/lib/features/chat/screens/chat_room_screen.dart
@@ -8,6 +8,7 @@ import 'package:mostro/features/chat/providers/chat_providers.dart';
 import 'package:mostro/features/chat/widgets/info_panels.dart';
 import 'package:mostro/features/chat/widgets/message_bubble.dart';
 import 'package:mostro/features/chat/widgets/message_input.dart';
+import 'package:mostro/features/chat/widgets/trade_state_header.dart';
 import 'package:mostro/shared/widgets/bottom_nav_bar.dart';
 import 'package:mostro/shared/widgets/nym_avatar.dart';
 import 'package:mostro/src/rust/api/messages.dart' as messages_api;
@@ -269,6 +270,10 @@ class _ChatRoomScreenState extends ConsumerState<ChatRoomScreen> {
     // Chat column
     final chatColumn = Column(
       children: [
+        // Sticky trade-state header — pinned below the app bar, does not
+        // scroll with messages. Hides itself when the order can't be resolved.
+        TradeStateHeader(orderId: widget.orderId),
+
         // Info panels (mobile only)
         if (!showSidePanel)
           AnimatedSwitcher(

--- a/lib/features/chat/widgets/trade_state_header.dart
+++ b/lib/features/chat/widgets/trade_state_header.dart
@@ -1,0 +1,334 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:mostro/core/app_routes.dart';
+import 'package:mostro/core/app_theme.dart';
+import 'package:mostro/features/home/providers/home_order_providers.dart';
+import 'package:mostro/features/order/providers/trade_state_provider.dart';
+import 'package:mostro/features/trades/providers/trades_providers.dart';
+import 'package:mostro/src/rust/api/orders.dart' as orders_api;
+import 'package:mostro/src/rust/api/types.dart' as rust_types;
+
+// ── Order resolution ──────────────────────────────────────────────────────────
+
+/// Resolves the order backing a chat room, for the sticky trade-state header.
+///
+/// Priority:
+/// 1. Live order book entry ([orderBookProvider]).
+/// 2. One-shot `getOrder()` from the in-memory book.
+/// 3. Persisted trade DB (`listTrades()`), so taken/terminal trades still
+///    resolve after the order leaves the book.
+///
+/// Returns `null` when no data is found so the header can hide itself.
+/// Re-resolves whenever the live trade status changes.
+final chatTradeOrderProvider =
+    FutureProvider.family.autoDispose<OrderItem?, String>((ref, orderId) async {
+  // Re-resolve when the polled status changes (e.g. active → fiatSent).
+  ref.watch(tradeStatusProvider(orderId));
+
+  final book = ref.watch(orderBookProvider).valueOrNull;
+  final fromBook = book?.where((o) => o.id == orderId).firstOrNull;
+  if (fromBook != null) return fromBook;
+
+  try {
+    final info = await orders_api.getOrder(orderId: orderId);
+    if (info != null) return _toOrderItem(info);
+
+    final trades = await orders_api.listTrades();
+    final trade = trades.where((t) => t.order.id == orderId).firstOrNull;
+    if (trade != null) return _toOrderItem(trade.order);
+  } catch (e) {
+    debugPrint('[TradeStateHeader] order lookup failed: $e');
+  }
+  return null;
+});
+
+OrderItem? _toOrderItem(rust_types.OrderInfo info) {
+  try {
+    return OrderItem.fromInfo(info);
+  } on ArgumentError {
+    // Malformed amount shape (neither fixed nor range) — degrade gracefully.
+    return null;
+  }
+}
+
+// ── TradeStateHeader ──────────────────────────────────────────────────────────
+
+/// Compact trade-state card pinned below the chat app bar (UX proposal #6).
+///
+/// Row 1: status pill · "Buying/Selling N sats" · fiat amount.
+/// Row 2: payment method · live countdown ("MM:SS left") · "View order ↗".
+///
+/// Tapping anywhere on the card navigates to the trade detail screen.
+/// Hides itself entirely when the order cannot be resolved.
+class TradeStateHeader extends ConsumerWidget {
+  const TradeStateHeader({super.key, required this.orderId});
+
+  final String orderId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final order = ref.watch(chatTradeOrderProvider(orderId)).valueOrNull;
+    if (order == null) return const SizedBox.shrink();
+
+    final colors = Theme.of(context).extension<AppColors>();
+    final textTheme = Theme.of(context).textTheme;
+
+    final cardColor = colors?.backgroundCard ?? const Color(0xFF1E2230);
+    final primary = colors?.textPrimary ?? const Color(0xFFFFFFFF);
+    final secondary = colors?.textSecondary ?? const Color(0xFFB0B3C6);
+    final amber = colors?.warningAmber ?? const Color(0xFFE89C3C);
+    final green = colors?.mostroGreen ?? const Color(0xFF8CC63F);
+
+    // Live status overrides the snapshot baked into the resolved order.
+    final liveStatus = ref.watch(tradeStatusProvider(orderId)).valueOrNull;
+    final statusFilter = orderStatusToFilter(liveStatus ?? order.status);
+    final (pillBg, pillFg) = _statusColors(statusFilter);
+
+    // Buyer/seller role: in-memory map → persisted DB → derive from order.
+    final isBuyer = ref.watch(tradeRoleProvider)[orderId] ??
+        ref.watch(tradeRoleFromDbProvider(orderId)).valueOrNull ??
+        _deriveIsBuyer(order);
+
+    final roleWord = isBuyer ? 'Buying' : 'Selling';
+    final amountLabel = order.amountSats != null
+        ? '$roleWord ${_fmtSats(order.amountSats!)} sats'
+        : '$roleWord Bitcoin';
+
+    final dot = Text('·', style: textTheme.bodySmall?.copyWith(color: secondary));
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.md,
+        AppSpacing.sm,
+        AppSpacing.md,
+        0,
+      ),
+      child: Material(
+        color: cardColor,
+        borderRadius: BorderRadius.circular(AppRadius.card),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(AppRadius.card),
+          onTap: () => context.push(AppRoute.tradeDetailPath(orderId)),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: 14,
+              vertical: AppSpacing.md,
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // ── Row 1: status pill · amount · fiat ────────────────────
+                Wrap(
+                  spacing: 6,
+                  runSpacing: AppSpacing.xs,
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: AppSpacing.sm,
+                        vertical: 2,
+                      ),
+                      decoration: BoxDecoration(
+                        color: pillBg,
+                        borderRadius: BorderRadius.circular(AppRadius.chip),
+                      ),
+                      child: Text(
+                        statusFilter.label,
+                        style: textTheme.bodySmall?.copyWith(
+                          color: pillFg,
+                          fontWeight: FontWeight.w500,
+                          fontSize: 11,
+                        ),
+                      ),
+                    ),
+                    dot,
+                    Text(
+                      amountLabel,
+                      style: textTheme.bodySmall?.copyWith(
+                        color: primary,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    dot,
+                    Text(
+                      '${order.displayAmount} ${order.fiatCode}',
+                      style: textTheme.bodySmall?.copyWith(color: secondary),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 6),
+
+                // ── Row 2: method · countdown · view order ────────────────
+                Row(
+                  children: [
+                    if (order.paymentMethod.isNotEmpty) ...[
+                      Icon(Icons.credit_card, size: 12, color: secondary),
+                      const SizedBox(width: AppSpacing.xs),
+                      Flexible(
+                        child: Text(
+                          order.paymentMethod,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: textTheme.bodySmall?.copyWith(
+                            color: secondary,
+                            fontSize: 11,
+                          ),
+                        ),
+                      ),
+                    ],
+                    if (order.expiresAt != null)
+                      _CountdownChip(
+                        expiresAt: order.expiresAt!,
+                        color: amber,
+                        separatorColor: secondary,
+                        showSeparator: order.paymentMethod.isNotEmpty,
+                      ),
+                    const Spacer(),
+                    const SizedBox(width: AppSpacing.sm),
+                    Text(
+                      'View order',
+                      style: textTheme.bodySmall?.copyWith(
+                        color: green,
+                        fontWeight: FontWeight.w600,
+                        fontSize: 11,
+                      ),
+                    ),
+                    const SizedBox(width: 2),
+                    Icon(Icons.north_east, size: 11, color: green),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  /// Maps a [TradeStatusFilter] to (background, foreground) pill colors.
+  static (Color, Color) _statusColors(TradeStatusFilter status) {
+    return switch (status) {
+      TradeStatusFilter.pending => AppColors.statusPending,
+      TradeStatusFilter.waitingInvoice => AppColors.statusWaiting,
+      TradeStatusFilter.waitingPayment => AppColors.statusWaiting,
+      TradeStatusFilter.active => AppColors.statusActive,
+      TradeStatusFilter.fiatSent => AppColors.statusActive,
+      TradeStatusFilter.success => AppColors.statusSuccess,
+      TradeStatusFilter.canceled => AppColors.statusInactive,
+      TradeStatusFilter.dispute => AppColors.statusDispute,
+      // `all` is a filter sentinel, not a real trade status.
+      TradeStatusFilter.all => AppColors.statusInactive,
+    };
+  }
+
+  /// Derives the local user's role from the order itself when no role record
+  /// exists: the maker of a buy order buys; the taker of a sell order buys.
+  static bool _deriveIsBuyer(OrderItem order) =>
+      order.isMine ? order.kind == 'buy' : order.kind == 'sell';
+
+  /// Formats a sats amount with thousands separators (e.g. "1,117").
+  static String _fmtSats(BigInt sats) {
+    final s = sats.toString();
+    final buf = StringBuffer();
+    for (var i = 0; i < s.length; i++) {
+      if (i > 0 && (s.length - i) % 3 == 0) buf.write(',');
+      buf.write(s[i]);
+    }
+    return buf.toString();
+  }
+}
+
+// ── Countdown chip ────────────────────────────────────────────────────────────
+
+/// Live "MM:SS left" countdown, ticking each second.
+///
+/// Renders nothing once the expiry has passed (the timer also stops then).
+class _CountdownChip extends StatefulWidget {
+  const _CountdownChip({
+    required this.expiresAt,
+    required this.color,
+    required this.separatorColor,
+    this.showSeparator = false,
+  });
+
+  final DateTime expiresAt;
+  final Color color;
+  final Color separatorColor;
+
+  /// Whether to prefix a "·" separator (when a payment method precedes it).
+  final bool showSeparator;
+
+  @override
+  State<_CountdownChip> createState() => _CountdownChipState();
+}
+
+class _CountdownChipState extends State<_CountdownChip> {
+  Timer? _timer;
+
+  @override
+  void initState() {
+    super.initState();
+    _timer = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (!mounted) return;
+      setState(() {});
+      // Stop ticking once expired — the chip stays hidden from then on.
+      if (!widget.expiresAt.isAfter(DateTime.now())) {
+        _timer?.cancel();
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final remaining = widget.expiresAt.difference(DateTime.now());
+    if (remaining.inSeconds <= 0) return const SizedBox.shrink();
+
+    final textTheme = Theme.of(context).textTheme;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (widget.showSeparator) ...[
+          const SizedBox(width: 6),
+          Text(
+            '·',
+            style: textTheme.bodySmall?.copyWith(color: widget.separatorColor),
+          ),
+          const SizedBox(width: 6),
+        ],
+        Icon(Icons.schedule, size: 12, color: widget.color),
+        const SizedBox(width: 3),
+        Text(
+          '${_fmtRemaining(remaining)} left',
+          style: textTheme.bodySmall?.copyWith(
+            color: widget.color,
+            fontWeight: FontWeight.w700,
+            fontSize: 11,
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// "MM:SS" under an hour, "H:MM:SS" above.
+  static String _fmtRemaining(Duration d) {
+    String two(int v) => v.toString().padLeft(2, '0');
+    final m = d.inMinutes.remainder(60);
+    final s = d.inSeconds.remainder(60);
+    return d.inHours > 0
+        ? '${d.inHours}:${two(m)}:${two(s)}'
+        : '${two(m)}:${two(s)}';
+  }
+}

--- a/lib/features/home/providers/order_reason_provider.dart
+++ b/lib/features/home/providers/order_reason_provider.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:mostro/features/home/providers/home_order_providers.dart';
+
+/// "Reason to pick" badge for an order book card (UX proposal #3).
+///
+/// Each reason is awarded to at most one card in the visible list, and each
+/// card carries at most one reason. Priority when a card qualifies for
+/// several: best premium > most reputable > just published.
+enum OrderReason { bestPremium, mostReputable, justPublished }
+
+/// How recent an order must be to qualify as "Just published".
+const justPublishedWindow = Duration(minutes: 10);
+
+/// Computes the reason badge for each order in [orders] (the currently
+/// displayed, filtered list). Returns a map of order id -> reason.
+///
+/// Rules (deterministic):
+/// - Best premium: the single order with the lowest premium. Ties broken by
+///   list position (first wins).
+/// - Most reputable: the order with the highest rating (must be > 0), ties
+///   broken by higher tradeCount, then list position. Skips the card that
+///   already won "best premium".
+/// - Just published: the most recently created order with
+///   createdAt < 10 minutes ago, among cards not already awarded.
+Map<String, OrderReason> computeOrderReasons(
+  List<OrderItem> orders, {
+  DateTime? now,
+}) {
+  if (orders.isEmpty) return const {};
+  final reasons = <String, OrderReason>{};
+
+  // Best premium — lowest premium in the visible list.
+  OrderItem best = orders.first;
+  for (final o in orders.skip(1)) {
+    if (o.premium < best.premium) best = o;
+  }
+  reasons[best.id] = OrderReason.bestPremium;
+
+  // Most reputable — highest rating (> 0), ties broken by tradeCount.
+  OrderItem? reputable;
+  for (final o in orders) {
+    if (reasons.containsKey(o.id)) continue;
+    if (o.rating <= 0) continue;
+    if (reputable == null ||
+        o.rating > reputable.rating ||
+        (o.rating == reputable.rating && o.tradeCount > reputable.tradeCount)) {
+      reputable = o;
+    }
+  }
+  if (reputable != null) {
+    reasons[reputable.id] = OrderReason.mostReputable;
+  }
+
+  // Just published — newest order created < 10 minutes ago.
+  final cutoff = (now ?? DateTime.now()).subtract(justPublishedWindow);
+  OrderItem? fresh;
+  for (final o in orders) {
+    if (reasons.containsKey(o.id)) continue;
+    if (!o.createdAt.isAfter(cutoff)) continue;
+    if (fresh == null || o.createdAt.isAfter(fresh.createdAt)) {
+      fresh = o;
+    }
+  }
+  if (fresh != null) {
+    reasons[fresh.id] = OrderReason.justPublished;
+  }
+
+  return reasons;
+}
+
+/// Reason badges for the currently displayed (filtered) order list.
+final orderReasonsProvider = Provider<Map<String, OrderReason>>((ref) {
+  final orders = ref.watch(filteredOrdersProvider);
+  return computeOrderReasons(orders);
+});

--- a/lib/features/home/screens/home_screen.dart
+++ b/lib/features/home/screens/home_screen.dart
@@ -6,6 +6,7 @@ import 'package:mostro/core/app_routes.dart';
 import 'package:mostro/core/app_theme.dart';
 import 'package:mostro/features/drawer/screens/drawer_menu.dart';
 import 'package:mostro/features/home/providers/home_order_providers.dart';
+import 'package:mostro/features/home/providers/order_reason_provider.dart';
 import 'package:mostro/features/home/widgets/order_list_item.dart';
 import 'package:mostro/shared/widgets/bottom_nav_bar.dart';
 import 'package:mostro/shared/utils/fiat_currencies.dart';
@@ -64,6 +65,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
     final colors = theme.extension<AppColors>();
     final green = colors?.mostroGreen ?? const Color(0xFF8CC63F);
     final filteredOrders = ref.watch(filteredOrdersProvider);
+    // "Reason to pick" badges computed once per visible list (not per card).
+    final orderReasons = ref.watch(orderReasonsProvider);
     final flags = ref.watch(currencyFlagsProvider);
     final screenWidth = MediaQuery.sizeOf(context).width;
     final isDesktop = screenWidth >= AppBreakpoints.desktop;
@@ -92,6 +95,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
             return OrderListItem(
               order: order,
               currencyFlags: flags,
+              reason: orderReasons[order.id],
               onTap: () => onTap(order.id, ref.read(homeOrderTypeProvider)),
             );
           },
@@ -116,6 +120,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
           return OrderListItem(
             order: order,
             currencyFlags: flags,
+            reason: orderReasons[order.id],
             onTap: () => onTap(order.id, ref.read(homeOrderTypeProvider)),
           );
         },

--- a/lib/features/home/widgets/order_list_item.dart
+++ b/lib/features/home/widgets/order_list_item.dart
@@ -2,20 +2,30 @@ import 'package:flutter/material.dart';
 
 import 'package:mostro/core/app_theme.dart';
 import 'package:mostro/features/home/providers/home_order_providers.dart';
+import 'package:mostro/features/home/providers/order_reason_provider.dart';
 import 'package:mostro/l10n/app_localizations.dart';
 
-/// Order list item card with 5 rows per V1 spec.
+/// Order list item card — "reason to pick" redesign.
+///
+/// Each card may carry one [OrderReason] pill (computed once per visible list
+/// and passed in — never computed here), a color-coded premium pill, and a
+/// numeric reputation row.
 class OrderListItem extends StatelessWidget {
   const OrderListItem({
     super.key,
     required this.order,
     this.onTap,
     this.currencyFlags = const {},
+    this.reason,
   });
 
   final OrderItem order;
   final VoidCallback? onTap;
   final Map<String, String> currencyFlags;
+
+  /// "Reason to pick" badge awarded to this card, if any. Computed across the
+  /// visible list (see [orderReasonsProvider]) and passed in by the screen.
+  final OrderReason? reason;
 
   @override
   Widget build(BuildContext context) {
@@ -23,22 +33,52 @@ class OrderListItem extends StatelessWidget {
     final colors = theme.extension<AppColors>();
     final cardBg = colors?.backgroundCard ?? const Color(0xFF1E2230);
     final inputBg = colors?.backgroundInput ?? const Color(0xFF252A3A);
+    final textPrimary = colors?.textPrimary ?? Colors.white;
     final textSec = colors?.textSecondary ?? const Color(0xFFB0B3C6);
     final green = colors?.mostroGreen ?? const Color(0xFF8CC63F);
     final sellColor = colors?.sellColor ?? const Color(0xFFFF8A8A);
+    final amber = colors?.warningAmber ?? const Color(0xFFE89C3C);
+    final blueFill = colors?.blueAccent ?? const Color(0xFF35485E);
 
     final l10n = AppLocalizations.of(context);
     final isSelling = order.kind == 'sell';
-    final pillLabel = switch ((order.isMine, isSelling)) {
+    final typeLabel = switch ((order.isMine, isSelling)) {
       (true, true) => l10n.orderPillYouAreSelling,
       (true, false) => l10n.orderPillYouAreBuying,
       (false, true) => l10n.orderPillSelling,
       (false, false) => l10n.orderPillBuying,
     };
-    final pillColor = isSelling ? sellColor : green;
-    final premiumPositive = order.premium >= 0;
-    final premiumColor = premiumPositive ? green : sellColor;
+    final typeColor = isSelling ? sellColor : green;
     final flag = currencyFlags[order.fiatCode] ?? '';
+
+    // Premium pill: green < 2 (incl. negative), amber 2–5, sell-red > 5.
+    final premiumColor = order.premium < 2
+        ? green
+        : order.premium > 5
+            ? sellColor
+            : amber;
+    final premiumText =
+        '${order.premium >= 0 ? '+' : ''}${order.premium.toStringAsFixed(1)}%';
+
+    // Reason pill styling (gold per design ≈ #FFC940; blue per info-blue).
+    final (reasonLabel, reasonColor, reasonBg) = switch (reason) {
+      OrderReason.bestPremium => (
+          '⚡ Best premium',
+          green,
+          green.withValues(alpha: 0.15),
+        ),
+      OrderReason.mostReputable => (
+          '⭐ Most reputable',
+          Colors.amber,
+          Colors.amber.withValues(alpha: 0.15),
+        ),
+      OrderReason.justPublished => (
+          '🆕 Just published',
+          const Color(0xFF7BB4F0),
+          blueFill.withValues(alpha: 0.55),
+        ),
+      null => (null, null, null),
+    };
 
     return GestureDetector(
       onTap: onTap,
@@ -52,28 +92,26 @@ class OrderListItem extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // Row 1: Status pill + relative timestamp
+            // Row 1: reason pill + type pill + relative timestamp
             Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: AppSpacing.sm,
-                    vertical: 2,
+                if (reasonLabel != null) ...[
+                  _Pill(
+                    label: reasonLabel,
+                    color: reasonColor!,
+                    background: reasonBg!,
                   ),
-                  decoration: BoxDecoration(
-                    color: pillColor.withValues(alpha: 0.15),
-                    borderRadius: BorderRadius.circular(AppRadius.chip),
-                  ),
-                  child: Text(
-                    pillLabel,
-                    style: TextStyle(
-                      color: pillColor,
-                      fontSize: 11,
-                      fontWeight: FontWeight.w600,
-                    ),
+                  const SizedBox(width: AppSpacing.xs),
+                ],
+                Flexible(
+                  child: _Pill(
+                    label: typeLabel,
+                    color: typeColor,
+                    background: typeColor.withValues(alpha: 0.12),
+                    fontSize: 10,
                   ),
                 ),
+                const Spacer(),
                 Text(
                   _relativeTime(order.createdAt),
                   style: theme.textTheme.bodySmall!.copyWith(color: textSec),
@@ -82,10 +120,9 @@ class OrderListItem extends StatelessWidget {
             ),
             const SizedBox(height: AppSpacing.sm),
 
-            // Row 2: Fiat amount + currency code + flag
+            // Row 2: fiat amount + currency + flag, premium pill right-aligned
             Row(
-              crossAxisAlignment: CrossAxisAlignment.baseline,
-              textBaseline: TextBaseline.alphabetic,
+              crossAxisAlignment: CrossAxisAlignment.center,
               children: [
                 Flexible(
                   child: Text(
@@ -101,18 +138,60 @@ class OrderListItem extends StatelessWidget {
                     fontWeight: FontWeight.w600,
                   ),
                 ),
+                const Spacer(),
+                _Pill(
+                  label: premiumText,
+                  color: premiumColor,
+                  background: premiumColor.withValues(alpha: 0.13),
+                ),
               ],
             ),
-            const SizedBox(height: AppSpacing.xs),
+            const SizedBox(height: 2),
 
-            // Row 3: Price type label + premium
+            // Row 3: small secondary "Market price" caption
             Text(
-              'Market Price (${premiumPositive ? '+' : ''}${order.premium.toStringAsFixed(1)}%)',
-              style: TextStyle(color: premiumColor, fontSize: 13),
+              'Market price',
+              style: TextStyle(color: textSec, fontSize: 11),
             ),
             const SizedBox(height: AppSpacing.sm),
 
-            // Row 4: Payment methods
+            // Row 4: numeric reputation — ★ 4.9 · 47 trades · 312 days
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppSpacing.sm,
+                vertical: AppSpacing.xs,
+              ),
+              decoration: BoxDecoration(
+                color: inputBg,
+                borderRadius: BorderRadius.circular(AppRadius.chip),
+              ),
+              child: Row(
+                children: [
+                  const Icon(Icons.star, size: 14, color: Colors.amber),
+                  const SizedBox(width: AppSpacing.xs),
+                  Text(
+                    order.rating.toStringAsFixed(1),
+                    style: TextStyle(
+                      color: textPrimary,
+                      fontSize: 13,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  Flexible(
+                    child: Text(
+                      ' · ${order.tradeCount} trades'
+                      ' · ${order.daysActive} days',
+                      style: TextStyle(color: textSec, fontSize: 12),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: AppSpacing.xs),
+
+            // Row 5: payment methods
             Container(
               width: double.infinity,
               padding: const EdgeInsets.symmetric(
@@ -137,35 +216,6 @@ class OrderListItem extends StatelessWidget {
                 ],
               ),
             ),
-            const SizedBox(height: AppSpacing.xs),
-
-            // Row 5: Rating + trade count + days active
-            Container(
-              width: double.infinity,
-              padding: const EdgeInsets.symmetric(
-                horizontal: AppSpacing.sm,
-                vertical: AppSpacing.xs,
-              ),
-              decoration: BoxDecoration(
-                color: inputBg,
-                borderRadius: BorderRadius.circular(AppRadius.chip),
-              ),
-              child: Row(
-                children: [
-                  _StarRating(rating: order.rating, color: Colors.amber),
-                  const SizedBox(width: AppSpacing.sm),
-                  Text(
-                    '${order.tradeCount} trades',
-                    style: TextStyle(color: textSec, fontSize: 12),
-                  ),
-                  const Spacer(),
-                  Text(
-                    '${order.daysActive}d',
-                    style: TextStyle(color: textSec, fontSize: 12),
-                  ),
-                ],
-              ),
-            ),
           ],
         ),
       ),
@@ -181,27 +231,40 @@ class OrderListItem extends StatelessWidget {
   }
 }
 
-/// Fractional star rating display (up to 5 stars).
-class _StarRating extends StatelessWidget {
-  const _StarRating({required this.rating, required this.color});
+/// Small rounded pill used for reason, type, and premium badges.
+class _Pill extends StatelessWidget {
+  const _Pill({
+    required this.label,
+    required this.color,
+    required this.background,
+    this.fontSize = 11,
+  });
 
-  final double rating;
+  final String label;
   final Color color;
+  final Color background;
+  final double fontSize;
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: List.generate(5, (i) {
-        final fill = (rating - i).clamp(0.0, 1.0);
-        if (fill >= 0.75) {
-          return Icon(Icons.star, size: 12, color: color);
-        } else if (fill >= 0.25) {
-          return Icon(Icons.star_half, size: 12, color: color);
-        } else {
-          return Icon(Icons.star_border, size: 12, color: color);
-        }
-      }),
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.sm,
+        vertical: 2,
+      ),
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(AppRadius.chip),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: color,
+          fontSize: fontSize,
+          fontWeight: FontWeight.w600,
+        ),
+        overflow: TextOverflow.ellipsis,
+      ),
     );
   }
 }
@@ -228,14 +291,20 @@ class OrderListItemSkeleton extends StatelessWidget {
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              _shimmerBox(60, 18, shimmer),
+              _shimmerBox(100, 18, shimmer),
               _shimmerBox(40, 14, shimmer),
             ],
           ),
           const SizedBox(height: AppSpacing.sm),
-          _shimmerBox(180, 24, shimmer),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              _shimmerBox(140, 24, shimmer),
+              _shimmerBox(48, 18, shimmer),
+            ],
+          ),
           const SizedBox(height: AppSpacing.xs),
-          _shimmerBox(140, 14, shimmer),
+          _shimmerBox(80, 12, shimmer),
           const SizedBox(height: AppSpacing.sm),
           _shimmerBox(double.infinity, 24, shimmer),
           const SizedBox(height: AppSpacing.xs),

--- a/lib/features/notifications/screens/notifications_screen.dart
+++ b/lib/features/notifications/screens/notifications_screen.dart
@@ -7,21 +7,33 @@ import 'package:mostro/core/app_theme.dart';
 import 'package:mostro/features/account/providers/backup_reminder_provider.dart';
 import 'package:mostro/features/notifications/models/notification_model.dart';
 import 'package:mostro/features/notifications/providers/notifications_provider.dart';
-import 'package:mostro/features/notifications/widgets/notification_card.dart';
+import 'package:mostro/features/notifications/widgets/notification_group_card.dart';
+import 'package:mostro/features/notifications/widgets/system_notification_banner.dart';
 
 /// Notifications screen — Route `/notifications`.
 ///
-/// Shows a scrollable list of notifications with a pinned backup reminder
-/// card at the top when active. Supports Mark all as read and Clear all.
-class NotificationsScreen extends ConsumerWidget {
+/// Trade-related notifications are grouped by order id into collapsible
+/// group cards (latest event shown, earlier events expandable). System
+/// notifications (backup reminder, announcements) render in a separate
+/// banner section at the top. Filter chips narrow the list to dispute
+/// groups or system items.
+class NotificationsScreen extends ConsumerStatefulWidget {
   const NotificationsScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<NotificationsScreen> createState() =>
+      _NotificationsScreenState();
+}
+
+enum _NotificationFilter { all, disputes, system }
+
+class _NotificationsScreenState extends ConsumerState<NotificationsScreen> {
+  _NotificationFilter _filter = _NotificationFilter.all;
+
+  @override
+  Widget build(BuildContext context) {
     final backupActive = ref.watch(backupReminderProvider);
     final notifications = ref.watch(notificationsProvider);
-    final colors = Theme.of(context).extension<AppColors>();
-    final green = colors?.mostroGreen ?? const Color(0xFF8CC63F);
 
     return Scaffold(
       appBar: AppBar(
@@ -36,16 +48,17 @@ class NotificationsScreen extends ConsumerWidget {
                   ref.read(notificationsProvider.notifier).deleteAll();
               }
             },
-            itemBuilder: (_) => const [
-              PopupMenuItem(
-                value: _MenuAction.markAllRead,
-                child: Text('Mark all as read'),
-              ),
-              PopupMenuItem(
-                value: _MenuAction.clearAll,
-                child: Text('Clear all'),
-              ),
-            ],
+            itemBuilder:
+                (_) => const [
+                  PopupMenuItem(
+                    value: _MenuAction.markAllRead,
+                    child: Text('Mark all as read'),
+                  ),
+                  PopupMenuItem(
+                    value: _MenuAction.clearAll,
+                    child: Text('Clear all'),
+                  ),
+                ],
           ),
         ],
       ),
@@ -55,10 +68,8 @@ class NotificationsScreen extends ConsumerWidget {
         },
         child: _buildBody(
           context: context,
-          ref: ref,
           backupActive: backupActive,
           notifications: notifications,
-          green: green,
         ),
       ),
     );
@@ -66,10 +77,8 @@ class NotificationsScreen extends ConsumerWidget {
 
   Widget _buildBody({
     required BuildContext context,
-    required WidgetRef ref,
     required bool backupActive,
     required List<NotificationModel> notifications,
-    required Color green,
   }) {
     final hasContent = backupActive || notifications.isNotEmpty;
 
@@ -77,29 +86,105 @@ class NotificationsScreen extends ConsumerWidget {
       return const _EmptyState();
     }
 
-    return ListView(
-      padding: const EdgeInsets.symmetric(
-        horizontal: AppSpacing.lg,
-        vertical: AppSpacing.md,
-      ),
+    // ── Partition: system items vs trade/dispute groups ──
+    final systemItems = <NotificationModel>[];
+    final groups = <String, List<NotificationModel>>{};
+    for (final n in notifications) {
+      final key = n.orderId ?? n.disputeId;
+      if (key == null) {
+        systemItems.add(n);
+      } else {
+        groups.putIfAbsent(key, () => []).add(n);
+      }
+    }
+    systemItems.sort((a, b) => b.timestamp.compareTo(a.timestamp));
+    for (final events in groups.values) {
+      events.sort((a, b) => b.timestamp.compareTo(a.timestamp));
+    }
+    final sortedGroups =
+        groups.values.toList()
+          ..sort((a, b) => b.first.timestamp.compareTo(a.first.timestamp));
+
+    final disputeGroups =
+        sortedGroups
+            .where((g) => g.any((n) => n.type == NotificationType.dispute))
+            .toList();
+    final systemCount = systemItems.length + (backupActive ? 1 : 0);
+
+    final showSystem =
+        _filter == _NotificationFilter.all ||
+        _filter == _NotificationFilter.system;
+    final visibleGroups = switch (_filter) {
+      _NotificationFilter.all => sortedGroups,
+      _NotificationFilter.disputes => disputeGroups,
+      _NotificationFilter.system => <List<NotificationModel>>[],
+    };
+
+    final notifier = ref.read(notificationsProvider.notifier);
+
+    return Column(
       children: [
-        if (backupActive) ...[
-          _BackupReminderCard(green: green),
-          const SizedBox(height: AppSpacing.sm),
-        ],
-        for (final n in notifications) ...[
-          NotificationCard(
-            notification: n,
-            onMarkRead: () =>
-                ref.read(notificationsProvider.notifier).markAsRead(n.id),
-            onDelete: () =>
-                ref.read(notificationsProvider.notifier).delete(n.id),
-            onTap: () => _handleTap(context, n),
+        _FilterChipsRow(
+          selected: _filter,
+          disputeCount: disputeGroups.length,
+          systemCount: systemCount,
+          onSelected: (f) => setState(() => _filter = f),
+        ),
+        Expanded(
+          child: ListView(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSpacing.lg,
+              vertical: AppSpacing.md,
+            ),
+            children: [
+              // ── System section (banners) ──
+              if (showSystem) ...[
+                if (backupActive) ...[
+                  const _BackupReminderBanner(),
+                  const SizedBox(height: AppSpacing.sm),
+                ],
+                for (final n in systemItems) ...[
+                  SystemNotificationBanner(
+                    notification: n,
+                    onMarkRead: () => notifier.markAsRead(n.id),
+                    onDelete: () => notifier.delete(n.id),
+                    onTap: () => _handleTap(context, n),
+                  ),
+                  const SizedBox(height: AppSpacing.sm),
+                ],
+              ],
+              // ── Trade groups ──
+              for (final group in visibleGroups) ...[
+                NotificationGroupCard(
+                  notifications: group,
+                  isDisputeGroup: group.first.orderId == null,
+                  onMarkRead: (n) => notifier.markAsRead(n.id),
+                  onDelete: (n) => notifier.delete(n.id),
+                  onTapNotification: (n) => _handleTap(context, n),
+                  onGoToTrade: () => _goToTrade(context, group.first),
+                ),
+                const SizedBox(height: AppSpacing.sm),
+              ],
+              if ((!showSystem && visibleGroups.isEmpty) ||
+                  (_filter == _NotificationFilter.system && systemCount == 0))
+                const Padding(
+                  padding: EdgeInsets.only(top: AppSpacing.xxl),
+                  child: _EmptyState(),
+                ),
+            ],
           ),
-          const SizedBox(height: AppSpacing.sm),
-        ],
+        ),
       ],
     );
+  }
+
+  /// Footer action of a group card — open the trade (or dispute) detail.
+  void _goToTrade(BuildContext context, NotificationModel n) {
+    if (n.orderId != null) {
+      context.push(AppRoute.tradeDetailPath(n.orderId!));
+    } else if (n.disputeId != null) {
+      context.push(AppRoute.disputeDetailsPath(n.disputeId!));
+    }
   }
 
   void _handleTap(BuildContext context, NotificationModel n) {
@@ -143,30 +228,141 @@ class NotificationsScreen extends ConsumerWidget {
 
 enum _MenuAction { markAllRead, clearAll }
 
-// ── Backup reminder card ──────────────────────────────────────────────────────
+// ── Filter chips row ──────────────────────────────────────────────────────────
 
-class _BackupReminderCard extends StatelessWidget {
-  const _BackupReminderCard({required this.green});
+class _FilterChipsRow extends StatelessWidget {
+  const _FilterChipsRow({
+    required this.selected,
+    required this.disputeCount,
+    required this.systemCount,
+    required this.onSelected,
+  });
 
-  final Color green;
+  final _NotificationFilter selected;
+  final int disputeCount;
+  final int systemCount;
+  final ValueChanged<_NotificationFilter> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final chips = <(_NotificationFilter, String)>[
+      (_NotificationFilter.all, 'All'),
+      (
+        _NotificationFilter.disputes,
+        disputeCount > 0 ? 'Disputes · $disputeCount' : 'Disputes',
+      ),
+      (
+        _NotificationFilter.system,
+        systemCount > 0 ? 'System · $systemCount' : 'System',
+      ),
+    ];
+
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.lg,
+        AppSpacing.md,
+        AppSpacing.lg,
+        0,
+      ),
+      child: Row(
+        children: [
+          for (final (filter, label) in chips) ...[
+            _FilterChip(
+              label: label,
+              isSelected: selected == filter,
+              onTap: () => onSelected(filter),
+            ),
+            const SizedBox(width: AppSpacing.sm),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _FilterChip extends StatelessWidget {
+  const _FilterChip({
+    required this.label,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  final String label;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<AppColors>();
+    final green = colors?.mostroGreen ?? const Color(0xFF8CC63F);
+    final cardBg = colors?.backgroundCard ?? const Color(0xFF1E2230);
+    final textSec = colors?.textSecondary ?? const Color(0xFFB0B3C6);
+
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(999),
+      child: Container(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.md,
+          vertical: 6,
+        ),
+        decoration: BoxDecoration(
+          color: isSelected ? green.withValues(alpha: 0.15) : cardBg,
+          borderRadius: BorderRadius.circular(999),
+          border: Border.all(
+            color:
+                isSelected ? green.withValues(alpha: 0.4) : Colors.transparent,
+            width: 1,
+          ),
+        ),
+        child: Text(
+          label,
+          style: Theme.of(context).textTheme.bodySmall!.copyWith(
+            color: isSelected ? green : textSec,
+            fontSize: 12,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ── Backup reminder banner ────────────────────────────────────────────────────
+
+class _BackupReminderBanner extends StatelessWidget {
+  const _BackupReminderBanner();
 
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).extension<AppColors>();
     final cardBg = colors?.backgroundCard ?? const Color(0xFF1E2230);
+    final amber = colors?.warningAmber ?? const Color(0xFFE89C3C);
 
     return GestureDetector(
       onTap: () => context.push(AppRoute.keyManagement),
       child: Container(
-        padding: const EdgeInsets.all(AppSpacing.lg),
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.md,
+          vertical: AppSpacing.sm + 2,
+        ),
         decoration: BoxDecoration(
           color: cardBg,
           borderRadius: BorderRadius.circular(AppRadius.card),
-          border: Border.all(color: const Color(0xFFD84D4D), width: 1),
+          border: Border.all(color: amber.withValues(alpha: 0.3), width: 1),
         ),
         child: Row(
           children: [
-            const Icon(Icons.gavel, color: Color(0xFFD84D4D), size: 24),
+            Container(
+              width: 32,
+              height: 32,
+              decoration: BoxDecoration(
+                color: amber.withValues(alpha: 0.15),
+                borderRadius: BorderRadius.circular(AppRadius.chip),
+              ),
+              child: Icon(Icons.warning_amber_rounded, color: amber, size: 18),
+            ),
             const SizedBox(width: AppSpacing.md),
             Expanded(
               child: Column(
@@ -175,14 +371,17 @@ class _BackupReminderCard extends StatelessWidget {
                   Text(
                     'You must back up your account',
                     style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                          fontWeight: FontWeight.w600,
-                          color: const Color(0xFFD84D4D),
-                        ),
+                      fontWeight: FontWeight.w600,
+                      fontSize: 13,
+                      color: Colors.white,
+                    ),
                   ),
                   const SizedBox(height: 2),
                   Text(
                     'Tap to view and save your secret words.',
-                    style: Theme.of(context).textTheme.bodySmall,
+                    style: Theme.of(
+                      context,
+                    ).textTheme.bodySmall!.copyWith(fontSize: 11),
                   ),
                 ],
               ),
@@ -206,7 +405,10 @@ class _TypeIcon extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final (icon, color) = switch (type) {
-      NotificationType.orderUpdate => (Icons.shopping_bag_outlined, Colors.blue),
+      NotificationType.orderUpdate => (
+        Icons.shopping_bag_outlined,
+        Colors.blue,
+      ),
       NotificationType.tradeUpdate => (Icons.star_outline, Colors.amber),
       NotificationType.payment => (Icons.bolt_outlined, Colors.yellow),
       NotificationType.dispute => (Icons.gavel, Colors.red),
@@ -239,10 +441,9 @@ class _EmptyState extends StatelessWidget {
           const SizedBox(height: AppSpacing.md),
           Text(
             'No notifications',
-            style: Theme.of(context)
-                .textTheme
-                .bodyMedium!
-                .copyWith(color: Colors.white38),
+            style: Theme.of(
+              context,
+            ).textTheme.bodyMedium!.copyWith(color: Colors.white38),
           ),
         ],
       ),

--- a/lib/features/notifications/widgets/notification_group_card.dart
+++ b/lib/features/notifications/widgets/notification_group_card.dart
@@ -1,0 +1,386 @@
+import 'package:flutter/material.dart';
+
+import 'package:mostro/core/app_theme.dart';
+import 'package:mostro/features/notifications/models/notification_model.dart';
+
+/// Collapsible card grouping all notifications that reference the same
+/// trade (order id) or dispute.
+///
+/// Collapsed it shows the latest event only; "View N earlier events"
+/// expands the remaining events inline. A footer action navigates to the
+/// trade (or dispute) detail screen.
+class NotificationGroupCard extends StatefulWidget {
+  const NotificationGroupCard({
+    super.key,
+    required this.notifications,
+    required this.onMarkRead,
+    required this.onDelete,
+    required this.onTapNotification,
+    required this.onGoToTrade,
+    this.isDisputeGroup = false,
+  });
+
+  /// Events for this trade, sorted newest first. Must not be empty.
+  final List<NotificationModel> notifications;
+  final ValueChanged<NotificationModel> onMarkRead;
+  final ValueChanged<NotificationModel> onDelete;
+  final ValueChanged<NotificationModel> onTapNotification;
+  final VoidCallback onGoToTrade;
+
+  /// True when the group is keyed by a dispute id (no order id available).
+  final bool isDisputeGroup;
+
+  @override
+  State<NotificationGroupCard> createState() => _NotificationGroupCardState();
+}
+
+class _NotificationGroupCardState extends State<NotificationGroupCard> {
+  bool _expanded = false;
+
+  NotificationModel get _latest => widget.notifications.first;
+
+  List<NotificationModel> get _earlier => widget.notifications.skip(1).toList();
+
+  int get _unreadCount => widget.notifications.where((n) => !n.isRead).length;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<AppColors>();
+    final cardBg = colors?.backgroundCard ?? const Color(0xFF1E2230);
+    final green = colors?.mostroGreen ?? const Color(0xFF8CC63F);
+    final textSec = colors?.textSecondary ?? const Color(0xFFB0B3C6);
+    final hasDispute = widget.notifications.any(
+      (n) => n.type == NotificationType.dispute,
+    );
+
+    return Container(
+      padding: const EdgeInsets.all(AppSpacing.md),
+      decoration: BoxDecoration(
+        color: cardBg,
+        borderRadius: BorderRadius.circular(AppRadius.card),
+        border:
+            _unreadCount > 0
+                ? Border.all(color: Colors.white12, width: 1)
+                : null,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // ── Header row: dot + trade label + unread badge ──
+          Row(
+            children: [
+              Container(
+                width: 8,
+                height: 8,
+                decoration: BoxDecoration(
+                  color: hasDispute ? const Color(0xFFD84D4D) : green,
+                  shape: BoxShape.circle,
+                ),
+              ),
+              const SizedBox(width: AppSpacing.sm),
+              Expanded(
+                child: Text(
+                  _groupTitle(),
+                  style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: Colors.white,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              if (_unreadCount > 0)
+                Container(
+                  width: 20,
+                  height: 20,
+                  alignment: Alignment.center,
+                  decoration: BoxDecoration(
+                    color: green,
+                    shape: BoxShape.circle,
+                  ),
+                  child: Text(
+                    '$_unreadCount',
+                    style: const TextStyle(
+                      color: Colors.black,
+                      fontSize: 11,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+          const SizedBox(height: AppSpacing.sm),
+
+          // ── Latest event ──
+          _EventRow(
+            notification: _latest,
+            highlight: true,
+            onMarkRead: () => widget.onMarkRead(_latest),
+            onDelete: () => widget.onDelete(_latest),
+            onTap: () => widget.onTapNotification(_latest),
+          ),
+
+          // ── Earlier events (expandable) ──
+          if (_expanded && _earlier.isNotEmpty) ...[
+            const SizedBox(height: AppSpacing.xs),
+            for (final n in _earlier)
+              Padding(
+                padding: const EdgeInsets.only(top: AppSpacing.xs),
+                child: _EventRow(
+                  notification: n,
+                  highlight: false,
+                  onMarkRead: () => widget.onMarkRead(n),
+                  onDelete: () => widget.onDelete(n),
+                  onTap: () => widget.onTapNotification(n),
+                ),
+              ),
+          ],
+          const SizedBox(height: AppSpacing.sm),
+
+          // ── Footer: expand toggle + go to trade ──
+          Row(
+            children: [
+              Expanded(
+                child:
+                    _earlier.isEmpty
+                        ? const SizedBox.shrink()
+                        : InkWell(
+                          onTap: () => setState(() => _expanded = !_expanded),
+                          borderRadius: BorderRadius.circular(AppRadius.chip),
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(vertical: 4),
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Icon(
+                                  _expanded
+                                      ? Icons.keyboard_arrow_up
+                                      : Icons.keyboard_arrow_down,
+                                  size: 16,
+                                  color: textSec,
+                                ),
+                                const SizedBox(width: 2),
+                                Flexible(
+                                  child: Text(
+                                    _expanded
+                                        ? 'Hide earlier events'
+                                        : 'View ${_earlier.length} earlier '
+                                            '${_earlier.length == 1 ? 'event' : 'events'}',
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .bodySmall!
+                                        .copyWith(color: textSec, fontSize: 12),
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+              ),
+              InkWell(
+                onTap: widget.onGoToTrade,
+                borderRadius: BorderRadius.circular(AppRadius.chip),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 4),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        widget.isDisputeGroup ? 'View dispute' : 'Go to trade',
+                        style: Theme.of(context).textTheme.bodySmall!.copyWith(
+                          color: green,
+                          fontSize: 12,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const SizedBox(width: 2),
+                      Icon(Icons.arrow_forward, size: 14, color: green),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// "Trade · 5,400 sats" when an amount is derivable from any event's
+  /// detail map, otherwise "Trade #a1b2c3d4" (short order id).
+  String _groupTitle() {
+    final sats = _deriveSats();
+    if (sats != null) {
+      final label = widget.isDisputeGroup ? 'Dispute' : 'Trade';
+      return '$label · $sats sats';
+    }
+    final id = _latest.orderId ?? _latest.disputeId ?? '';
+    final shortId = id.length > 8 ? id.substring(0, 8) : id;
+    return widget.isDisputeGroup ? 'Dispute #$shortId' : 'Trade #$shortId';
+  }
+
+  /// Looks for an "N sats" amount in any event's detail values.
+  String? _deriveSats() {
+    final re = RegExp(r'([\d,.]+)\s*sats?\b');
+    for (final n in widget.notifications) {
+      final detail = n.detail;
+      if (detail == null) continue;
+      for (final value in detail.values) {
+        final match = re.firstMatch(value);
+        if (match != null) return match.group(1);
+      }
+    }
+    return null;
+  }
+}
+
+// ── Single event row inside a group ──────────────────────────────────────────
+
+class _EventRow extends StatelessWidget {
+  const _EventRow({
+    required this.notification,
+    required this.highlight,
+    required this.onMarkRead,
+    required this.onDelete,
+    required this.onTap,
+  });
+
+  final NotificationModel notification;
+
+  /// Latest event gets a tinted pill; earlier events render muted.
+  final bool highlight;
+  final VoidCallback onMarkRead;
+  final VoidCallback onDelete;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<AppColors>();
+    final green = colors?.mostroGreen ?? const Color(0xFF8CC63F);
+    final textSec = colors?.textSecondary ?? const Color(0xFFB0B3C6);
+    final isDispute = notification.type == NotificationType.dispute;
+    final pillColor = isDispute ? const Color(0xFFD84D4D) : green;
+
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(AppRadius.chip),
+      child: Row(
+        children: [
+          Flexible(
+            child:
+                highlight
+                    ? Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: AppSpacing.sm,
+                        vertical: 2,
+                      ),
+                      decoration: BoxDecoration(
+                        color: pillColor.withValues(alpha: 0.15),
+                        borderRadius: BorderRadius.circular(999),
+                      ),
+                      child: Text(
+                        notification.title,
+                        style: Theme.of(context).textTheme.bodySmall!.copyWith(
+                          color: pillColor,
+                          fontSize: 12,
+                          fontWeight: FontWeight.w600,
+                        ),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    )
+                    : Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        if (!notification.isRead)
+                          Container(
+                            width: 6,
+                            height: 6,
+                            margin: const EdgeInsets.only(right: AppSpacing.sm),
+                            decoration: BoxDecoration(
+                              color: green,
+                              shape: BoxShape.circle,
+                            ),
+                          ),
+                        Flexible(
+                          child: Text(
+                            notification.title,
+                            style: Theme.of(context).textTheme.bodySmall!
+                                .copyWith(color: textSec, fontSize: 12),
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                      ],
+                    ),
+          ),
+          const SizedBox(width: AppSpacing.sm),
+          Text(
+            '· ${relativeTime(notification.timestamp)}',
+            style: Theme.of(
+              context,
+            ).textTheme.bodySmall!.copyWith(color: textSec, fontSize: 11),
+          ),
+          const Spacer(),
+          _EventOverflowMenu(
+            isRead: notification.isRead,
+            onMarkRead: onMarkRead,
+            onDelete: onDelete,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── Overflow menu (per event) ─────────────────────────────────────────────────
+
+enum _EventMenuAction { markRead, delete }
+
+class _EventOverflowMenu extends StatelessWidget {
+  const _EventOverflowMenu({
+    required this.isRead,
+    required this.onMarkRead,
+    required this.onDelete,
+  });
+
+  final bool isRead;
+  final VoidCallback onMarkRead;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    return PopupMenuButton<_EventMenuAction>(
+      iconSize: 16,
+      padding: EdgeInsets.zero,
+      constraints: const BoxConstraints(),
+      onSelected: (action) {
+        switch (action) {
+          case _EventMenuAction.markRead:
+            onMarkRead();
+          case _EventMenuAction.delete:
+            onDelete();
+        }
+      },
+      itemBuilder:
+          (_) => [
+            if (!isRead)
+              const PopupMenuItem(
+                value: _EventMenuAction.markRead,
+                child: Text('Mark as read'),
+              ),
+            const PopupMenuItem(
+              value: _EventMenuAction.delete,
+              child: Text('Delete'),
+            ),
+          ],
+    );
+  }
+}
+
+/// Shared relative-time formatter for notification widgets.
+String relativeTime(DateTime dt) {
+  final diff = DateTime.now().difference(dt);
+  if (diff.isNegative || diff.inMinutes < 1) return 'Just now';
+  if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
+  if (diff.inHours < 24) return '${diff.inHours}h ago';
+  return '${diff.inDays}d ago';
+}

--- a/lib/features/notifications/widgets/system_notification_banner.dart
+++ b/lib/features/notifications/widgets/system_notification_banner.dart
@@ -1,0 +1,168 @@
+import 'package:flutter/material.dart';
+
+import 'package:mostro/core/app_theme.dart';
+import 'package:mostro/features/notifications/models/notification_model.dart';
+import 'package:mostro/features/notifications/widgets/notification_group_card.dart'
+    show relativeTime;
+
+/// Banner-style card for notifications that don't reference a trade
+/// (system items: backup reminders, announcements, etc.).
+///
+/// Amber-bordered per the redesign mock; keeps the standard mark-as-read /
+/// delete overflow actions.
+class SystemNotificationBanner extends StatelessWidget {
+  const SystemNotificationBanner({
+    super.key,
+    required this.notification,
+    required this.onMarkRead,
+    required this.onDelete,
+    this.onTap,
+  });
+
+  final NotificationModel notification;
+  final VoidCallback onMarkRead;
+  final VoidCallback onDelete;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<AppColors>();
+    final cardBg = colors?.backgroundCard ?? const Color(0xFF1E2230);
+    final amber = colors?.warningAmber ?? const Color(0xFFE89C3C);
+    final textSec = colors?.textSecondary ?? const Color(0xFFB0B3C6);
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(AppRadius.card),
+        child: Container(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.md,
+            vertical: AppSpacing.sm + 2,
+          ),
+          decoration: BoxDecoration(
+            color: cardBg,
+            borderRadius: BorderRadius.circular(AppRadius.card),
+            border: Border.all(color: amber.withValues(alpha: 0.3), width: 1),
+          ),
+          child: Row(
+            children: [
+              Container(
+                width: 32,
+                height: 32,
+                decoration: BoxDecoration(
+                  color: amber.withValues(alpha: 0.15),
+                  borderRadius: BorderRadius.circular(AppRadius.chip),
+                ),
+                child: Icon(
+                  Icons.warning_amber_rounded,
+                  color: amber,
+                  size: 18,
+                ),
+              ),
+              const SizedBox(width: AppSpacing.md),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        if (!notification.isRead)
+                          Container(
+                            width: 6,
+                            height: 6,
+                            margin: const EdgeInsets.only(right: AppSpacing.sm),
+                            decoration: BoxDecoration(
+                              color:
+                                  colors?.mostroGreen ??
+                                  const Color(0xFF8CC63F),
+                              shape: BoxShape.circle,
+                            ),
+                          ),
+                        Flexible(
+                          child: Text(
+                            notification.title,
+                            style: Theme.of(
+                              context,
+                            ).textTheme.bodyMedium!.copyWith(
+                              fontWeight: FontWeight.w600,
+                              color: Colors.white,
+                              fontSize: 13,
+                            ),
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      '${notification.message} '
+                      '· ${relativeTime(notification.timestamp)}',
+                      style: Theme.of(context).textTheme.bodySmall!.copyWith(
+                        color: textSec,
+                        fontSize: 11,
+                      ),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+              ),
+              _BannerOverflowMenu(
+                isRead: notification.isRead,
+                onMarkRead: onMarkRead,
+                onDelete: onDelete,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ── Overflow menu ──────────────────────────────────────────────────────────────
+
+enum _BannerMenuAction { markRead, delete }
+
+class _BannerOverflowMenu extends StatelessWidget {
+  const _BannerOverflowMenu({
+    required this.isRead,
+    required this.onMarkRead,
+    required this.onDelete,
+  });
+
+  final bool isRead;
+  final VoidCallback onMarkRead;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    return PopupMenuButton<_BannerMenuAction>(
+      iconSize: 16,
+      padding: EdgeInsets.zero,
+      constraints: const BoxConstraints(),
+      onSelected: (action) {
+        switch (action) {
+          case _BannerMenuAction.markRead:
+            onMarkRead();
+          case _BannerMenuAction.delete:
+            onDelete();
+        }
+      },
+      itemBuilder:
+          (_) => [
+            if (!isRead)
+              const PopupMenuItem(
+                value: _BannerMenuAction.markRead,
+                child: Text('Mark as read'),
+              ),
+            const PopupMenuItem(
+              value: _BannerMenuAction.delete,
+              child: Text('Delete'),
+            ),
+          ],
+    );
+  }
+}

--- a/lib/features/order/screens/add_order_screen.dart
+++ b/lib/features/order/screens/add_order_screen.dart
@@ -6,6 +6,7 @@ import 'package:mostro/core/app_routes.dart';
 import 'package:mostro/core/app_theme.dart';
 import 'package:mostro/features/order/widgets/currency_section.dart';
 import 'package:mostro/features/settings/providers/settings_provider.dart';
+import 'package:mostro/features/order/widgets/order_preset_selector.dart';
 import 'package:mostro/features/order/widgets/payment_method_section.dart';
 import 'package:mostro/features/order/widgets/price_section.dart';
 import 'package:mostro/core/services/identity_service.dart';
@@ -50,6 +51,8 @@ class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
       ref.read(isMarketPriceProvider.notifier).state = true;
       ref.read(premiumValueProvider.notifier).state = 0.0;
       ref.read(fixedSatsProvider.notifier).state = '';
+      ref.read(selectedOrderPresetProvider.notifier).state =
+          OrderPreset.custom;
     });
   }
 
@@ -83,6 +86,65 @@ class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
       final amount = double.tryParse(_amountController.text);
       return amount != null && amount > 0;
     }
+  }
+
+  /// Prefills the form from the chosen preset. Presets are suggestions —
+  /// the user can still review/edit everything before submitting.
+  void _applyPreset(OrderPreset preset, OrderInfo? source) {
+    ref.read(selectedOrderPresetProvider.notifier).state = preset;
+    switch (preset) {
+      case OrderPreset.express:
+        if (source == null) return;
+        final isRange =
+            source.fiatAmountMin != null && source.fiatAmountMax != null;
+        setState(() {
+          _isRange = isRange;
+          if (isRange) {
+            _minController.text = _formatNum(source.fiatAmountMin!);
+            _maxController.text = _formatNum(source.fiatAmountMax!);
+            _amountController.clear();
+          } else {
+            _amountController.text = source.fiatAmount != null
+                ? _formatNum(source.fiatAmount!)
+                : '';
+            _minController.clear();
+            _maxController.clear();
+          }
+        });
+        ref.read(selectedFiatCodeProvider.notifier).state = source.fiatCode;
+        final methods = source.paymentMethod
+            .split(',')
+            .map((m) => m.trim())
+            .where((m) => m.isNotEmpty)
+            .toList();
+        if (methods.isNotEmpty) {
+          ref.read(selectedPaymentMethodsProvider.notifier).state = methods;
+        }
+        ref.read(isMarketPriceProvider.notifier).state = true;
+        ref.read(premiumValueProvider.notifier).state =
+            source.premium.clamp(-10.0, 10.0);
+        ref.read(fixedSatsProvider.notifier).state = '';
+      case OrderPreset.conservative:
+        ref.read(isMarketPriceProvider.notifier).state = true;
+        ref.read(premiumValueProvider.notifier).state = 0.0;
+        ref.read(fixedSatsProvider.notifier).state = '';
+      case OrderPreset.custom:
+        // Full form as-is — nothing to prefill.
+        break;
+    }
+  }
+
+  static String _formatNum(double v) =>
+      v == v.roundToDouble() ? v.toStringAsFixed(0) : v.toString();
+
+  /// "1234567" → "1,234,567" for sats display.
+  static String _groupDigits(String s) {
+    final b = StringBuffer();
+    for (var i = 0; i < s.length; i++) {
+      if (i > 0 && (s.length - i) % 3 == 0) b.write(',');
+      b.write(s[i]);
+    }
+    return b.toString();
   }
 
   Future<void> _submit() async {
@@ -169,6 +231,8 @@ class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
     final customMethod = ref.watch(customPaymentMethodProvider);
     final isMarket = ref.watch(isMarketPriceProvider);
     final fixedSatsStr = ref.watch(fixedSatsProvider);
+    final fiatCode = ref.watch(selectedFiatCodeProvider);
+    final premium = ref.watch(premiumValueProvider);
     final isValid = _checkValid(selectedMethods, customMethod, isMarket, fixedSatsStr);
 
     return Scaffold(
@@ -176,6 +240,10 @@ class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
       body: ListView(
         padding: const EdgeInsets.all(AppSpacing.lg),
         children: [
+          // Preset cards: Express / Conservative / Custom
+          OrderPresetSelector(onSelect: _applyPreset),
+          const SizedBox(height: AppSpacing.lg),
+
           // Card 1: Order type + amount + currency
           _Card(
             color: cardBg,
@@ -289,15 +357,27 @@ class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
         ],
       ),
 
-      // Bottom bar: Cancel + Submit
+      // Bottom bar: live preview + Cancel + Submit
       bottomNavigationBar: SafeArea(
         child: Padding(
           padding: const EdgeInsets.symmetric(
             horizontal: AppSpacing.lg,
             vertical: AppSpacing.md,
           ),
-          child: Row(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
             children: [
+              _previewFooter(
+                colors: colors,
+                cardBg: cardBg,
+                isMarket: isMarket,
+                fixedSatsStr: fixedSatsStr,
+                fiatCode: fiatCode,
+                premium: premium,
+              ),
+              const SizedBox(height: AppSpacing.md),
+              Row(
+                children: [
               Expanded(
                 child: OutlinedButton(
                   onPressed: () => context.pop(),
@@ -337,9 +417,116 @@ class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
                       : const Text('Submit'),
                 ),
               ),
+                ],
+              ),
             ],
           ),
         ),
+      ),
+    );
+  }
+
+  /// Live preview footer — "You receive ≈ X sats for Y ARS · live for 24 h".
+  ///
+  /// A sats figure is only shown in Fixed price mode (where the user entered
+  /// it); there is no exchange-rate source in the app for market-price
+  /// estimates, so market mode shows the fiat side + premium only.
+  Widget _previewFooter({
+    required AppColors? colors,
+    required Color cardBg,
+    required bool isMarket,
+    required String fixedSatsStr,
+    required String fiatCode,
+    required double premium,
+  }) {
+    final textPrimary = colors?.textPrimary ?? Colors.white;
+    final secondary = colors?.textSecondary ?? Colors.grey;
+    final subtle = colors?.textSubtle ?? Colors.grey;
+
+    // Fiat side, mirroring _checkValid's rules.
+    String? amountStr;
+    if (_isRange) {
+      final min = double.tryParse(_minController.text);
+      final max = double.tryParse(_maxController.text);
+      if (min != null && max != null && min > 0 && min < max) {
+        amountStr = '${_formatNum(min)}–${_formatNum(max)} $fiatCode';
+      }
+    } else {
+      final amount = double.tryParse(_amountController.text);
+      if (amount != null && amount > 0) {
+        amountStr = '${_formatNum(amount)} $fiatCode';
+      }
+    }
+
+    // Exact sats are only known in Fixed price mode (user-entered).
+    BigInt? sats;
+    if (!isMarket) {
+      final parsed = BigInt.tryParse(fixedSatsStr);
+      if (parsed != null && parsed > BigInt.zero) sats = parsed;
+    }
+
+    Widget body;
+    if (amountStr == null) {
+      body = Text(
+        'Enter an amount to see a live preview.',
+        style: TextStyle(fontSize: 13, color: subtle),
+      );
+    } else {
+      final bold = TextStyle(
+        fontSize: 13,
+        fontWeight: FontWeight.w700,
+        color: textPrimary,
+      );
+      final spans = <TextSpan>[];
+      if (sats != null) {
+        spans
+          ..add(TextSpan(text: _isBuy ? 'You receive ' : 'You sell '))
+          ..add(TextSpan(
+            text: '${_groupDigits(sats.toString())} sats',
+            style: bold,
+          ))
+          ..add(const TextSpan(text: ' for '))
+          ..add(TextSpan(text: amountStr, style: bold));
+      } else {
+        final priceLabel = premium == 0
+            ? 'market price'
+            : 'market ${premium > 0 ? '+' : ''}${_formatNum(premium)}%';
+        spans
+          ..add(TextSpan(text: _isBuy ? 'You buy BTC for ' : 'You sell BTC for '))
+          ..add(TextSpan(text: amountStr, style: bold))
+          ..add(const TextSpan(text: ' at '))
+          ..add(TextSpan(text: priceLabel, style: bold));
+      }
+      spans
+        ..add(const TextSpan(text: ' · live for '))
+        ..add(TextSpan(text: '24 h', style: bold));
+
+      body = Text.rich(
+        TextSpan(
+          style: TextStyle(fontSize: 13, height: 1.5, color: secondary),
+          children: spans,
+        ),
+      );
+    }
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(AppSpacing.md),
+      decoration: BoxDecoration(
+        color: cardBg,
+        borderRadius: BorderRadius.circular(AppRadius.card),
+        border: Border.all(color: subtle.withValues(alpha: 0.25)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'PREVIEW',
+            style: TextStyle(fontSize: 11, letterSpacing: 1, color: subtle),
+          ),
+          const SizedBox(height: AppSpacing.xs),
+          body,
+        ],
       ),
     );
   }

--- a/lib/features/order/screens/take_order_screen.dart
+++ b/lib/features/order/screens/take_order_screen.dart
@@ -184,7 +184,7 @@ class _TakeOrderScreenState extends ConsumerState<TakeOrderScreen> {
 
     final flag = flags[order.fiatCode] ?? '';
     final title = widget.isBuying ? 'SELL ORDER DETAILS' : 'BUY ORDER DETAILS';
-    final actionLabel = widget.isBuying ? 'Buy' : 'Sell';
+    final actionLabel = widget.isBuying ? 'BUY THESE SATS' : 'SELL SATS';
     final premiumPositive = order.premium >= 0;
 
     return Scaffold(
@@ -199,15 +199,35 @@ class _TakeOrderScreenState extends ConsumerState<TakeOrderScreen> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
-                  '${order.displayAmount} ${order.fiatCode} $flag',
+                  widget.isBuying
+                      ? 'Someone is selling sats'
+                      : 'Someone is buying sats',
                   style: theme.textTheme.headlineMedium,
                 ),
                 const SizedBox(height: AppSpacing.xs),
+                Text.rich(
+                  TextSpan(
+                    text: 'for ',
+                    style: TextStyle(color: textSec, fontSize: 14),
+                    children: [
+                      TextSpan(
+                        text: '${order.displayAmount} ${order.fiatCode} $flag',
+                        style: TextStyle(
+                          color: colors?.textPrimary ?? Colors.white,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const TextSpan(text: ' at market price'),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.xs),
                 Text(
-                  'Market Price (${premiumPositive ? '+' : ''}${order.premium.toStringAsFixed(1)}%)',
+                  'Premium: ${premiumPositive ? '+' : ''}${order.premium.toStringAsFixed(1)}%',
                   style: TextStyle(
                     color: premiumPositive ? green : colors?.sellColor,
                     fontSize: 13,
+                    fontWeight: FontWeight.w600,
                   ),
                 ),
               ],
@@ -289,63 +309,123 @@ class _TakeOrderScreenState extends ConsumerState<TakeOrderScreen> {
           if (!privacyMode) ...[
             _InfoCard(
               color: cardBg,
-              child: Row(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  const Icon(Icons.star, size: 16, color: Colors.amber),
-                  const SizedBox(width: AppSpacing.xs),
                   Text(
-                    order.rating.toStringAsFixed(1),
-                    style: theme.textTheme.bodyMedium,
+                    'Creator reputation',
+                    style: TextStyle(color: textSec, fontSize: 12),
                   ),
-                  const SizedBox(width: AppSpacing.lg),
-                  Icon(Icons.person_outline, size: 16, color: textSec),
-                  const SizedBox(width: AppSpacing.xs),
-                  Text(
-                    '${order.tradeCount}',
-                    style: theme.textTheme.bodyMedium,
-                  ),
-                  const SizedBox(width: AppSpacing.lg),
-                  Icon(Icons.calendar_month_outlined, size: 16, color: textSec),
-                  const SizedBox(width: AppSpacing.xs),
-                  Text(
-                    '${order.daysActive}d',
-                    style: theme.textTheme.bodyMedium,
+                  const SizedBox(height: AppSpacing.md),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: _ReputationStat(
+                          value: order.rating.toStringAsFixed(1),
+                          label: 'rating',
+                          icon: Icons.star,
+                          iconColor: Colors.amber,
+                        ),
+                      ),
+                      Expanded(
+                        child: _ReputationStat(
+                          value: '${order.tradeCount}',
+                          label: 'trades',
+                        ),
+                      ),
+                      Expanded(
+                        child: _ReputationStat(
+                          value: '${order.daysActive}',
+                          label: 'days active',
+                        ),
+                      ),
+                    ],
                   ),
                 ],
               ),
             ),
             const SizedBox(height: AppSpacing.sm),
           ],
-          const SizedBox(height: AppSpacing.xl),
 
-          // Countdown timer
+          // Contextual countdown: what expires and what happens then.
           if (_remaining > Duration.zero) ...[
-            Center(
-              child: Column(
+            _InfoCard(
+              color: cardBg,
+              child: Row(
                 children: [
                   SizedBox(
-                    width: 80,
-                    height: 80,
-                    child: CircularProgressIndicator(
-                      value: () {
-                        if (order.expiresAt == null) return 0.0;
-                        final lifetime = order.expiresAt!
-                            .difference(order.createdAt)
-                            .inSeconds;
-                        if (lifetime <= 0) return 0.0;
-                        return (_remaining.inSeconds / lifetime)
-                            .clamp(0.0, 1.0);
-                      }(),
-                      strokeWidth: 4,
-                      color: green,
-                      backgroundColor:
-                          colors?.backgroundInput ?? const Color(0xFF252A3A),
+                    width: 72,
+                    height: 72,
+                    child: Stack(
+                      alignment: Alignment.center,
+                      children: [
+                        SizedBox(
+                          width: 72,
+                          height: 72,
+                          child: CircularProgressIndicator(
+                            value: () {
+                              if (order.expiresAt == null) return 0.0;
+                              final lifetime = order.expiresAt!
+                                  .difference(order.createdAt)
+                                  .inSeconds;
+                              if (lifetime <= 0) return 0.0;
+                              return (_remaining.inSeconds / lifetime)
+                                  .clamp(0.0, 1.0);
+                            }(),
+                            strokeWidth: 5,
+                            color: green,
+                            backgroundColor: colors?.backgroundInput ??
+                                const Color(0xFF252A3A),
+                          ),
+                        ),
+                        Text(
+                          _formatDuration(_remaining),
+                          style: const TextStyle(
+                            fontSize: 11,
+                            fontWeight: FontWeight.w700,
+                            fontFamily: 'monospace',
+                          ),
+                        ),
+                      ],
                     ),
                   ),
-                  const SizedBox(height: AppSpacing.sm),
-                  Text(
-                    'Time remaining: ${_formatDuration(_remaining)}',
-                    style: TextStyle(color: textSec, fontSize: 13),
+                  const SizedBox(width: AppSpacing.lg),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'TIME TO TAKE THIS ORDER',
+                          style: TextStyle(
+                            color: green,
+                            fontSize: 11,
+                            fontWeight: FontWeight.w700,
+                            letterSpacing: 0.5,
+                          ),
+                        ),
+                        const SizedBox(height: AppSpacing.xs),
+                        Text.rich(
+                          TextSpan(
+                            text: 'If it expires, the order is removed '
+                                'from the book. ',
+                            style: TextStyle(
+                              color: textSec,
+                              fontSize: 12,
+                              height: 1.4,
+                            ),
+                            children: [
+                              TextSpan(
+                                text: "It won't affect your reputation.",
+                                style: TextStyle(
+                                  color: green,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
                 ],
               ),
@@ -375,11 +455,12 @@ class _TakeOrderScreenState extends ConsumerState<TakeOrderScreen> {
                       borderRadius: BorderRadius.circular(AppRadius.button),
                     ),
                   ),
-                  child: const Text('Close'),
+                  child: const Text('CLOSE'),
                 ),
               ),
               const SizedBox(width: AppSpacing.md),
               Expanded(
+                flex: 2,
                 child: FilledButton(
                   onPressed: _submitting ? null : _onTakeOrder,
                   style: FilledButton.styleFrom(
@@ -411,6 +492,46 @@ class _TakeOrderScreenState extends ConsumerState<TakeOrderScreen> {
         '${dt.day.toString().padLeft(2, '0')} '
         '${dt.hour.toString().padLeft(2, '0')}:'
         '${dt.minute.toString().padLeft(2, '0')}';
+  }
+}
+
+/// One column of the 3-column creator-reputation block.
+class _ReputationStat extends StatelessWidget {
+  const _ReputationStat({
+    required this.value,
+    required this.label,
+    this.icon,
+    this.iconColor,
+  });
+
+  final String value;
+  final String label;
+  final IconData? icon;
+  final Color? iconColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<AppColors>();
+    final textSec = colors?.textSecondary ?? const Color(0xFFB0B3C6);
+    return Column(
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            if (icon != null) ...[
+              Icon(icon, size: 16, color: iconColor),
+              const SizedBox(width: AppSpacing.xs),
+            ],
+            Text(
+              value,
+              style: const TextStyle(fontSize: 20, fontWeight: FontWeight.w700),
+            ),
+          ],
+        ),
+        const SizedBox(height: 2),
+        Text(label, style: TextStyle(color: textSec, fontSize: 11)),
+      ],
+    );
   }
 }
 

--- a/lib/features/order/widgets/order_preset_selector.dart
+++ b/lib/features/order/widgets/order_preset_selector.dart
@@ -1,0 +1,249 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:mostro/core/app_theme.dart';
+import 'package:mostro/src/rust/api/orders.dart' as orders_api;
+import 'package:mostro/src/rust/api/types.dart';
+
+/// Presets offered at the top of the create-order form.
+enum OrderPreset { express, conservative, custom }
+
+/// Currently selected preset in the create-order form.
+final selectedOrderPresetProvider =
+    StateProvider<OrderPreset>((_) => OrderPreset.custom);
+
+/// Statuses that mean the trade finished successfully.
+const _successStatuses = {
+  OrderStatus.success,
+  OrderStatus.settledHoldInvoice,
+  OrderStatus.settledByAdmin,
+  OrderStatus.completedByAdmin,
+};
+
+/// The user's most recent successful trade order, or `null` if none exists.
+///
+/// Used as the data source for the Express preset — its card is hidden
+/// when this resolves to `null`.
+final lastSuccessfulOrderProvider =
+    FutureProvider.autoDispose<OrderInfo?>((ref) async {
+  try {
+    final trades = await orders_api.listTrades();
+    final successful = trades
+        .where((t) =>
+            t.outcome == TradeOutcome.success ||
+            _successStatuses.contains(t.order.status))
+        .toList()
+      ..sort((a, b) => (b.completedAt ?? b.startedAt)
+          .compareTo(a.completedAt ?? a.startedAt));
+    return successful.isEmpty ? null : successful.first.order;
+  } catch (e) {
+    debugPrint('[order presets] listTrades failed: $e');
+    return null;
+  }
+});
+
+/// "Start from a preset" section — Express / Conservative / Custom cards.
+///
+/// Presets only prefill the existing form fields via [onSelect]; the user
+/// can still review and edit everything before submitting.
+class OrderPresetSelector extends ConsumerWidget {
+  const OrderPresetSelector({super.key, required this.onSelect});
+
+  /// Called when a preset card is tapped. For Express, `expressSource` is
+  /// the order to copy values from; it is `null` for the other presets.
+  final void Function(OrderPreset preset, OrderInfo? expressSource) onSelect;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = Theme.of(context).extension<AppColors>();
+    final green = colors?.mostroGreen ?? const Color(0xFF8CC63F);
+    final blue = colors?.blueAccent ?? const Color(0xFF60A5FA);
+    final purple = colors?.purpleButton ?? const Color(0xFF8359C2);
+    final cardBg = colors?.backgroundCard ?? const Color(0xFF1E2230);
+    final selected = ref.watch(selectedOrderPresetProvider);
+    final lastOrder = ref.watch(lastSuccessfulOrderProvider).valueOrNull;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'START FROM A PRESET',
+          style: TextStyle(
+            fontSize: 11,
+            letterSpacing: 1,
+            color: colors?.textSubtle,
+          ),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        if (lastOrder != null) ...[
+          _PresetCard(
+            cardBg: cardBg,
+            iconData: Icons.bolt,
+            iconColor: green,
+            title: 'Express',
+            subtitle: _expressSubtitle(lastOrder),
+            tag: 'RECOMMENDED',
+            tagColor: green,
+            selected: selected == OrderPreset.express,
+            highlightColor: green,
+            onTap: () => onSelect(OrderPreset.express, lastOrder),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+        ],
+        _PresetCard(
+          cardBg: cardBg,
+          iconData: Icons.shield_outlined,
+          iconColor: blue,
+          title: 'Conservative',
+          subtitle: 'Market price · 0% premium · you choose amount & methods',
+          selected: selected == OrderPreset.conservative,
+          highlightColor: green,
+          onTap: () => onSelect(OrderPreset.conservative, null),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        _PresetCard(
+          cardBg: cardBg,
+          iconData: Icons.settings,
+          iconColor: purple,
+          title: 'Custom',
+          subtitle:
+              'All fields — amount, range, methods, premium, fixed or market price',
+          selected: selected == OrderPreset.custom,
+          highlightColor: green,
+          onTap: () => onSelect(OrderPreset.custom, null),
+        ),
+      ],
+    );
+  }
+
+  /// "Same as your last successful order — 50 ARS, MP, 0% premium".
+  static String _expressSubtitle(OrderInfo order) {
+    final parts = <String>[];
+    if (order.fiatAmount != null) {
+      parts.add('${_formatNum(order.fiatAmount!)} ${order.fiatCode}');
+    } else if (order.fiatAmountMin != null && order.fiatAmountMax != null) {
+      parts.add('${_formatNum(order.fiatAmountMin!)}–'
+          '${_formatNum(order.fiatAmountMax!)} ${order.fiatCode}');
+    } else {
+      parts.add(order.fiatCode);
+    }
+    final firstMethod = order.paymentMethod
+        .split(',')
+        .map((m) => m.trim())
+        .where((m) => m.isNotEmpty)
+        .firstOrNull;
+    if (firstMethod != null) parts.add(firstMethod);
+    final p = order.premium;
+    parts.add('${p > 0 ? '+' : ''}${_formatNum(p)}% premium');
+    return 'Same as your last successful order — ${parts.join(', ')}';
+  }
+
+  static String _formatNum(double v) =>
+      v == v.roundToDouble() ? v.toStringAsFixed(0) : v.toString();
+}
+
+class _PresetCard extends StatelessWidget {
+  const _PresetCard({
+    required this.cardBg,
+    required this.iconData,
+    required this.iconColor,
+    required this.title,
+    required this.subtitle,
+    required this.selected,
+    required this.highlightColor,
+    required this.onTap,
+    this.tag,
+    this.tagColor,
+  });
+
+  final Color cardBg;
+  final IconData iconData;
+  final Color iconColor;
+  final String title;
+  final String subtitle;
+  final String? tag;
+  final Color? tagColor;
+  final bool selected;
+  final Color highlightColor;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = theme.extension<AppColors>();
+
+    return GestureDetector(
+      onTap: onTap,
+      behavior: HitTestBehavior.opaque,
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(AppSpacing.md),
+        decoration: BoxDecoration(
+          color: cardBg,
+          borderRadius: BorderRadius.circular(AppRadius.card),
+          border: Border.all(
+            color: selected ? highlightColor : Colors.transparent,
+            width: 1.5,
+          ),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Container(
+                  width: 36,
+                  height: 36,
+                  decoration: BoxDecoration(
+                    color: iconColor.withValues(alpha: 0.15),
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: Icon(iconData, size: 20, color: iconColor),
+                ),
+                const SizedBox(width: AppSpacing.sm),
+                Expanded(
+                  child: Text(
+                    title,
+                    style: const TextStyle(
+                      fontSize: 15,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ),
+                if (tag != null)
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: AppSpacing.sm,
+                      vertical: 3,
+                    ),
+                    decoration: BoxDecoration(
+                      color: (tagColor ?? highlightColor)
+                          .withValues(alpha: 0.15),
+                      borderRadius: BorderRadius.circular(AppRadius.chip),
+                    ),
+                    child: Text(
+                      tag!,
+                      style: TextStyle(
+                        fontSize: 10,
+                        fontWeight: FontWeight.w700,
+                        color: tagColor ?? highlightColor,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Text(
+              subtitle,
+              style: TextStyle(
+                fontSize: 12,
+                height: 1.5,
+                color: colors?.textSecondary,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:mostro/l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -10,18 +11,21 @@ import 'package:mostro/core/app_theme.dart';
 import 'package:mostro/src/rust/api/disputes.dart' as disputes_api;
 import 'package:mostro/src/rust/api/orders.dart' as orders_api;
 import 'package:mostro/features/account/providers/privacy_mode_provider.dart';
+import 'package:mostro/features/chat/providers/chat_providers.dart';
 import 'package:mostro/features/disputes/providers/disputes_providers.dart';
 import 'package:mostro/features/home/providers/home_order_providers.dart';
 import 'package:mostro/features/order/providers/trade_state_provider.dart';
 import 'package:mostro/features/trades/providers/trades_providers.dart';
 import 'package:mostro/features/trades/widgets/release_confirmation_dialog.dart';
-import 'package:mostro/features/trades/widgets/trade_info_cards.dart';
 import 'package:mostro/shared/widgets/mostro_reactive_button.dart';
+import 'package:mostro/shared/widgets/nym_avatar.dart';
 
 /// Trade detail screen — Route `/trade_detail/:orderId`.
 ///
-/// Shows trade summary, payment method, dates, order ID, instructions,
-/// countdown timer, and role-based action buttons.
+/// One explicit next action per state-machine state: a single primary CTA,
+/// secondary/destructive actions collapsed behind the app-bar overflow menu,
+/// a persistent chat chip, a contextual timer (what expires + consequence),
+/// and a step timeline of the trade.
 class TradeDetailScreen extends ConsumerStatefulWidget {
   const TradeDetailScreen({super.key, required this.orderId});
 
@@ -60,6 +64,9 @@ enum TradeStatus {
   const TradeStatus(this.label);
   final String label;
 }
+
+/// Overflow-menu actions (cancel / dispute / release collapsed behind ⋮).
+enum _MenuAction { cancel, dispute, release }
 
 class _TradeDetailScreenState extends ConsumerState<TradeDetailScreen> {
   Timer? _countdownTimer;
@@ -176,6 +183,57 @@ class _TradeDetailScreenState extends ConsumerState<TradeDetailScreen> {
     }
   }
 
+  /// Open a dispute for this trade, upsert into the local dispute notifier,
+  /// and navigate to the dispute chat.
+  Future<void> _openDispute() async {
+    try {
+      final dispute = await disputes_api.openDispute(tradeId: widget.orderId);
+      if (!mounted) return;
+      final raw = dispute.openedAt;
+      // PlatformInt64 = int on native, BigInt on web.
+      final openedAt = raw is BigInt ? raw.toInt() : raw;
+      ref.read(disputeNotifierProvider.notifier).upsert(
+            DisputeItem(
+              id: dispute.id,
+              tradeId: dispute.tradeId,
+              status: DisputeStatus.open,
+              initiatedByMe: true,
+              openedAt: openedAt,
+            ),
+          );
+      if (!mounted) return;
+      context.push(AppRoute.disputeDetailsPath(dispute.id));
+    } catch (e, st) {
+      debugPrint('[TradeDetailScreen] openDispute error: $e\n$st');
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(AppLocalizations.of(context).openDisputeFailed)),
+      );
+    }
+  }
+
+  /// Confirm and release the sats (seller). Shared between the primary CTA
+  /// in the fiat-sent state and the overflow menu in the disputed state.
+  Future<void> _releaseOrder() async {
+    final confirmed = await showReleaseConfirmationDialog(context);
+    if (confirmed != true || !mounted) return;
+    try {
+      await orders_api.releaseOrder(orderId: widget.orderId);
+      if (!mounted) return;
+      if (ref.read(privacyModeProvider)) {
+        context.go(AppRoute.home);
+      } else {
+        context.push(AppRoute.rateUserPath(widget.orderId));
+      }
+    } catch (e, st) {
+      debugPrint('[TradeDetailScreen] releaseOrder error: $e\n$st');
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(AppLocalizations.of(context).releaseFailed)),
+      );
+    }
+  }
+
   String _getInstructionText(bool isBuyer, TradeStatus status) {
     final l10n = AppLocalizations.of(context);
     if (status == TradeStatus.waitingInvoice) {
@@ -190,7 +248,8 @@ class _TradeDetailScreenState extends ConsumerState<TradeDetailScreen> {
     }
     if (isBuyer) {
       if (status == TradeStatus.active) {
-        return 'Send the fiat payment to the seller, then tap "Fiat Sent".';
+        return 'Once you have sent the money, mark it below. '
+            'Only open a dispute if the seller stops responding.';
       } else if (status == TradeStatus.fiatSent) {
         return 'Fiat payment marked as sent. Waiting for the seller '
             'to confirm receipt and release your sats.';
@@ -198,7 +257,7 @@ class _TradeDetailScreenState extends ConsumerState<TradeDetailScreen> {
     } else {
       // Seller
       if (status == TradeStatus.active) {
-        return 'Contact the buyer with payment instructions.';
+        return 'Contact the buyer with payment instructions via the chat above.';
       } else if (status == TradeStatus.fiatSent) {
         return 'The buyer has confirmed they sent the fiat payment. '
             'Once you verify receipt, release the sats.';
@@ -219,91 +278,130 @@ class _TradeDetailScreenState extends ConsumerState<TradeDetailScreen> {
       return 'Your order is published and waiting for a counterpart to take it. '
           'You can cancel it at any time.';
     }
+    if (status == TradeStatus.cancelled) {
+      return 'This trade was cancelled. No funds were exchanged.';
+    }
     return 'Trade in progress.';
   }
 
   String _formatDuration(Duration d) {
-    if (d.isNegative) return '00:00:00';
-    final h = d.inHours.toString().padLeft(2, '0');
+    if (d.isNegative) return '00:00';
     final m = (d.inMinutes % 60).toString().padLeft(2, '0');
     final s = (d.inSeconds % 60).toString().padLeft(2, '0');
-    return '$h:$m:$s';
+    if (d.inHours > 0) return '${d.inHours}:$m:$s';
+    return '$m:$s';
   }
 
-  /// Open a dispute for this trade, upsert into the local dispute notifier,
-  /// and navigate to the dispute chat.
-  Future<void> _openDispute() async {
-    try {
-      final dispute = await disputes_api.openDispute(tradeId: widget.orderId);
-      if (!context.mounted) return;
-      final raw = dispute.openedAt;
-      // PlatformInt64 = int on native, BigInt on web.
-      final openedAt = raw is BigInt ? raw.toInt() : raw;
-      ref.read(disputeNotifierProvider.notifier).upsert(
-            DisputeItem(
-              id: dispute.id,
-              tradeId: dispute.tradeId,
-              status: DisputeStatus.open,
-              initiatedByMe: true,
-              openedAt: openedAt,
-            ),
-          );
-      if (!context.mounted) return;
-      context.push(AppRoute.disputeDetailsPath(dispute.id));
-    } catch (e, st) {
-      debugPrint('[TradeDetailScreen] openDispute error: $e\n$st');
-      if (!context.mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(AppLocalizations.of(context).openDisputeFailed)),
-      );
-    }
+  // ── State → copy mapping ─────────────────────────────────────────────────
+
+  /// Headline of the state strip — the one thing happening right now.
+  String _headline(bool isBuyer, TradeStatus status, OrderItem? order) {
+    final amount = order != null
+        ? '${order.displayAmount} ${order.fiatCode}'
+        : 'the agreed amount';
+    return switch (status) {
+      TradeStatus.pending => 'Waiting for someone to take your order',
+      TradeStatus.waitingInvoice => isBuyer
+          ? 'Share a Lightning invoice to receive your sats'
+          : 'Waiting for the buyer to share an invoice',
+      TradeStatus.waitingPayment => isBuyer
+          ? 'Waiting for the seller to lock the sats'
+          : 'Pay the hold invoice to lock the sats',
+      TradeStatus.active => isBuyer
+          ? 'Send $amount to the seller'
+          : 'Waiting for the buyer to send $amount',
+      TradeStatus.fiatSent => isBuyer
+          ? 'Waiting for the seller to release your sats'
+          : 'Confirm you received $amount',
+      TradeStatus.disputed => 'Dispute in progress',
+      TradeStatus.pendingRating ||
+      TradeStatus.completed => 'Trade complete!',
+      TradeStatus.rated => 'Trade complete',
+      TradeStatus.cancelled => 'Order cancelled',
+      TradeStatus.loading => 'Loading trade…',
+    };
   }
 
-  /// Shared style for destructive (cancel / dispute) outlined buttons.
-  ButtonStyle _destructiveOutlineStyle(Color destructiveRed) =>
-      OutlinedButton.styleFrom(
-        foregroundColor: destructiveRed,
-        side: BorderSide(color: destructiveRed),
-        minimumSize: const Size(0, 40),
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(AppRadius.button),
+  /// Contextual timer copy: what expires and what happens then.
+  (String, String)? _timerContext(bool isBuyer, TradeStatus status) {
+    return switch (status) {
+      TradeStatus.pending => (
+          'Time for this order to stay in the book',
+          'If it expires, the order is removed from the book. '
+              "It won't affect your reputation.",
         ),
-      );
-
-  /// RELEASE button — shared between the Disputed and Fiat-Sent seller flows.
-  Widget _buildReleaseButton(Color green) {
-    return MostroReactiveButton(
-      label: 'RELEASE',
-      backgroundColor: green,
-      icon: Icons.lock_open,
-      onPressed: () async {
-        final confirmed = await showReleaseConfirmationDialog(context);
-        if (confirmed != true || !context.mounted) return;
-        try {
-          await orders_api.releaseOrder(orderId: widget.orderId);
-          if (!context.mounted) return;
-          if (ref.read(privacyModeProvider)) {
-            context.go(AppRoute.home);
-          } else {
-            context.push(AppRoute.rateUserPath(widget.orderId));
-          }
-        } catch (e, st) {
-          debugPrint('[TradeDetailScreen] releaseOrder error: $e\n$st');
-          if (!context.mounted) return;
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(AppLocalizations.of(context).releaseFailed)),
-          );
-        }
-      },
-      onError: (e) {
-        debugPrint('[TradeDetailScreen] releaseOrder onError: $e');
-        if (!mounted) return;
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(AppLocalizations.of(context).releaseFailed)),
-        );
-      },
-    );
+      TradeStatus.waitingInvoice => (
+          isBuyer
+              ? 'Time to share your invoice'
+              : 'Time for the buyer to share an invoice',
+          'If it expires, the trade is cancelled and the order '
+              'returns to the book.',
+        ),
+      TradeStatus.waitingPayment => (
+          isBuyer
+              ? 'Time for the seller to lock the sats'
+              : 'Time to pay the hold invoice',
+          'If it expires, the trade is cancelled and the order '
+              'returns to the book.',
+        ),
+      TradeStatus.active => (
+          isBuyer
+              ? 'Time to send the fiat payment'
+              : 'Time for the buyer to send the fiat',
+          'If it expires, the trade can be cancelled. '
+              'Coordinate in the chat if more time is needed.',
+        ),
+      TradeStatus.fiatSent => (
+          isBuyer
+              ? 'Time for the seller to confirm receipt'
+              : 'Time to confirm receipt and release',
+          'If something looks wrong, open a dispute from the ⋮ menu.',
+        ),
+      _ => null,
+    };
   }
+
+  /// Status pill colors — (background, text).
+  (Color, Color) _statusPillColors(TradeStatus status) => switch (status) {
+        TradeStatus.pending => AppColors.statusPending,
+        TradeStatus.waitingInvoice ||
+        TradeStatus.waitingPayment => AppColors.statusWaiting,
+        TradeStatus.active => AppColors.statusActive,
+        TradeStatus.fiatSent => AppColors.statusSettled,
+        TradeStatus.pendingRating ||
+        TradeStatus.completed ||
+        TradeStatus.rated => AppColors.statusSuccess,
+        TradeStatus.disputed => AppColors.statusDispute,
+        _ => AppColors.statusInactive,
+      };
+
+  /// 0-based index of the current step in [_steps]; equals the list length
+  /// once the trade is fully done.
+  int _currentStep(TradeStatus status) => switch (status) {
+        TradeStatus.pending => 0,
+        TradeStatus.waitingInvoice || TradeStatus.waitingPayment => 1,
+        TradeStatus.active => 2,
+        TradeStatus.fiatSent => 3,
+        TradeStatus.pendingRating || TradeStatus.completed => 4,
+        TradeStatus.rated => 5,
+        _ => -1, // disputed / cancelled / loading — timeline hidden
+      };
+
+  /// Step labels. Lightning setup is one step because the invoice/hold-invoice
+  /// order depends on which side made the order.
+  List<String> _steps(bool isBuyer) => [
+        'Order taken',
+        isBuyer
+            ? 'You share an invoice · seller locks the sats'
+            : 'Buyer shares an invoice · you lock the sats',
+        isBuyer ? 'You send the fiat payment' : 'Buyer sends the fiat payment',
+        isBuyer
+            ? 'Seller confirms and releases your sats'
+            : 'You confirm receipt and release the sats',
+        'Rate your counterpart',
+      ];
+
+  // ── Build ────────────────────────────────────────────────────────────────
 
   @override
   Widget build(BuildContext context) {
@@ -329,506 +427,728 @@ class _TradeDetailScreenState extends ConsumerState<TradeDetailScreen> {
     // Use TradeStatus.loading while the provider hasn't resolved so the UI
     // doesn't flash the pending CTA before the real status is known.
     final tradeStatusAsync = ref.watch(tradeStatusProvider(widget.orderId));
-    final TradeStatus status;
-    if (tradeStatusAsync.hasValue) {
-      status = _mapOrderStatus(tradeStatusAsync.value!);
-    } else if (tradeStatusAsync.hasError) {
-      status = TradeStatus.loading;
-    } else {
-      status = TradeStatus.loading;
-    }
+    final status = tradeStatusAsync.hasValue
+        ? _mapOrderStatus(tradeStatusAsync.value!)
+        : TradeStatus.loading;
 
     // Look up order details from the live order book.
     final allOrders = ref.watch(orderBookProvider).valueOrNull ?? [];
     final order = allOrders.where((o) => o.id == widget.orderId).firstOrNull;
 
+    final inFlight = const {
+      TradeStatus.waitingInvoice,
+      TradeStatus.waitingPayment,
+      TradeStatus.active,
+      TradeStatus.fiatSent,
+      TradeStatus.disputed,
+    }.contains(status);
+
     return Scaffold(
       appBar: AppBar(
-        title: const Text('ORDER DETAILS'),
+        title: Text(inFlight ? 'ACTIVE TRADE' : 'ORDER DETAILS'),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
           onPressed: () =>
               context.canPop() ? context.pop() : context.go(AppRoute.home),
         ),
+        actions: [_buildOverflowMenu(status, isBuyer, colors)],
       ),
       body: ListView(
         padding: const EdgeInsets.all(AppSpacing.lg),
         children: [
-          // Card 1: Trade summary
-          TradeInfoCard(
-            child: Column(
+          // Persistent chat chip — always-on access to the counterpart.
+          if (inFlight) ...[
+            _ChatChip(orderId: widget.orderId),
+            const SizedBox(height: AppSpacing.md),
+          ],
+
+          // State strip: step pill + status pill + headline + instruction
+          // + contextual timer.
+          _buildStateStrip(theme, colors, isBuyer, status, order),
+          const SizedBox(height: AppSpacing.lg),
+
+          // Single primary CTA for the current state.
+          ..._buildPrimaryAction(status, isBuyer, green, colors),
+
+          // Step timeline.
+          if (_currentStep(status) >= 0) ...[
+            const SizedBox(height: AppSpacing.lg),
+            _buildTimeline(theme, colors, isBuyer, status),
+          ],
+
+          // Compact meta footer: order ID + created date.
+          const SizedBox(height: AppSpacing.lg),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
+            child: Row(
+              children: [
+                Flexible(
+                  child: Text(
+                    'ID ${_shortId(widget.orderId)}',
+                    style: TextStyle(
+                      color: textSec,
+                      fontSize: 12,
+                      fontFamily: 'monospace',
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.xs),
+                InkWell(
+                  onTap: () {
+                    Clipboard.setData(ClipboardData(text: widget.orderId));
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                        content: Text('Order ID copied'),
+                        duration: Duration(seconds: 1),
+                      ),
+                    );
+                  },
+                  child: Icon(Icons.copy, size: 14, color: textSec),
+                ),
+                const Spacer(),
+                if (order != null)
+                  Text(
+                    'created ${_formatDate(order.createdAt)}',
+                    style: TextStyle(color: textSec, fontSize: 12),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  static String _shortId(String id) =>
+      id.length <= 14 ? id : '${id.substring(0, 8)}…${id.substring(id.length - 5)}';
+
+  // ── Overflow menu (collapsed secondary/destructive actions) ──────────────
+
+  Widget _buildOverflowMenu(
+      TradeStatus status, bool isBuyer, AppColors? colors) {
+    final red = colors?.destructiveRed ?? const Color(0xFFD84D4D);
+
+    final canCancel = const {
+      TradeStatus.pending,
+      TradeStatus.waitingInvoice,
+      TradeStatus.waitingPayment,
+      TradeStatus.active,
+      TradeStatus.fiatSent,
+    }.contains(status) ||
+        (status == TradeStatus.disputed && !isBuyer);
+    final canDispute =
+        status == TradeStatus.active || status == TradeStatus.fiatSent;
+    final canRelease = status == TradeStatus.disputed && !isBuyer;
+
+    if (!canCancel && !canDispute && !canRelease) {
+      return const SizedBox.shrink();
+    }
+
+    return PopupMenuButton<_MenuAction>(
+      icon: const Icon(Icons.more_vert),
+      onSelected: (action) => switch (action) {
+        _MenuAction.cancel => _cancelOrder(),
+        _MenuAction.dispute => _openDispute(),
+        _MenuAction.release => _releaseOrder(),
+      },
+      itemBuilder: (ctx) => [
+        if (canRelease)
+          const PopupMenuItem(
+            value: _MenuAction.release,
+            child: ListTile(
+              contentPadding: EdgeInsets.zero,
+              leading: Icon(Icons.lock_open, size: 18),
+              title: Text('Release sats'),
+              dense: true,
+            ),
+          ),
+        if (canCancel)
+          PopupMenuItem(
+            value: _MenuAction.cancel,
+            child: ListTile(
+              contentPadding: EdgeInsets.zero,
+              leading: Icon(Icons.cancel_outlined, size: 18, color: red),
+              title: Text('Cancel order', style: TextStyle(color: red)),
+              dense: true,
+            ),
+          ),
+        if (canDispute)
+          PopupMenuItem(
+            value: _MenuAction.dispute,
+            child: ListTile(
+              contentPadding: EdgeInsets.zero,
+              leading: Icon(Icons.gavel, size: 18, color: red),
+              title: Text('Open dispute', style: TextStyle(color: red)),
+              dense: true,
+            ),
+          ),
+      ],
+    );
+  }
+
+  // ── State strip ──────────────────────────────────────────────────────────
+
+  Widget _buildStateStrip(
+    ThemeData theme,
+    AppColors? colors,
+    bool isBuyer,
+    TradeStatus status,
+    OrderItem? order,
+  ) {
+    final cardBg = colors?.backgroundCard ?? const Color(0xFF1E2230);
+    final textSec = colors?.textSecondary ?? const Color(0xFFB0B3C6);
+    final (pillBg, pillFg) = _statusPillColors(status);
+    final currentStep = _currentStep(status);
+    final totalSteps = _steps(isBuyer).length;
+    final timerCtx = _timerContext(isBuyer, status);
+    final showTimer = timerCtx != null && _remaining > Duration.zero;
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(AppSpacing.lg),
+      decoration: BoxDecoration(
+        color: cardBg,
+        borderRadius: BorderRadius.circular(AppRadius.card),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              if (currentStep >= 0)
+                _Pill(
+                  label: currentStep >= totalSteps
+                      ? 'DONE'
+                      : 'STEP ${currentStep + 1} OF $totalSteps',
+                  background: colors?.backgroundElevated ??
+                      const Color(0xFF2A2D35),
+                  foreground: textSec,
+                ),
+              if (currentStep >= 0) const SizedBox(width: AppSpacing.sm),
+              _Pill(
+                label: status.label,
+                background: pillBg,
+                foreground: pillFg,
+              ),
+            ],
+          ),
+          const SizedBox(height: AppSpacing.md),
+          Text(
+            _headline(isBuyer, status, order),
+            style: theme.textTheme.headlineMedium,
+          ),
+          if (order != null) ...[
+            const SizedBox(height: AppSpacing.xs),
+            Text(
+              '${order.displayAmount} ${order.fiatCode} · ${order.paymentMethod}',
+              style: TextStyle(
+                color: textSec,
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+              ),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ],
+          const SizedBox(height: AppSpacing.sm),
+          Text(
+            _getInstructionText(isBuyer, status),
+            style: theme.textTheme.bodyMedium,
+          ),
+          if (showTimer) ...[
+            const SizedBox(height: AppSpacing.lg),
+            _buildContextualTimer(colors, timerCtx),
+          ],
+        ],
+      ),
+    );
+  }
+
+  /// Mini timer row: clock + remaining + label, progress bar, consequence.
+  Widget _buildContextualTimer(AppColors? colors, (String, String) ctx) {
+    final (label, consequence) = ctx;
+    final textSec = colors?.textSecondary ?? const Color(0xFFB0B3C6);
+    final green = colors?.mostroGreen ?? const Color(0xFF8CC63F);
+    final amber = colors?.warningAmber ?? const Color(0xFFE89C3C);
+    final red = colors?.destructiveRed ?? const Color(0xFFD84D4D);
+    final track = colors?.backgroundInput ?? const Color(0xFF252A3A);
+
+    final fraction = _totalCountdownSeconds > 0
+        ? (_remaining.inSeconds / _totalCountdownSeconds).clamp(0.0, 1.0)
+        : 0.0;
+    // Lime → amber at <10% remaining → red at <2%.
+    final timerColor = fraction < 0.02
+        ? red
+        : fraction < 0.10
+            ? amber
+            : green;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Icon(Icons.schedule, size: 16, color: timerColor),
+            const SizedBox(width: AppSpacing.sm),
+            Text(
+              _formatDuration(_remaining),
+              style: TextStyle(
+                color: timerColor,
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+                fontFamily: 'monospace',
+              ),
+            ),
+            const SizedBox(width: AppSpacing.sm),
+            Expanded(
+              child: Text(
+                label,
+                style: TextStyle(color: textSec, fontSize: 12),
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        ClipRRect(
+          borderRadius: BorderRadius.circular(2),
+          child: LinearProgressIndicator(
+            value: fraction,
+            minHeight: 4,
+            color: timerColor,
+            backgroundColor: track,
+          ),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        Text(
+          consequence,
+          style: TextStyle(color: textSec, fontSize: 12, height: 1.4),
+        ),
+      ],
+    );
+  }
+
+  // ── Primary CTA ──────────────────────────────────────────────────────────
+
+  /// One explicit next action per state. Waiting-on-counterpart states get a
+  /// disabled button with a spinner instead of a tappable CTA.
+  List<Widget> _buildPrimaryAction(
+    TradeStatus status,
+    bool isBuyer,
+    Color green,
+    AppColors? colors,
+  ) {
+    final red = colors?.destructiveRed ?? const Color(0xFFD84D4D);
+
+    FilledButton bigButton({
+      required String label,
+      required IconData icon,
+      required VoidCallback onPressed,
+      Color? background,
+      Color? foreground,
+    }) =>
+        FilledButton.icon(
+          onPressed: onPressed,
+          icon: Icon(icon, size: 18),
+          label: Text(label),
+          style: FilledButton.styleFrom(
+            backgroundColor: background ?? green,
+            foregroundColor: foreground ?? Colors.black,
+            minimumSize: const Size.fromHeight(56),
+            textStyle:
+                const TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(AppRadius.card),
+            ),
+          ),
+        );
+
+    switch ((status, isBuyer)) {
+      case (TradeStatus.waitingInvoice, true):
+        return [
+          bigButton(
+            label: 'Add Lightning invoice',
+            icon: Icons.receipt_long_outlined,
+            onPressed: () =>
+                context.push(AppRoute.addInvoicePath(widget.orderId)),
+          ),
+        ];
+      case (TradeStatus.waitingPayment, false):
+        return [
+          bigButton(
+            label: 'Pay hold invoice',
+            icon: Icons.bolt,
+            onPressed: () =>
+                context.push(AppRoute.payInvoicePath(widget.orderId)),
+          ),
+        ];
+      case (TradeStatus.active, true):
+        return [
+          MostroReactiveButton(
+            label: 'Mark fiat sent',
+            backgroundColor: green,
+            icon: Icons.check,
+            onPressed: () async {
+              await orders_api.sendFiatSent(orderId: widget.orderId);
+            },
+            onError: (e) {
+              debugPrint('[TradeDetailScreen] sendFiatSent onError: $e');
+              if (!mounted) return;
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                    content:
+                        Text(AppLocalizations.of(context).fiatSentFailed)),
+              );
+            },
+          ),
+        ];
+      case (TradeStatus.fiatSent, false):
+        return [
+          MostroReactiveButton(
+            label: 'Confirm & release sats',
+            backgroundColor: green,
+            icon: Icons.lock_open,
+            onPressed: _releaseOrder,
+            onError: (e) {
+              debugPrint('[TradeDetailScreen] releaseOrder onError: $e');
+              if (!mounted) return;
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                    content: Text(AppLocalizations.of(context).releaseFailed)),
+              );
+            },
+          ),
+        ];
+      case (TradeStatus.disputed, _):
+        return [
+          bigButton(
+            label: 'View dispute',
+            icon: Icons.gavel,
+            background: red,
+            foreground: Colors.white,
+            onPressed: () {
+              final dispute = ref.read(
+                disputeByTradeIdProvider(widget.orderId),
+              );
+              if (dispute == null) {
+                final l10n = AppLocalizations.of(context);
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(
+                    content: Text(l10n.disputeNotFoundForOrder),
+                    duration: const Duration(seconds: 2),
+                  ),
+                );
+                return;
+              }
+              context.push(AppRoute.disputeDetailsPath(dispute.id));
+            },
+          ),
+        ];
+      case (TradeStatus.pendingRating, _):
+        return [
+          bigButton(
+            label: 'Rate your counterpart',
+            icon: Icons.star_outline,
+            onPressed: () {
+              if (ref.read(privacyModeProvider)) {
+                context.go(AppRoute.home);
+              } else {
+                context.push(AppRoute.rateUserPath(widget.orderId));
+              }
+            },
+          ),
+        ];
+      case (TradeStatus.rated, _) || (TradeStatus.cancelled, _):
+        return [
+          OutlinedButton(
+            onPressed: () =>
+                context.canPop() ? context.pop() : context.go(AppRoute.home),
+            style: OutlinedButton.styleFrom(
+              foregroundColor: green,
+              side: BorderSide(color: green),
+              minimumSize: const Size.fromHeight(48),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(AppRadius.card),
+              ),
+            ),
+            child: const Text('CLOSE'),
+          ),
+        ];
+      // Waiting on the counterpart (or order still pending / loading):
+      // disabled button with spinner so the "next action" is explicit.
+      case (TradeStatus.waitingInvoice, false):
+        return [_waitingButton('Waiting for the buyer…', colors)];
+      case (TradeStatus.waitingPayment, true):
+        return [_waitingButton('Waiting for the seller…', colors)];
+      case (TradeStatus.active, false):
+        return [_waitingButton('Waiting for the fiat payment…', colors)];
+      case (TradeStatus.fiatSent, true):
+        return [_waitingButton('Waiting for the seller…', colors)];
+      case (TradeStatus.pending, _):
+        return [_waitingButton('Waiting for a counterpart…', colors)];
+      default:
+        return const [];
+    }
+  }
+
+  Widget _waitingButton(String label, AppColors? colors) {
+    final textSec = colors?.textSecondary ?? const Color(0xFFB0B3C6);
+    return Container(
+      height: 56,
+      decoration: BoxDecoration(
+        color: colors?.backgroundCard ?? const Color(0xFF1E2230),
+        borderRadius: BorderRadius.circular(AppRadius.card),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          SizedBox(
+            width: 16,
+            height: 16,
+            child: CircularProgressIndicator(strokeWidth: 2, color: textSec),
+          ),
+          const SizedBox(width: AppSpacing.md),
+          Text(
+            label,
+            style: TextStyle(
+              color: textSec,
+              fontSize: 15,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ── Step timeline ────────────────────────────────────────────────────────
+
+  Widget _buildTimeline(
+    ThemeData theme,
+    AppColors? colors,
+    bool isBuyer,
+    TradeStatus status,
+  ) {
+    final cardBg = colors?.backgroundCard ?? const Color(0xFF1E2230);
+    final elevated = colors?.backgroundElevated ?? const Color(0xFF2A2D35);
+    final green = colors?.mostroGreen ?? const Color(0xFF8CC63F);
+    final amber = colors?.warningAmber ?? const Color(0xFFE89C3C);
+    final textSec = colors?.textSecondary ?? const Color(0xFFB0B3C6);
+    final textSubtle = colors?.textSubtle ?? const Color(0xFF9A9A9C);
+
+    final steps = _steps(isBuyer);
+    final current = _currentStep(status);
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(AppSpacing.lg),
+      decoration: BoxDecoration(
+        color: cardBg,
+        borderRadius: BorderRadius.circular(AppRadius.card),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'YOUR TRADE',
+            style: TextStyle(
+              color: textSubtle,
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+              letterSpacing: 1,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.md),
+          for (var i = 0; i < steps.length; i++) ...[
+            if (i > 0) const SizedBox(height: AppSpacing.md),
+            Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(
-                  isBuyer
-                      ? 'You are buying sats'
-                      : 'You are selling sats',
-                  style: theme.textTheme.headlineSmall,
-                ),
-                if (order != null) ...[
-                  const SizedBox(height: AppSpacing.xs),
-                  Text(
-                    '${order.displayAmount} ${order.fiatCode}',
-                    style: TextStyle(color: green, fontSize: 14, fontWeight: FontWeight.w600),
+                Container(
+                  width: 22,
+                  height: 22,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: i < current
+                        ? green
+                        : i == current
+                            ? amber
+                            : elevated,
                   ),
-                ],
-                const SizedBox(height: AppSpacing.xs),
-                Text(
-                  'Order ${widget.orderId}',
-                  style: TextStyle(color: textSec, fontSize: 12),
+                  alignment: Alignment.center,
+                  child: i < current
+                      ? const Icon(Icons.check, size: 14, color: Colors.black)
+                      : i == current
+                          ? Container(
+                              width: 8,
+                              height: 8,
+                              decoration: const BoxDecoration(
+                                shape: BoxShape.circle,
+                                color: Colors.black,
+                              ),
+                            )
+                          : null,
                 ),
-              ],
-            ),
-          ),
-          const SizedBox(height: AppSpacing.sm),
-
-          // Card 2: Payment method
-          TradeInfoCard(
-            child: Row(
-              children: [
-                Icon(Icons.payment_outlined, size: 18, color: textSec),
-                const SizedBox(width: AppSpacing.sm),
-                Text(order?.paymentMethod ?? '—', style: theme.textTheme.bodyMedium),
-              ],
-            ),
-          ),
-          const SizedBox(height: AppSpacing.sm),
-
-          // Card 3: Creation date
-          TradeInfoCard(
-            child: Row(
-              children: [
-                Icon(Icons.calendar_today_outlined, size: 18, color: textSec),
-                const SizedBox(width: AppSpacing.sm),
-                Text(
-                  order != null ? _formatDate(order.createdAt) : '—',
-                  style: theme.textTheme.bodyMedium,
-                ),
-              ],
-            ),
-          ),
-          const SizedBox(height: AppSpacing.sm),
-
-          // Card 4: Order ID
-          OrderIdCard(orderId: widget.orderId),
-          const SizedBox(height: AppSpacing.sm),
-
-          // Card 5: Instructions + status
-          InstructionsCard(
-            text: _getInstructionText(isBuyer, status),
-            statusLabel: status.label,
-          ),
-          const SizedBox(height: AppSpacing.xl),
-
-          // Countdown
-          if (_remaining > Duration.zero) ...[
-            Center(
-              child: Column(
-                children: [
-                  SizedBox(
-                    width: 80,
-                    height: 80,
-                    child: CircularProgressIndicator(
-                      value: _totalCountdownSeconds > 0
-                          ? (_remaining.inSeconds / _totalCountdownSeconds)
-                              .clamp(0.0, 1.0)
-                          : 1.0,
-                      strokeWidth: 4,
-                      color: _remaining.inMinutes < 5
-                          ? colors?.destructiveRed ?? const Color(0xFFD84D4D)
-                          : green,
-                      backgroundColor:
-                          colors?.backgroundInput ?? const Color(0xFF252A3A),
-                    ),
-                  ),
-                  const SizedBox(height: AppSpacing.sm),
-                  Text(
-                    'Time remaining: ${_formatDuration(_remaining)}',
-                    style: TextStyle(color: textSec, fontSize: 13),
-                  ),
-                ],
-              ),
-            ),
-            const SizedBox(height: AppSpacing.xl),
-          ],
-
-          // ── Pending — CANCEL button (maker can cancel before taken) ──
-          if (status == TradeStatus.pending) ...[
-            OutlinedButton.icon(
-              onPressed: _cancelOrder,
-              icon: const Icon(Icons.cancel_outlined, size: 16),
-              label: const Text('CANCEL'),
-              style: OutlinedButton.styleFrom(
-                foregroundColor: colors?.destructiveRed ?? const Color(0xFFD84D4D),
-                side: BorderSide(color: colors?.destructiveRed ?? const Color(0xFFD84D4D)),
-                minimumSize: const Size.fromHeight(40),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(AppRadius.button),
-                ),
-              ),
-            ),
-          ],
-
-          // ── Buyer: Waiting Invoice — ADD INVOICE button ────────
-          if (isBuyer && status == TradeStatus.waitingInvoice) ...[
-            FilledButton.icon(
-              onPressed: () =>
-                  context.push(AppRoute.addInvoicePath(widget.orderId)),
-              icon: const Icon(Icons.receipt_long_outlined, size: 16),
-              label: const Text('ADD INVOICE'),
-              style: FilledButton.styleFrom(
-                backgroundColor: green,
-                foregroundColor: Colors.black,
-                minimumSize: const Size.fromHeight(40),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(AppRadius.button),
-                ),
-              ),
-            ),
-          ],
-
-          // ── Seller: Waiting Payment — PAY INVOICE button ───────
-          if (!isBuyer && status == TradeStatus.waitingPayment) ...[
-            FilledButton.icon(
-              onPressed: () =>
-                  context.push(AppRoute.payInvoicePath(widget.orderId)),
-              icon: const Icon(Icons.bolt, size: 16),
-              label: const Text('PAY INVOICE'),
-              style: FilledButton.styleFrom(
-                backgroundColor: green,
-                foregroundColor: Colors.black,
-                minimumSize: const Size.fromHeight(40),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(AppRadius.button),
-                ),
-              ),
-            ),
-          ],
-
-          // Action buttons (buyer flow — T060)
-          if (isBuyer && status == TradeStatus.active) ...[
-            MostroReactiveButton(
-              label: 'FIAT SENT',
-              backgroundColor: green,
-              icon: Icons.send,
-              onPressed: () async {
-                await orders_api.sendFiatSent(orderId: widget.orderId);
-              },
-              onError: (e) {
-                debugPrint('[TradeDetailScreen] sendFiatSent onError: $e');
-                if (!mounted) return;
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(content: Text(AppLocalizations.of(context).fiatSentFailed)),
-                );
-              },
-            ),
-            const SizedBox(height: AppSpacing.sm),
-            Row(
-              children: [
+                const SizedBox(width: AppSpacing.md),
                 Expanded(
-                  child: OutlinedButton.icon(
-                    onPressed: _cancelOrder,
-                    icon: const Icon(Icons.cancel_outlined, size: 16),
-                    label: const Text('CANCEL'),
-                    style: _destructiveOutlineStyle(
-                      colors?.destructiveRed ?? const Color(0xFFD84D4D),
-                    ),
-                  ),
-                ),
-                const SizedBox(width: AppSpacing.sm),
-                Expanded(
-                  child: OutlinedButton.icon(
-                    onPressed: _openDispute,
-                    icon: const Icon(Icons.gavel, size: 16),
-                    label: const Text('DISPUTE'),
-                    style: _destructiveOutlineStyle(
-                      colors?.destructiveRed ?? const Color(0xFFD84D4D),
-                    ),
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: AppSpacing.sm),
-            FilledButton.icon(
-              onPressed: () =>
-                  context.push(AppRoute.chatRoomPath(widget.orderId)),
-              icon: const Icon(Icons.chat_bubble_outline, size: 16),
-              label: const Text('CONTACT'),
-              style: FilledButton.styleFrom(
-                backgroundColor: green,
-                foregroundColor: Colors.black,
-                minimumSize: const Size.fromHeight(40),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(AppRadius.button),
-                ),
-              ),
-            ),
-          ],
-
-          // ── Seller: Active — CLOSE + CANCEL + DISPUTE + CONTACT ──
-          if (!isBuyer && status == TradeStatus.active) ...[
-            Row(
-              children: [
-                Expanded(
-                  child: OutlinedButton(
-                    onPressed: () => context.pop(),
-                    style: OutlinedButton.styleFrom(
-                      foregroundColor: green,
-                      side: BorderSide(color: green),
-                      minimumSize: const Size(0, 40),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(AppRadius.button),
-                      ),
-                    ),
-                    child: const Text('CLOSE'),
-                  ),
-                ),
-                const SizedBox(width: AppSpacing.sm),
-                Expanded(
-                  child: OutlinedButton.icon(
-                    onPressed: _cancelOrder,
-                    icon: const Icon(Icons.cancel_outlined, size: 16),
-                    label: const Text('CANCEL'),
-                    style: _destructiveOutlineStyle(
-                      colors?.destructiveRed ?? const Color(0xFFD84D4D),
-                    ),
-                  ),
-                ),
-                const SizedBox(width: AppSpacing.sm),
-                Expanded(
-                  child: OutlinedButton.icon(
-                    onPressed: _openDispute,
-                    icon: const Icon(Icons.gavel, size: 16),
-                    label: const Text('DISPUTE'),
-                    style: _destructiveOutlineStyle(
-                      colors?.destructiveRed ?? const Color(0xFFD84D4D),
-                    ),
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: AppSpacing.sm),
-            FilledButton.icon(
-              onPressed: () =>
-                  context.push(AppRoute.chatRoomPath(widget.orderId)),
-              icon: const Icon(Icons.chat_bubble_outline, size: 16),
-              label: const Text('CONTACT'),
-              style: FilledButton.styleFrom(
-                backgroundColor: green,
-                foregroundColor: Colors.black,
-                minimumSize: const Size.fromHeight(40),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(AppRadius.button),
-                ),
-              ),
-            ),
-          ],
-
-          // ── Disputed — CLOSE + CONTACT + CANCEL + RELEASE + VIEW DISPUTE ──
-          if (status == TradeStatus.disputed) ...[
-            Row(
-              children: [
-                Expanded(
-                  child: OutlinedButton(
-                    onPressed: () => context.pop(),
-                    style: OutlinedButton.styleFrom(
-                      foregroundColor: green,
-                      side: BorderSide(color: green),
-                      minimumSize: const Size(0, 40),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(AppRadius.button),
-                      ),
-                    ),
-                    child: const Text('CLOSE'),
-                  ),
-                ),
-                const SizedBox(width: AppSpacing.sm),
-                Expanded(
-                  child: OutlinedButton.icon(
-                    onPressed: () =>
-                        context.push(AppRoute.chatRoomPath(widget.orderId)),
-                    icon: const Icon(Icons.chat_bubble_outline, size: 16),
-                    label: const Text('CONTACT'),
-                    style: OutlinedButton.styleFrom(
-                      foregroundColor: green,
-                      side: BorderSide(color: green),
-                      minimumSize: const Size(0, 40),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(AppRadius.button),
+                  child: Padding(
+                    padding: const EdgeInsets.only(top: 2),
+                    child: Text(
+                      steps[i],
+                      style: TextStyle(
+                        fontSize: 13,
+                        height: 1.3,
+                        color: i <= current
+                            ? colors?.textPrimary ?? Colors.white
+                            : textSec,
+                        fontWeight:
+                            i == current ? FontWeight.w700 : FontWeight.w500,
                       ),
                     ),
                   ),
                 ),
               ],
-            ),
-            // CANCEL + RELEASE only available to the seller during a dispute.
-            if (!isBuyer) ...[
-            const SizedBox(height: AppSpacing.sm),
-            Row(
-              children: [
-                Expanded(
-                  child: OutlinedButton.icon(
-                    onPressed: _cancelOrder,
-                    icon: const Icon(Icons.cancel_outlined, size: 16),
-                    label: const Text('CANCEL'),
-                    style: _destructiveOutlineStyle(
-                      colors?.destructiveRed ?? const Color(0xFFD84D4D),
-                    ),
-                  ),
-                ),
-                const SizedBox(width: AppSpacing.sm),
-                Expanded(child: _buildReleaseButton(green)),
-              ],
-            ),
-            ], // end if (!isBuyer)
-            const SizedBox(height: AppSpacing.sm),
-            FilledButton.icon(
-              onPressed: () {
-                final dispute = ref.read(
-                  disputeByTradeIdProvider(widget.orderId),
-                );
-                if (dispute == null) {
-                  final l10n = AppLocalizations.of(context);
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      content: Text(l10n.disputeNotFoundForOrder),
-                      duration: const Duration(seconds: 2),
-                    ),
-                  );
-                  return;
-                }
-                context.push(AppRoute.disputeDetailsPath(dispute.id));
-              },
-              icon: const Icon(Icons.gavel, size: 16),
-              label: const Text('VIEW DISPUTE'),
-              style: FilledButton.styleFrom(
-                backgroundColor: colors?.destructiveRed ?? const Color(0xFFD84D4D),
-                foregroundColor: Colors.white,
-                minimumSize: const Size.fromHeight(40),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(AppRadius.button),
-                ),
-              ),
-            ),
-          ],
-
-          // ── Seller: Fiat Sent — CLOSE + RELEASE + CANCEL + DISPUTE + CONTACT ──
-          if (!isBuyer && status == TradeStatus.fiatSent) ...[
-            Row(
-              children: [
-                Expanded(
-                  child: OutlinedButton(
-                    onPressed: () => context.pop(),
-                    style: OutlinedButton.styleFrom(
-                      foregroundColor: green,
-                      side: BorderSide(color: green),
-                      minimumSize: const Size(0, 40),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(AppRadius.button),
-                      ),
-                    ),
-                    child: const Text('CLOSE'),
-                  ),
-                ),
-                const SizedBox(width: AppSpacing.sm),
-                Expanded(child: _buildReleaseButton(green)),
-              ],
-            ),
-            const SizedBox(height: AppSpacing.sm),
-            Row(
-              children: [
-                Expanded(
-                  child: OutlinedButton.icon(
-                    onPressed: _cancelOrder,
-                    icon: const Icon(Icons.cancel_outlined, size: 16),
-                    label: const Text('CANCEL'),
-                    style: _destructiveOutlineStyle(
-                      colors?.destructiveRed ?? const Color(0xFFD84D4D),
-                    ),
-                  ),
-                ),
-                const SizedBox(width: AppSpacing.sm),
-                Expanded(
-                  child: OutlinedButton.icon(
-                    onPressed: _openDispute,
-                    icon: const Icon(Icons.gavel, size: 16),
-                    label: const Text('DISPUTE'),
-                    style: _destructiveOutlineStyle(
-                      colors?.destructiveRed ?? const Color(0xFFD84D4D),
-                    ),
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: AppSpacing.sm),
-            FilledButton.icon(
-              onPressed: () =>
-                  context.push(AppRoute.chatRoomPath(widget.orderId)),
-              icon: const Icon(Icons.chat_bubble_outline, size: 16),
-              label: const Text('CONTACT'),
-              style: FilledButton.styleFrom(
-                backgroundColor: green,
-                foregroundColor: Colors.black,
-                minimumSize: const Size.fromHeight(40),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(AppRadius.button),
-                ),
-              ),
-            ),
-          ],
-
-          // ── Pending rating — RATE + CLOSE ─────────────────────────────
-          if (status == TradeStatus.pendingRating) ...[
-            FilledButton.icon(
-              onPressed: () {
-                if (ref.read(privacyModeProvider)) {
-                  context.go(AppRoute.home);
-                } else {
-                  context.push(AppRoute.rateUserPath(widget.orderId));
-                }
-              },
-              icon: const Icon(Icons.star_outline, size: 16),
-              label: const Text('RATE'),
-              style: FilledButton.styleFrom(
-                backgroundColor: green,
-                foregroundColor: Colors.black,
-                minimumSize: const Size.fromHeight(40),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(AppRadius.button),
-                ),
-              ),
-            ),
-            const SizedBox(height: AppSpacing.sm),
-            OutlinedButton(
-              onPressed: () => context.pop(),
-              style: OutlinedButton.styleFrom(
-                foregroundColor: green,
-                side: BorderSide(color: green),
-                minimumSize: const Size.fromHeight(40),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(AppRadius.button),
-                ),
-              ),
-              child: const Text('CLOSE'),
-            ),
-          ],
-
-          // ── Rated — CLOSE only (no further actions) ───────────────────
-          if (status == TradeStatus.rated) ...[
-            OutlinedButton(
-              onPressed: () => context.pop(),
-              style: OutlinedButton.styleFrom(
-                foregroundColor: green,
-                side: BorderSide(color: green),
-                minimumSize: const Size.fromHeight(40),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(AppRadius.button),
-                ),
-              ),
-              child: const Text('CLOSE'),
             ),
           ],
         ],
+      ),
+    );
+  }
+}
+
+// ── Small shared widgets ──────────────────────────────────────────────────────
+
+class _Pill extends StatelessWidget {
+  const _Pill({
+    required this.label,
+    required this.background,
+    required this.foreground,
+  });
+
+  final String label;
+  final Color background;
+  final Color foreground;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.sm,
+        vertical: 3,
+      ),
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(AppRadius.chip),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: foreground,
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0.3,
+        ),
+      ),
+    );
+  }
+}
+
+/// Persistent chat chip: counterpart handle + unread badge, navigates to the
+/// trade chat. Replaces the old ghost CONTACT button at the bottom.
+class _ChatChip extends ConsumerWidget {
+  const _ChatChip({required this.orderId});
+
+  final String orderId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = Theme.of(context).extension<AppColors>();
+    final purple = colors?.purpleButton ?? const Color(0xFF8359C2);
+    final textSec = colors?.textSecondary ?? const Color(0xFFB0B3C6);
+
+    final rooms = ref.watch(chatRoomsNotifierProvider);
+    final room = rooms.where((r) => r.orderId == orderId).firstOrNull;
+
+    final handle = room?.peerHandle ?? 'your counterpart';
+    final unread = room?.unreadCount ?? 0;
+
+    return InkWell(
+      onTap: () => context.push(AppRoute.chatRoomPath(orderId)),
+      borderRadius: BorderRadius.circular(AppRadius.card),
+      child: Container(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.md,
+          vertical: AppSpacing.sm + 2,
+        ),
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            colors: [
+              purple.withValues(alpha: 0.20),
+              purple.withValues(alpha: 0.07),
+            ],
+          ),
+          border: Border.all(color: purple.withValues(alpha: 0.27)),
+          borderRadius: BorderRadius.circular(AppRadius.card),
+        ),
+        child: Row(
+          children: [
+            if (room != null)
+              NymAvatar(
+                iconIndex: room.peerIconIndex,
+                colorHue: room.peerColorHue,
+                size: 36,
+              )
+            else
+              CircleAvatar(
+                radius: 18,
+                backgroundColor: purple.withValues(alpha: 0.3),
+                child:
+                    Icon(Icons.chat_bubble_outline, size: 18, color: purple),
+              ),
+            const SizedBox(width: AppSpacing.md),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    handle,
+                    style: const TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  Text(
+                    unread > 0
+                        ? 'Secure chat · $unread new'
+                        : 'Secure chat · end-to-end encrypted',
+                    style: TextStyle(fontSize: 11, color: textSec),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+              ),
+            ),
+            if (unread > 0) ...[
+              Container(
+                width: 22,
+                height: 22,
+                alignment: Alignment.center,
+                decoration:
+                    BoxDecoration(shape: BoxShape.circle, color: purple),
+                child: Text(
+                  '$unread',
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+              const SizedBox(width: AppSpacing.xs),
+            ],
+            Icon(Icons.chevron_right, color: purple),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary

Implements the UX redesign proposals from the Claude Design handoff bundle (*Mostro UX Redesign EN*) onto the existing screens. The bundle's design doc prioritized proposals #1, #4 and #5; proposals #2 (first-trade onboarding) and #9 (ephemeral identity explainer) were not mocked in the canvas and are intentionally out of scope.

### Per proposal

- **#1 Explicit next action** — `trade_detail_screen.dart` rebuilt: one large state-dependent primary CTA (Add invoice / Pay hold invoice / Mark fiat sent / Confirm & release / Rate), waiting-on-counterpart states render a disabled spinner button, Cancel / Dispute / Release collapsed behind the app-bar ⋮ overflow menu, step timeline card, and a persistent chat chip (counterpart handle + unread badge) replacing the ghost CONTACT button.
- **#5 Timer with context** — trade detail and take-order timers now label *what* expires and the consequence ("If it expires, the order is removed from the book. It won't affect your reputation."), with lime → amber (<10%) → red (<2%) color thresholds.
- **#3 Order book reasons** — deterministic differentiator pills (⚡ Best premium / ⭐ Most reputable / 🆕 Just published), each awarded to a single winner per visible book; color-coded premium pill; 5-star row replaced by numeric reputation (`★ 4.9 · 47 trades · 312 days`).
- **#6 Chat sticky trade state** — pinned header below the chat app bar: status pill, buying/selling sats, fiat amount, payment method, live countdown, "View order ↗".
- **#8 Grouped notifications** — collapsible per-trade groups with latest event, expandable history, unread badges, "Go to trade →"; backup reminder restyled as an amber system banner; filter chips All / Disputes / System (Active/Completed not derivable from the stored model — skipped rather than shipping dead UI).
- **#4 Backup ritual** — trigger bottom sheet ("Back up now" / "Remind me tomorrow" with persisted 24 h snooze), full-screen 12-word grid with paper warning, 3-random-word verification with decoys from the same mnemonic, persisted backed-up flag + "Backed up" chip on the account screen. Words live only in screen state and are nulled on dispose.
- **#7 Create-order presets** — Express (prefilled from the last successful trade, hidden when none exists), Conservative, Custom cards above the form + live preview footer. Sats estimate only for fixed-price orders (no exchange-rate source exists in the codebase).

### Theme

New `warningAmber` token in `AppColors`; everything else uses existing tokens. No new dependencies, no `.arb` changes (new strings follow each file's existing hardcoded-English pattern).

## Test plan

- [x] `flutter analyze` — clean (3 remaining infos are pre-existing in untouched files)
- [x] `flutter test` — passes
- [ ] Manual walkthrough of an end-to-end trade on a test node (book → take → invoice → fiat sent → release → rate)
- [ ] Verify backup ritual on a fresh profile (trigger sheet → words → verification → badge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-step backup ritual to verify and confirm account backup security
  * Backup reminders with "Remind me tomorrow" snooze functionality
  * "Reason to pick" badges highlight best premium, most reputable, and newly published orders
  * Order preset selector for quick setup with Express, Conservative, and Custom options
  * Grouped and filterable notifications organized by trade or dispute
  * Trade status header now visible in chat conversations

* **Refactor**
  * Enhanced notification screen with improved layout and filtering capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->