### PR TITLE
docs: sync v1-reference (multi-mostro, disputes, relay sync)

### DIFF
--- a/.specify/v1-reference/DISPUTE_SYSTEM.md
+++ b/.specify/v1-reference/DISPUTE_SYSTEM.md
@@ -171,6 +171,15 @@ Four independent status systems coexist during a dispute. Confusing them causes 
 - Historic events are stored in Sembast with `type: 'dispute_chat'` and `dispute_id: <id>`. Each record keeps the full gift wrap payload (`kind`, `content`, `tags`, etc.).
 - `_loadHistoricalMessages()` filters by `type` + `dispute_id`, unwraps each gift wrap with `session.adminSharedKey`, converts to `DisputeChatMessage`, deduplicates by inner event ID, and sorts ascending.
 
+> **Pending in v2 — not yet implemented.** v1 re-establishes dispute chats after an
+> account restore from mnemonic: the recovery flow repopulates the session's `adminPubkey`
+> + `disputeId` and re-subscribes so dispute chats are accessible immediately. v2's account
+> restore is still a stub (`import_from_mnemonic(recover)` ignores the flag), so dispute-chat
+> restoration is not built yet. This belongs with the broader restore/recovery feature; the
+> v1 reference for the restore protocol flow is `DISPUTE_CHAT_RESTORE.md` in the v1 repo
+> (not mirrored here — it is largely a v1 bug tracker, including a dart_nostr-specific
+> isolated-subscription workaround that v2 should avoid).
+
 ### Live subscription
 - `_subscribe()` builds a `NostrRequest` for kind `1059` events where the `p` tag matches `session.adminSharedKey.public`.
 - `NostrService.subscribeToEvents()` feeds `_onChatEvent`:

--- a/.specify/v1-reference/MULTI_MOSTRO_SUPPORT.md
+++ b/.specify/v1-reference/MULTI_MOSTRO_SUPPORT.md
@@ -1,0 +1,385 @@
+# Multi-Mostro Instance Support
+
+> **v1 Reference.** Consolidates three v1 docs into a single reference for the v2
+> migration: `MULTI_MOSTRO_SUPPORT.md` (node registry + selector), `COMMUNITY_DISCOVERY.md`
+> (first-launch community selector), and `DEEP_LINK_MOSTRO_SWITCH.md` (switch via deep link).
+> Reorganized by topic; v1 development-process detail (phase status, "files created"
+> lists, test-count tables, full localization-key inventories) is omitted.
+
+## Overview
+
+Multi-Mostro support lets a single app installation connect to multiple Mostro
+instances (nodes). Users switch between **trusted** (hardcoded) and **custom**
+(user-added) nodes, each with its own order book and trading sessions.
+
+A "community" and a "Mostro node" are the **same entity** seen two ways: the node
+registry tracks the pubkey and connection concerns, while the community view adds
+rich metadata (region, avatar, description, accepted currencies, fee, sats range,
+social links) fetched from Nostr. In v1 this is made explicit by deriving the node
+registry from the community config (see [Trusted Communities](#trusted-communities)).
+
+There are three entry points for choosing/switching the active node:
+1. **First-launch community selector** (onboarding, after the walkthrough).
+2. **Settings node selector** (Mostro card → bottom sheet).
+3. **Deep link** carrying `mostro=<pubkey>` (confirmation dialog, then switch).
+
+All three converge on the same mutation: `SettingsNotifier.updateMostroInstance()`.
+
+## Core Architecture
+
+### Single Source of Truth
+
+`Settings.mostroPublicKey` is the single source of truth for which node is active.
+All downstream systems (relay sync, subscriptions, order management) react to changes
+in this field via Riverpod. The node registry and selectors only ever **write** to it
+through `updateMostroInstance()`.
+
+### Node Registry
+
+The app maintains a registry of known nodes, each identified by its Nostr hex pubkey:
+
+- **Trusted nodes**: hardcoded in `Config.trustedMostroNodes`, cannot be removed.
+- **Custom nodes**: added by users, persisted in SharedPreferences, can be removed.
+
+### Data Flow
+
+```text
+Config.trustedMostroNodes ──┐
+                             ├──▶ MostroNodesNotifier ──▶ UI (Node / Community Selector)
+SharedPreferences (custom) ──┘           │
+                                         │ selectNode()
+                                         ▼
+                               SettingsNotifier.updateMostroInstance()
+                                         │
+                                         ▼
+                               Settings.mostroPublicKey changes
+                                         │
+                              ┌──────────┼──────────┐
+                              ▼          ▼          ▼
+                         RelaysNotifier  NostrService  SubscriptionManager
+                         (relay sync)   (reconnect)    (resubscribe)
+```
+
+### Relay Management Per Node
+
+Relay lists are **not** stored per-node. Relay state is always derived from the
+currently active node:
+
+- When the active node changes via `updateMostroInstance()`, blacklisted relays and
+  user relays are reset (avoids cross-instance bleed).
+- `RelaysNotifier` subscribes to the active node's kind 10002 events and syncs the
+  relay list in real time (see [RELAY_SYNC_IMPLEMENTATION.md](./RELAY_SYNC_IMPLEMENTATION.md)).
+- Default relays from `Config.nostrRelays` serve as a fallback for any node.
+
+## Trusted Communities
+
+Mirrored from [mostro.community](https://github.com/MostroP2P/community), defined in
+`lib/core/config/communities.dart`:
+
+| Region | Pubkey (truncated) | Social |
+|--------|-------------------|--------|
+| Cuba | `00000235a3e9...1366a` | [Telegram](https://t.me/Cuba_Bitcoin), [Website](https://cubabitcoin.org/kmbalache/) |
+| Spain | `0000cc02101e...36b40` | [Telegram](https://t.me/nostromostro) |
+| Colombia | `00000978acc5...8441b` | [Telegram](https://t.me/ColombiaP2P), [X](https://x.com/ColombiaP2P) |
+| Bolivia | `00007cb3305f...3f91` | [Telegram](https://t.me/btcxbolivia), [X](https://x.com/btcxbolivia), [Instagram](https://www.instagram.com/btcxbolivia) |
+| Default | `82fa8cb978b4...8390` | (fallback when user skips) |
+
+**Single source of truth:** `Config.trustedMostroNodes` is **derived from**
+`trustedCommunities` at runtime, eliminating duplication between the node system and
+the community config. `MostroNodesNotifier` initializes from this list, so all
+communities also appear as trusted nodes in the Settings node selector.
+
+## Metadata Fetching
+
+Two metadata layers enrich each node:
+
+- **Kind 0** (Nostr profile): name, about, picture.
+- **Kind 38385** (Mostro trade info): accepted currencies, fee, min/max order amount.
+
+### Sources
+
+There are two fetch paths in v1:
+
+- **`MostroNodesNotifier.fetchAllNodeMetadata()` / `fetchNodeMetadata()`** — used by
+  the Settings node selector. Fetches kind 0 only, via the app's `NostrService`
+  (`fetchEvents(filter)` one-shot with timeout). Triggered fire-and-forget after
+  `init()` via `unawaited()`, so it never blocks startup.
+- **`CommunityRepository.fetchCommunityMetadata(pubkeys)`** — used by the first-launch
+  community selector. Fetches kind 0 **and** kind 38385, via a standalone `dart:io`
+  WebSocket independent of `NostrService` (so it works before full app init).
+  Connection: `wss://relay.mostro.network`; timeout 10s; partial data is acceptable.
+
+### Subscriptions (CommunityRepository)
+
+Two concurrent REQ messages on a single WebSocket; waits for both EOSE (or timeout),
+then closes:
+
+```json
+["REQ", "<subId>", {"kinds": [0], "authors": ["<pubkey1>", "<pubkey2>", ...]}]
+["REQ", "<subId>", {"kinds": [38385], "authors": ["<pubkey1>", ...], "#y": ["mostro"]}]
+```
+
+### Extracted Fields
+
+| Kind | Field / Tag | Usage |
+|------|-------------|-------|
+| 0 | `name` | Display name (fallback: region from config) |
+| 0 | `about` | Description text on card |
+| 0 | `picture` | Avatar (HTTPS only, `NymAvatar` fallback) |
+| 38385 | `fiat_currencies_accepted` | Comma-separated currency codes shown as tags |
+| 38385 | `fee` | Trading fee percentage |
+| 38385 | `min_order_amount` | Minimum order in sats |
+| 38385 | `max_order_amount` | Maximum order in sats |
+
+### Validation & Resilience
+
+- **Deduplication**: for each kind, keep only the event with the highest `created_at`
+  per pubkey (handles multiple relays returning the same event). `limit: 1` is a relay
+  hint, not a guarantee, so single-node fetch deduplicates too.
+- **Signature verification**: `event.isVerified()` is checked before applying metadata;
+  forged events with invalid signatures are logged and skipped.
+- **URL sanitization**: `picture` and `website` accept only `https://` URLs;
+  `javascript:`, `http://`, `data:`, etc. are rejected (set to `null`).
+- **Mounted guard**: fetch methods check `mounted` after the async gap.
+- **All errors caught and logged**, never propagated; malformed/missing metadata skipped.
+
+### "All Currencies" Logic
+
+When a kind 38385 event exists (`hasTradeInfo = true`) but `fiat_currencies_accepted`
+is empty/absent, the card shows a localized **"All currencies"** tag, mirroring
+[mostro.community](https://mostro.community).
+
+## Entry Point 1: First-Launch Community Selector
+
+New users choose a community on first launch, before reaching home. Existing users are
+never interrupted — the selector is shown only once after the walkthrough.
+
+### User Flow
+
+```text
+New user:       App install ─▶ Walkthrough (complete or skip) ─▶ Community Selector ─▶ Home
+Existing user:  App launch   ─▶ Home (auto-migrated, no interruption)
+Return later:   Home ─▶ Settings ─▶ Mostro Card ─▶ Node Selector (Entry Point 2)
+```
+
+### GoRouter Redirect Chain
+
+In `lib/core/app_routes.dart`, the redirect evaluates two providers in order:
+
+```text
+1. firstRunProvider:
+   - loading / isFirstRun=true  -> redirect to /walkthrough
+   - isFirstRun=false           -> proceed to step 2
+
+2. communitySelectedProvider:
+   - loading        -> no redirect (wait; router refreshes on change)
+   - data(false)    -> redirect to /community_selector
+   - data(true)     -> proceed to requested route
+   - error          -> no redirect (don't block on errors)
+```
+
+`WalkthroughScreen._onIntroEnd()` navigates to `/community_selector` instead of `/`;
+the redirect handles the rest.
+
+### Screen Layout
+
+```text
++-----------------------------+
+|  bolt  Choose your community |  <- Title with bolt icon
+|  [search] Search...          |  <- Filters by name, region, currency, about
+|                               |
+|  +-------------------------+  |
+|  | Avatar  Name      check |  |  <- CommunityCard (selected state)
+|  | Region                   |  |
+|  | Description text...      |  |
+|  | [USD] [EUR] [CUP]       |  |  <- Currency tags (or "All currencies")
+|  | % Fee 1.0%  | Range ... |  |  <- Fee and sats range
+|  | tg  x  ig               |  |  <- Social link icons
+|  +-------------------------+  |
+|  [more cards...]              |
+|                               |
+|  gear  Use a custom node      |  <- Opens AddCustomNodeDialog
+|  [========= Done =========]  |  <- Confirm (visible after selection)
+|       Skip for now            |  <- Uses defaultMostroPubkey
++-----------------------------+
+```
+
+### States
+
+| State | Behavior |
+|-------|----------|
+| Loading | Skeleton placeholders (same count as `trustedCommunities`) |
+| Error | Cloud-off icon + message + retry (invalidates `communityListProvider`) |
+| Data (empty search) | "No communities found" |
+| Data | Scrollable list of `CommunityCard` widgets |
+| Selecting | Spinner on confirm button, interactions disabled |
+
+### Selection Flow
+
+```dart
+_selectAndProceed(pubkey):
+  1. _ensureNodeExists(pubkey)    // Add as custom node if unknown (awaited)
+  2. nodesNotifier.selectNode()   // -> settingsNotifier.updateMostroInstance()
+  3. markCommunitySelected()      // Persist to SharedPreferences
+  4. context.go('/')              // Navigate home (if still mounted)
+```
+
+- **Skip**: same as confirm but uses `defaultMostroPubkey`.
+- **Use custom node**: opens `AddCustomNodeDialog`; if a node was added (detected via
+  set-diff on pubkeys), auto-selects it and proceeds.
+
+### CommunityCard
+
+`StatelessWidget` with conditional sections: header (avatar + name + region + check),
+about (3 lines, ellipsis), currency tags (or "All currencies"), stats (fee % + sats
+range formatted K/M), social icons (Telegram, X, Instagram, …). `AnimatedContainer`
+(200ms) for selection state; selected = green border + tint + check icon. Uses
+`AppTheme` constants.
+
+### Auto-Migration (existing users)
+
+`CommunitySelectedNotifier._init()`:
+
+1. If `communitySelected` is already `true` -> done.
+2. Else if `firstRunComplete` is `true` (user onboarded before this feature existed)
+   -> auto-set `communitySelected = true`, skip the selector.
+3. Else -> `false` (new user, show selector).
+
+## Entry Point 2: Settings Node Selector
+
+From the Settings **Mostro** card (see [SETTINGS_SCREEN.md](./SETTINGS_SCREEN.md)),
+tapping opens `MostroNodeSelector.show(context)` — a bottom sheet listing trusted and
+custom nodes.
+
+- Each item: avatar (kind 0 picture or `NymAvatar` fallback), display name, truncated
+  pubkey, trusted badge, checkmark for the active node, delete for custom nodes.
+- **Add Custom Node** button opens `AddCustomNodeDialog`: accepts hex (64 chars) or
+  `npub1…` (auto-converted via `NostrUtils.decodeBech32()`), optional name, inline
+  duplicate + format validation. Fire-and-forget metadata fetch after a successful add.
+- **`_isSwitching` flag** disables all items + the add button during a switch; the sheet
+  closes on completion. Switching triggers session restore (consistent with the prior
+  text-field behavior).
+- **Cannot delete the active node** (shows a SnackBar); custom-node deletion uses a
+  confirmation dialog (consistent with relay deletion).
+
+## Entry Point 3: Deep-Link Instance Switch
+
+When a deep link carries a `mostro=<pubkey>` identifying a different instance than the
+current one, the app confirms before switching.
+
+### Format
+
+```text
+mostro:<order-id>?relays=<relay1>,<relay2>&mostro=<mostro_pubkey>
+```
+
+The `mostro` parameter is optional (backward compatible). When absent, the order is
+assumed to belong to the currently selected instance.
+
+### Flow
+
+1. App receives the `mostro:` deep link.
+2. `parseMostroUrl` (`nostr_utils.dart`) extracts `orderId`, `relays`, optional `mostroPubkey`.
+3. `DeepLinkHandler` compares `mostroPubkey` with `settings.mostroPublicKey`.
+4. Same (or absent) -> navigate directly to the order (existing behavior).
+5. Different -> show confirmation dialog.
+6. Confirm -> `updateMostroInstance(newPubkey)` then navigate.
+7. Cancel -> do nothing.
+
+## Model Reference
+
+### MostroNode
+
+```dart
+class MostroNode {
+  final String pubkey;       // Nostr hex public key (node identity)
+  String? name;              // From kind 0 or user-provided
+  String? picture;           // From kind 0 metadata
+  String? website;           // From kind 0 metadata
+  String? about;             // From kind 0 metadata
+  final bool isTrusted;      // true = hardcoded, false = custom
+  final DateTime? addedAt;   // null for trusted, timestamp for custom
+}
+```
+
+Equality is based on `pubkey` only. `withMetadata()` supports a `MostroNode.clear`
+sentinel to explicitly null a field, while omitting a field preserves the existing value.
+
+### MostroNodesNotifier API
+
+```dart
+// Lifecycle
+Future<void> init();                                        // Load trusted + custom; auto-import unrecognized active pubkey
+
+// Selection
+MostroNode? get selectedNode;                               // Active node from settings
+Future<void> selectNode(String pubkey);                     // Switch active node via SettingsNotifier
+
+// CRUD (custom nodes only)
+Future<bool> addCustomNode(String pubkey, {String? name});  // Validate (64-hex, no duplicates)
+Future<bool> removeCustomNode(String pubkey);               // Remove non-active, non-trusted node
+Future<bool> updateCustomNodeName(String pubkey, String newName);
+
+// Metadata (persisted for both custom and trusted nodes)
+void updateNodeMetadata(String pubkey, {String? name, ...});
+Future<void> fetchAllNodeMetadata();                        // Batch kind 0 (dedup, verify, sanitize)
+Future<void> fetchNodeMetadata(String pubkey);              // Single-node kind 0
+
+// Queries
+bool isTrustedNode(String pubkey);
+List<MostroNode> get trustedNodes;
+List<MostroNode> get customNodes;
+```
+
+All write operations return `false` on persistence failure **without** updating
+in-memory state (persist-before-state pattern → memory never diverges from disk).
+
+### Storage
+
+| Data | Location | Key |
+|------|----------|-----|
+| Trusted nodes | `Config.trustedMostroNodes` (hardcoded, derived from communities) | N/A |
+| Custom nodes | SharedPreferences | `mostro_custom_nodes` |
+| Active node | Settings (SharedPreferences) | `mostroPublicKey` |
+| Trusted node metadata | SharedPreferences | `trusted_node_metadata` |
+| Custom node metadata | within custom nodes JSON | `mostro_custom_nodes` |
+| Community selected (onboarding) | SharedPreferences | `community_selected` |
+
+## Error Handling Strategy
+
+The notifier is **resilient** — persistence failures are logged but never crash the app:
+
+| Method | On error | Behavior |
+|--------|----------|----------|
+| `_loadCustomNodes()` | Returns `[]` | Degrade to trusted-only nodes |
+| `_saveCustomNodes()` | Returns `false` | Callers check result before updating state |
+| `addCustomNode()` | Returns `false` | Node not added to memory if disk save fails |
+| `removeCustomNode()` | Returns `false` | Node stays in memory if disk save fails |
+| `updateCustomNodeName()` | Returns `false` | Name unchanged if disk save fails |
+| `init()` auto-import save | Ignored | Imported node lives for the session, won't persist |
+
+## Backward Compatibility
+
+1. **Existing users**: a saved `mostroPublicKey` keeps working. If it matches a trusted
+   node it's recognized; if it's a valid 64-char hex not matching any trusted node it's
+   auto-imported as a custom node; malformed pubkeys are silently skipped.
+2. **Environment variable**: `MOSTRO_PUB_KEY` override still works via `Config.mostroPubKey`.
+3. **No migration needed**: the system is additive — no existing data is modified/removed.
+4. **Settings model unchanged**: `Settings.mostroPublicKey` stays the single source of truth.
+5. **Community auto-migration**: users who upgrade from a version without community
+   discovery are never shown the first-launch selector (see
+   [Auto-Migration](#auto-migration-existing-users)).
+
+## Implementation Note: Subscription Idempotency
+
+`MostroService.init()` cancels its existing orders subscription
+(`_ordersSubscription?.cancel()`) at the start, to prevent subscription leaks when
+re-invoked from `LifecycleManager.onResumed()`. Relevant to v2: any re-entrant
+init/resume path on the relay/subscription layer must be idempotent.
+
+## Out of Scope (v1)
+
+- Decentralized community discovery via a dedicated NIP.
+- Real-time updates when a community changes its kind 38385.
+- User-created communities (curated list only).
+- A dedicated Settings community section (reuses the existing Mostro node selector).

--- a/.specify/v1-reference/NAVIGATION_ROUTES.md
+++ b/.specify/v1-reference/NAVIGATION_ROUTES.md
@@ -57,6 +57,10 @@ MostroApp
 | `/settings` | `SettingsScreen` | `settings_screen.dart` | General settings |
 | `/about` | `AboutScreen` | `about_screen.dart` | About the app |
 | `/walkthrough` | `WalkthroughScreen` | `walkthrough_screen.dart` | Initial tutorial |
+
+> **Pending in v2 — not yet implemented.** v1 adds a `/community_selector` route and a
+> second redirect stage (firstRun → communitySelected → home). Neither is present in v2 yet.
+> Target behavior: [MULTI_MOSTRO_SUPPORT.md](./MULTI_MOSTRO_SUPPORT.md#entry-point-1-first-launch-community-selector).
 | `/add_order` | `AddOrderScreen` | `add_order_screen.dart` | Create order (see `.specify/v1-reference/ORDER_CREATION.md`) |
 | `/rate_user/:orderId` | `RateCounterpartScreen` | `rate_counterpart_screen.dart` | Rate counterpart |
 | `/take_sell/:orderId` | `TakeOrderScreen` | `take_order_screen.dart` | Take sell order (see `.specify/v1-reference/TAKE_ORDER.md`) |

--- a/.specify/v1-reference/NOTIFICATIONS_SYSTEM.md
+++ b/.specify/v1-reference/NOTIFICATIONS_SYSTEM.md
@@ -34,6 +34,18 @@ static NotificationType getNotificationTypeFromAction(Action action) {
 }
 ```
 
+**Context-aware cancellation messages:** `Action.canceled` maps to a different message
+depending on the order's `previousStatus` and whether the local user initiated the cancel:
+
+- `waiting-payment` → "seller inactivity" message (`notification_order_canceled_by_seller_inactivity_message`)
+- `waiting-buyer-invoice` → "buyer inactivity" message (`notification_order_canceled_by_buyer_inactivity_message`)
+- user-initiated cancel (`wasUserInitiatedCancel = true`) → generic message that does **not**
+  blame the counterparty.
+
+The `previousStatus` / `wasUserInitiatedCancel` flags are threaded from `OrderNotifier` through
+`extractFromMostroMessage()` so the same `canceled` action produces the correct reason. All
+cancellations are persisted to history (previously some were dropped on an early return).
+
 ### 2. Services Layer
 
 #### PushNotificationService (`lib/services/push_notification_service.dart`)

--- a/.specify/v1-reference/ORDER_BOOK.md
+++ b/.specify/v1-reference/ORDER_BOOK.md
@@ -61,6 +61,7 @@ final currencyFilterProvider = StateProvider<List<String>>((ref) => []);
 final paymentMethodFilterProvider = StateProvider<List<String>>((ref) => []);
 final ratingFilterProvider = StateProvider<({double min, double max})>((ref) => (min: 0.0, max: 5.0));
 final premiumRangeFilterProvider = StateProvider<({double min, double max})>((ref) => (min: -10.0, max: 10.0));
+final minDaysFilterProvider = StateProvider<int>((ref) => 0);
 ```
 
 ### Filters Applied
@@ -76,6 +77,8 @@ The `filteredOrdersProvider` applies these filters to orders with `status == pen
 4. **Rating range** (`ratingFilterProvider`): `{min: 0.0, max: 5.0}`. Filters orders whose `rating.totalRating` falls within range. Applied only when range differs from default.
 
 5. **Premium range** (`premiumRangeFilterProvider`): `{min: -10.0, max: 10.0}`. Filters orders whose `premium` (parsed as double) falls within range. Applied only when range differs from default.
+
+6. **Days of use** (`minDaysFilterProvider`): `int`, default `0`. Maker account-age filter — excludes offers whose `rating.days` (the `days` field from the kind 38383 rating tag) is below `minDays`. Applied only when `minDays > 0`. In the filter dialog it is a 0–20 slider with an adjacent text input that accepts higher values (clamped 0–9999); the label switches from `Days: 20` to the typed value when a higher number is entered.
 
 ### Filter Persistence
 

--- a/.specify/v1-reference/ORDER_CREATION.md
+++ b/.specify/v1-reference/ORDER_CREATION.md
@@ -80,6 +80,18 @@ Initialization (`initState`):
    - `CurrencySection` + `selectedFiatCodeProvider`.
 3. **Fiat amount**
    - `AmountSection` with simple or range mode (`min`/`max`).
+   - Displays the node's order limits expressed in the selected fiat currency. The node
+     enforces a hard min/max in **sats** (`kind 38385`); `FiatAmountLimits`
+     (`lib/shared/utils/order_amount_limits.dart`) converts those sats bounds to whole-fiat
+     using the current exchange rate — min rounds **up**, max rounds **down**, min floored at
+     `1` — so every value in the shown range stays within the real sats limits. If the rate is
+     unavailable or the valid range collapses below 1 fiat unit (`isDisplayable == false`), it
+     falls back to showing the raw sats limits.
+
+   > **Depends on a v2 gap.** The fiat-limit display requires a live BTC/fiat exchange rate.
+   > In v2 the rate source is Nostr-based (NIP-33), which is **not implemented yet** (design
+   > only, in `.specify/NOSTR_EXCHANGE_RATES.md`). Until exchange rates land in v2, this
+   > display falls back to raw sats limits.
 4. **Payment methods**
    - Multi-select list + custom free text method.
 5. **Price type**

--- a/.specify/v1-reference/RELAY_SYNC_IMPLEMENTATION.md
+++ b/.specify/v1-reference/RELAY_SYNC_IMPLEMENTATION.md
@@ -32,7 +32,7 @@ The system maintains **real-time awareness** of relay list changes through persi
 
 From a user perspective, the system provides **seamless automatic connectivity** with complete override capabilities. Users never need to manually configure Mostro relays - they're discovered and configured automatically. However, users retain full control through an intuitive interface that allows blacklisting problematic relays, adding custom relays with full connectivity validation, and easily restoring previously blacklisted relays.
 
-The system also handles **instance transitions** gracefully. When a user switches to a different Mostro instance, the application performs a complete relay reset, clearing old Mostro relays while preserving user-added relays (when configured to do so), and immediately begins synchronization with the new instance.
+The system also handles **instance transitions** gracefully. When a user switches to a different Mostro instance, the application performs a **complete relay reset** — clearing the Mostro relays, the user-added relays, and the blacklist — and immediately begins synchronization with the new instance.
 
 ### Technical Resilience
 
@@ -88,7 +88,7 @@ Discovered relays persist in `settings.relays` and reload immediately, so normal
 
 ### Data Flow Architecture
 
-```
+```text
 ┌─────────────────┐    NIP-65 Events     ┌─────────────────┐
 │ Mostro Instance │ ──────────────────→  │ SubscriptionMgr │
 │   (kind 10002)  │                      │                 │
@@ -796,7 +796,7 @@ void _initSettingsListener() {
       _logger.i('Detected REAL Mostro pubkey change: $currentPubkey -> $newPubkey'); // Line 677
       currentPubkey = newPubkey;                            // Line 678
       
-      // 🔥 RESET COMPLETO: Limpiar todos los relays y hacer sync fresco
+      // COMPLETE RESET: clear all relays and do a fresh sync
       _cleanAllRelaysAndResync();                           // Line 681
     } else if (newPubkey != currentPubkey) {
       // Just update the tracking variable without reset (initial load)
@@ -1073,8 +1073,8 @@ Future<void> updateMostroInstance(String newValue) async {
     // COMPLETE RESET: Clear blacklist and user relays when changing Mostro
     state = state.copyWith(
       mostroPublicKey: newValue,                            // Line 57
-      blacklistedRelays: const [], // Blacklist vacío       // Line 58
-      userRelays: const [],         // User relays vacíos   // Line 59
+      blacklistedRelays: const [], // Clear blacklist       // Line 58
+      userRelays: const [],         // Clear user relays    // Line 59
     );
     
     _logger.i('Reset blacklist and user relays for new Mostro instance'); // Line 62
@@ -1176,20 +1176,20 @@ void _subscribeToRelayList(NostrFilter filter) {
 ### Data Flow Sequence Diagrams
 
 #### 1. Application Startup Sequence
-```
+```text
 App Launch → Settings Load → RelaysNotifier Init → Load Saved Relays → 
 Subscribe to Mostro Events → Wait for NostrService → Begin Sync
 ```
 
 #### 2. Mostro Relay List Update Sequence
-```
+```text
 NIP-65 Event Received → Author Validation → Timestamp Check → 
 Hash Deduplication → URL Normalization → Blacklist Filtering → 
 State Merging → Storage Persistence → NostrService Update
 ```
 
 #### 3. Manual Relay Addition Sequence
-```
+```text
 User Input → URL Normalization → Duplicate Check → 
 Connectivity Testing → Blacklist Removal → State Update → 
 Storage Persistence → UI Feedback
@@ -1232,7 +1232,7 @@ Storage Persistence → UI Feedback
 #### Instance Change Handling
 - **Complete State Reset**: Clean slate approach for new Mostro instances
 - **Dependency Cleanup**: Proper cleanup of subscriptions and timers
-- **User Data Preservation**: User relays survive instance changes (when configured)
+- **Clean Slate on Switch**: User relays and the blacklist are cleared on instance change so the new instance starts fresh
 
 ### Performance Optimizations
 

--- a/.specify/v1-reference/RELAY_SYNC_IMPLEMENTATION.md
+++ b/.specify/v1-reference/RELAY_SYNC_IMPLEMENTATION.md
@@ -32,7 +32,7 @@ The system maintains **real-time awareness** of relay list changes through persi
 
 From a user perspective, the system provides **seamless automatic connectivity** with complete override capabilities. Users never need to manually configure Mostro relays - they're discovered and configured automatically. However, users retain full control through an intuitive interface that allows blacklisting problematic relays, adding custom relays with full connectivity validation, and easily restoring previously blacklisted relays.
 
-The system also handles **instance transitions** gracefully. When a user switches to a different Mostro instance, the application performs a **complete relay reset** — clearing ALL relays (including user-added ones) and resetting to only the default relay (`wss://relay.mostro.network`). This ensures a clean state when changing trading instances. User relays are NOT preserved on instance change.
+The system also handles **instance transitions** gracefully. When a user switches to a different Mostro instance, the application performs a complete relay reset, clearing old Mostro relays while preserving user-added relays (when configured to do so), and immediately begins synchronization with the new instance.
 
 ### Technical Resilience
 
@@ -42,6 +42,37 @@ This relay synchronization system demonstrates advanced patterns in **distribute
 
 ---
 The system handles NIP-65 relay list events (kind 10002), implements dual storage strategies, provides two-tier connectivity validation, and manages complex state synchronization between user preferences and protocol requirements.
+
+---
+
+## Bootstrap Relay Discovery Layer
+
+The app does not seed hardcoded "default" relays into the user-visible relay list. Instead, a small set of **defensive bootstrap relays** (`Config.bootstrapRelays`) is used only to discover a Mostro instance's kind 10002 relay list. Once discovered, the app operates exclusively over the discovered relays; the bootstrap relays are never persisted nor shown.
+
+### Design
+
+- **Bootstrap relays live only at the NostrService connection level**, never in `RelaysNotifier` state or `settings.relays`. The visible list and `settings.relays` always contain only discovered (Mostro) relays plus user relays. This keeps the user-facing relay list equal to what the Mostro instance actually endorses, instead of pinning hardcoded relays the instance may not use.
+- **Engaged only when needed**, via additive init (never disconnect):
+  - **Cold start**: when `settings.relays` is empty, `NostrService.init()` falls back to `Config.bootstrapRelays` so the kind 10002 can be fetched.
+  - **All-down**: `RelayHealthMonitor` (a periodic watchdog, `Config.relayDiscoveryTimeout` interval) detects `liveRelayCount == 0` and calls `ensureBootstrapConnectivity()` + `subscribeAll()` + re-subscribes the kind 10002.
+  - **Instance switch**: `_cleanAllRelaysAndResync()` clears the list and calls `ensureBootstrapConnectivity()` so the new instance's kind 10002 can be fetched (the previous instance's relays may not carry it).
+- **Logical retirement**: once discovered relays are connected and `settings.relays` points only to them, bootstrap relays are no longer targeted. dart_nostr has **no per-relay disconnect** (`disconnectFromRelays()` closes all), so bootstrap sockets stay idle until the app closes rather than being individually closed.
+
+### Safety invariants (no event loss)
+
+1. **Never `disconnectFromRelays()`** — only additive init. This makes it impossible to drop existing connections/subscriptions (the cause of the historical subscription-loss bug; see `SUBSCRIPTION_LOSS_BUG.md`).
+2. **Watchdog floor** — when no relay is alive, bootstrap is engaged and subscriptions re-issued via the proven `subscribeAll()` path.
+3. **Fail-safe toward connecting** — a false positive only costs an idle socket, never silence.
+
+### Liveness signal
+
+`NostrService` tracks alive relays in `_connectedRelays` from the relay connection callbacks: a relay is added on `onRelayListening` (data received proves it alive) and removed on `onRelayConnectionError`/`onRelayConnectionDone` (error or socket close). Exposed via `liveRelayCount` and `connectedRelays`. The dart_nostr registry is not used for this because it is not pruned on disconnect.
+
+### Restart behavior
+
+Discovered relays persist in `settings.relays` and reload immediately, so normal launches connect only to discovered relays and never touch bootstrap. The kind 10002 still re-syncs over the discovered relays each launch (staying current with operator changes). Bootstrap is engaged again only on cold start or when every discovered relay is unreachable.
+
+**Key files**: `Config.bootstrapRelays` / `Config.relayDiscoveryTimeout` (`lib/core/config.dart`), `NostrService.ensureBootstrapConnectivity()` + init fail-safe + liveness tracking (`lib/services/nostr_service.dart`), `RelayHealthMonitor` (`lib/features/relays/relay_health_monitor.dart`).
 
 ---
 
@@ -57,7 +88,7 @@ The system handles NIP-65 relay list events (kind 10002), implements dual storag
 
 ### Data Flow Architecture
 
-```text
+```
 ┌─────────────────┐    NIP-65 Events     ┌─────────────────┐
 │ Mostro Instance │ ──────────────────→  │ SubscriptionMgr │
 │   (kind 10002)  │                      │                 │
@@ -765,7 +796,7 @@ void _initSettingsListener() {
       _logger.i('Detected REAL Mostro pubkey change: $currentPubkey -> $newPubkey'); // Line 677
       currentPubkey = newPubkey;                            // Line 678
       
-      // 🔥 FULL RESET: Clear all relays and do fresh sync
+      // 🔥 RESET COMPLETO: Limpiar todos los relays y hacer sync fresco
       _cleanAllRelaysAndResync();                           // Line 681
     } else if (newPubkey != currentPubkey) {
       // Just update the tracking variable without reset (initial load)
@@ -884,20 +915,18 @@ static RelayListEvent? fromEvent(NostrEvent event) {
 ```dart
 List<String> get validRelays {
   return relays
-      .where((url) => url.startsWith('wss://')) // Only secure WebSocket allowed in production
+      .where((url) => url.startsWith('wss://') || url.startsWith('ws://')) // Line 50
       .map((url) => url.trim())                             // Line 51
       .map((url) => url.endsWith('/') ? url.substring(0, url.length - 1) : url) // Line 52
       .toList();                                            // Line 53
 }
 ```
 
-> ⚠️ **Security Note:** Only `wss://` (secure WebSocket) URLs are accepted. The `ws://` protocol is unencrypted and rejected in production to prevent MITM attacks.
-
 **Technical Features**:
 - **NIP-65 Compliance**: Properly parses kind 10002 events
 - **Robust Tag Parsing**: Handles malformed or missing tags gracefully
 - **Timestamp Flexibility**: Supports both DateTime and int timestamp formats
-- **URL Normalization**: Removes trailing slashes, validates secure protocol only
+- **URL Normalization**: Removes trailing slashes and validates protocols
 
 ---
 
@@ -1044,8 +1073,8 @@ Future<void> updateMostroInstance(String newValue) async {
     // COMPLETE RESET: Clear blacklist and user relays when changing Mostro
     state = state.copyWith(
       mostroPublicKey: newValue,                            // Line 57
-      blacklistedRelays: const [], // Empty blacklist       // Line 58
-      userRelays: const [],         // Empty user relays   // Line 59
+      blacklistedRelays: const [], // Blacklist vacío       // Line 58
+      userRelays: const [],         // User relays vacíos   // Line 59
     );
     
     _logger.i('Reset blacklist and user relays for new Mostro instance'); // Line 62
@@ -1147,20 +1176,20 @@ void _subscribeToRelayList(NostrFilter filter) {
 ### Data Flow Sequence Diagrams
 
 #### 1. Application Startup Sequence
-```text
+```
 App Launch → Settings Load → RelaysNotifier Init → Load Saved Relays → 
 Subscribe to Mostro Events → Wait for NostrService → Begin Sync
 ```
 
 #### 2. Mostro Relay List Update Sequence
-```text
+```
 NIP-65 Event Received → Author Validation → Timestamp Check → 
 Hash Deduplication → URL Normalization → Blacklist Filtering → 
 State Merging → Storage Persistence → NostrService Update
 ```
 
 #### 3. Manual Relay Addition Sequence
-```text
+```
 User Input → URL Normalization → Duplicate Check → 
 Connectivity Testing → Blacklist Removal → State Update → 
 Storage Persistence → UI Feedback

--- a/.specify/v1-reference/SESSION_AND_KEY_MANAGEMENT.md
+++ b/.specify/v1-reference/SESSION_AND_KEY_MANAGEMENT.md
@@ -216,7 +216,10 @@ Sessions are persisted using `SessionStorage` (`lib/data/repositories/session_st
 
 - **Active Sessions**: Stored in memory (`SessionNotifier._sessions` map)
 - **Persistent Storage**: Serialized to Sembast for app restart recovery
-- **Cleanup**: Automatic cleanup of expired sessions (72 hours default)
+- **Cleanup**: User-configurable automatic cleanup (presets: 1 week, 1 month, 3 months,
+  6 months, 1 year, never). Default: 1 month (720 hours). When a session expires, all
+  associated data is cascade-deleted: chat events, dispute chat events, mostro messages,
+  notifications, and read status keys.
 
 ### Session Recovery from Mnemonic
 
@@ -292,7 +295,9 @@ Sessions can be deleted through several mechanisms:
 1. **Automatic Cleanup**: 10-second timer when no response from Mostro (both session types)
 2. **Timeout Detection**: Real-time detection via public events (taker scenarios)
 3. **Cancellation**: When orders are cancelled (pending/waiting states only)
-4. **Expiration**: Periodic cleanup of sessions older than 72 hours
+4. **Expiration**: Periodic cleanup based on user-configured retention period (default
+   30 days, configurable in Settings: 1 week / 1 month / 3 months / 6 months / 1 year /
+   never). Cascade-deletes all associated data (events, messages, notifications, read status).
 5. **Manual**: User-initiated session cleanup through settings
 
 #### **Session Cleanup Implementation**
@@ -542,6 +547,19 @@ class KeyStorage {
           SharedPreferencesKeys.keyIndex.value,
         ) ??
         1;  // Default to first trade key
+  }
+
+  // Selective clear: removes only keys owned by KeyStorage and
+  // user-identity data. Preserves app preferences (mostro_settings,
+  // first_run_complete, community_selected) to avoid resetting
+  // the selected Mostro instance or re-showing onboarding screens.
+  Future<void> clear() async {
+    await secureStorage.deleteAll();
+    await sharedPrefs.remove(SharedPreferencesKeys.keyIndex.value);
+    await sharedPrefs.remove(SharedPreferencesKeys.mostroCustomNodes.value);
+    await sharedPrefs.remove(SharedPreferencesKeys.trustedNodeMetadata.value);
+    await sharedPrefs.remove(SharedPreferencesKeys.backgroundFilters.value);
+    await sharedPrefs.remove(SharedPreferencesKeys.fullPrivacy.value);
   }
 }
 ```

--- a/.specify/v1-reference/SETTINGS_SCREEN.md
+++ b/.specify/v1-reference/SETTINGS_SCREEN.md
@@ -16,7 +16,7 @@
 
 | File | Purpose |
 |------|---------|
-| `lib/features/settings/settings.dart` | Immutable `Settings` model (relays, privacy mode, locale, fiat, lightning address, push toggles, logging flags). |
+| `lib/features/settings/settings.dart` | Immutable `Settings` model (relays, privacy mode, locale, fiat, lightning address, push toggles, logging flags, session expiration). |
 | `lib/features/settings/settings_notifier.dart` | `StateNotifier<Settings>` that loads/saves the model to `SharedPreferences` (`SharedPreferencesAsync`). |
 | `lib/features/settings/settings_provider.dart` | Global Riverpod provider consumed across the app. |
 
@@ -33,6 +33,7 @@
 - `mostroPublicKey` → `MostroNodesNotifier`, `NostrService` handshake headers.
 - `pushNotificationsEnabled`, `notificationSoundEnabled`, `notificationVibrationEnabled` → `PushNotificationService`, `FCMService`, notification UI.
 - `isLoggingEnabled` → `MemoryLogOutput` toggles in-app logging buffer.
+- `sessionExpirationHours` → `SessionNotifier` retention/cleanup window (`TradeHistorySelector`; `Config.sessionExpirationHours` = 720 fallback).
 - `fullPrivacyMode` → `RestoreManager`, `NostrService` (decides whether to keep master key in memory).
 
 ### Side Effects
@@ -90,6 +91,11 @@
 │  └───────────────────────────────────────────────┘  │
 │                                                     │
 │  ┌───────────────────────────────────────────────┐  │
+│  │  🕑  Trade History                            │  │
+│  │      1 month                                  │  │
+│  └───────────────────────────────────────────────┘  │
+│                                                     │
+│  ┌───────────────────────────────────────────────┐  │
 │  │  🛠️  Log Report                            >  │  │
 │  └───────────────────────────────────────────────┘  │
 │                                                     │
@@ -110,8 +116,9 @@
 | 4 | 👛 Wallet | NWC Wallet | "Connected. Balance: 11 sats" | Tap → `/wallet_settings` |
 | 5 | 📡 Relay | Relays | List with green/red status + ON/OFF toggle | Inline management + "Add Relay" button |
 | 6 | 🔔 Bell | Push Notifications | (chevron >) | Tap → `/notification_settings` |
-| 7 | 🛠️ Gear | Log Report | (chevron >) | Tap → `/logs` |
-| 8 | ⚡ Lightning | Mostro Node | Truncated pubkey + "Trusted" badge | Tap → MostroNodeSelector modal |
+| 7 | 🕑 Clock | Trade History | "1 month" (retention preset) | Tap → preset dropdown + confirmation dialog |
+| 8 | 🛠️ Gear | Log Report | (chevron >) | Tap → `/logs` |
+| 9 | ⚡ Lightning | Mostro Node | Truncated pubkey + "Trusted" badge | Tap → MostroNodeSelector modal |
 
 ### Relay Management (inline):
 - Each relay shows: URL + connection status dot (🟢 green = connected, 🔴 red = disconnected) + ON/OFF toggle
@@ -154,12 +161,24 @@ Each card is a `Container` with consistent styling (rounded corners, subtle bord
 - Explains push notification scope, links to `/notification_settings`.
 - Actual toggles live in `NotificationSettingsScreen` (documented below).
 
-#### 7. Dev Tools
+#### 7. Trade History (`TradeHistorySelector`)
+- Controls how long completed/inactive trade sessions are retained before automatic cleanup.
+- Dropdown with 6 presets: 1 week (168h), 1 month (720h, default), 3 months (2160h),
+  6 months (4320h), 1 year (8760h), Never (0 = no automatic cleanup).
+- Selection persists in `settings.sessionExpirationHours`; `SessionNotifier` reads it with
+  `Config.sessionExpirationHours` (720) as fallback.
+- Shows a confirmation dialog before applying a change.
+- On expiry, the session and all associated data are cascade-deleted (see
+  [SESSION_AND_KEY_MANAGEMENT.md](./SESSION_AND_KEY_MANAGEMENT.md) and
+  [TIMEOUT_DETECTION_AND_SESSION_CLEANUP.md](./TIMEOUT_DETECTION_AND_SESSION_CLEANUP.md));
+  active trades are protected from cleanup.
+
+#### 8. Dev Tools
 - Warns about debugging features.
 - Toggle for in-memory logging (`settings.isLoggingEnabled` → `MemoryLogOutput.isLoggingEnabled`).
 - Button → `/logs` to view/export logs.
 
-#### 8. Mostro Node Selector
+#### 9. Mostro Node Selector
 - Uses `MostroNodeSelector.show()` to pick from trusted/untrusted nodes.
 - Renders avatar, display name, truncated pubkey, and "Trusted" badge.
 - Changing node calls `SettingsNotifier.updateMostroInstance`, which resets relay blacklists and user-relay metadata.

--- a/.specify/v1-reference/TIMEOUT_DETECTION_AND_SESSION_CLEANUP.md
+++ b/.specify/v1-reference/TIMEOUT_DETECTION_AND_SESSION_CLEANUP.md
@@ -1,0 +1,1051 @@
+# Session and Order Lifecycle Management - Mostro Mobile
+
+## Overview
+
+This document provides comprehensive technical documentation for Mostro Mobile's session and order lifecycle management system. The implementation handles timeout detection, order cancellation, session cleanup, and real-time countdown timers for trading operations.
+
+**Purpose**: Technical reference for understanding the complete lifecycle management of trading sessions and orders.
+
+**Scope**: Covers timeout detection system, session management patterns, countdown timer architecture, and gift wrap-based communication handling.
+
+---
+
+## System Architecture
+
+### Core Components
+
+The lifecycle management system consists of four main components:
+
+1. **OrderNotifier** - Direct gift wrap handling and session cleanup
+2. **SessionNotifier** - Session lifecycle management and storage
+3. **Time Provider System** - Optimized countdown timers
+4. **UI Integration** - Real-time countdown display and notifications
+
+### Communication Architecture
+
+The system uses encrypted gift wrap messages for all timeout and cancellation handling:
+
+#### **Gift Wrap Channel (SubscriptionManager)**
+- **Purpose**: Handles all encrypted communications including timeout/cancellation instructions
+- **Events**: Kind 1059 (encrypted gift-wrapped messages)
+- **Usage**: "My Trades" data, private messaging, session state updates, timeout/cancellation notifications
+
+#### **Public Channel (OpenOrdersRepository)**  
+- **Purpose**: Handles public order discovery for Order Book display
+- **Events**: Kind 38383 (public Mostro order events)
+- **Usage**: Order Book display only (no timeout detection)
+
+---
+
+## Timeout Detection System
+
+### Gift Wrap-Based Detection Architecture
+
+The timeout detection system receives direct instructions from Mostro via encrypted gift wrap messages (kind 1059) and automatically handles timeouts and cancellations based on user role (maker vs taker).
+
+#### **OrderNotifier Implementation**
+
+```dart
+// lib/features/order/notifiers/order_notifier.dart
+class OrderNotifier extends AbstractMostroNotifier {
+  // Simplified implementation - timeout/cancellation logic moved to AbstractMostroNotifier
+  @override
+  Future<void> handleEvent(MostroMessage event, {bool bypassTimestampGate = false}) async {
+    // Handle the event normally - timeout/cancellation logic is now in AbstractMostroNotifier
+    await super.handleEvent(event, bypassTimestampGate: bypassTimestampGate);
+  }
+}
+```
+
+**Key Features**:
+- **Direct gift wrap handling**: Receives explicit timeout/cancellation instructions from Mostro
+- **Automatic cleanup**: Handles session deletion vs preservation based on user role
+- **Simplified logic**: No complex public event monitoring or timestamp comparisons
+
+### Direct Gift Wrap Handling
+
+The system processes timeout and cancellation instructions directly from Mostro via gift wrap messages:
+
+#### **AbstractMostroNotifier Gift Wrap Processing**
+
+```dart
+// lib/features/order/notifiers/abstract_mostro_notifier.dart
+Future<void> handleEvent(MostroMessage event, {bool bypassTimestampGate = false}) async {
+  switch (event.action) {
+    case Action.newOrder:
+      // Check if this is a timeout reactivation from Mostro
+      final currentSession = ref.read(sessionProvider(orderId));
+      if (currentSession != null && 
+          (state.status == Status.waitingBuyerInvoice || state.status == Status.waitingPayment)) {
+        // This is a maker receiving order reactivation after taker timeout
+        logger.i('MAKER: Received order reactivation from Mostro - taker timed out, order returned to pending');
+        
+        // Show notification: counterpart didn't respond, order will be republished
+        if (isRecent || !bypassTimestampGate) {
+          final notifProvider = ref.read(notificationActionsProvider.notifier);
+          notifProvider.showCustomMessage('orderTimeoutMaker');
+        }
+      }
+      break;
+      
+    case Action.canceled:
+      // Handle cancellation sent by Mostro (for both timeout and cancellation scenarios)
+      final currentSession = ref.read(sessionProvider(orderId));
+      if (currentSession != null) {
+        logger.i('CANCELLATION: Received cancellation message from Mostro for order $orderId');
+        
+        // Delete session - this applies to both maker and taker scenarios
+        final sessionNotifier = ref.read(sessionNotifierProvider.notifier);
+        await sessionNotifier.deleteSession(orderId);
+        
+        logger.i('Session deleted for canceled order $orderId');
+        
+        // Show cancellation notification
+        if (isRecent || !bypassTimestampGate) {
+          final notifProvider = ref.read(notificationActionsProvider.notifier);
+          notifProvider.showCustomMessage('orderCanceled');
+        }
+        
+        // Navigate to main order book screen
+        if (isRecent && !bypassTimestampGate) {
+          navProvider.go('/');
+        }
+        
+        return; // Session was deleted, no further processing needed
+      }
+      break;
+  }
+}
+```
+
+### Gift Wrap-Based Detection Logic
+
+The system receives explicit instructions from Mostro instead of inferring timeouts from public events:
+
+#### **Direct Instruction Processing**
+
+**Timeout Detection**:
+- **Mostro sends `Action.newOrder`** to makers when taker times out
+- **Mostro sends `Action.canceled`** to takers when they time out
+- **No timestamp comparison needed** - Mostro decides and instructs directly
+- **No synthetic message creation** - real gift wrap messages contain all needed information
+
+**Cancellation Detection**:
+- **Mostro sends `Action.canceled`** for all cancellation scenarios
+- **Session handling based on current state** - preserves active orders, deletes pending/waiting orders
+- **Universal handling** - same logic applies to timeouts and manual cancellations
+
+### Maker vs Taker Differentiation
+
+The system handles timeout scenarios differently based on the gift wrap action received:
+
+#### **Behavior by Gift Wrap Action**
+
+**MAKER (Order Creator) - Receives `Action.newOrder`**:
+```
+1. User creates order → Someone takes it → waiting state in My Trades
+2. Taker doesn't respond → Mostro sends Action.newOrder gift wrap to maker
+3. System preserves session and updates state to pending
+4. Notification: "Your counterpart didn't respond in time"
+5. Order stays in My Trades as pending, ready for someone else to take
+```
+
+**TAKER (Order Accepter) - Receives `Action.canceled`**:
+```
+1. User takes order → Order appears in My Trades with waiting state
+2. User doesn't respond in time → Mostro sends Action.canceled gift wrap to taker
+3. System deletes session completely
+4. Notification: "Order was canceled"
+5. Order disappears from My Trades and returns to Order Book for others to take
+```
+
+---
+
+## Session Management System
+
+### SessionNotifier Core Implementation
+
+The SessionNotifier manages the complete lifecycle of trading sessions:
+
+```dart
+// lib/shared/notifiers/session_notifier.dart
+class SessionNotifier extends StateNotifier<List<Session>> {
+  final Map<String, Session> _sessions = {};
+  final Map<int, Session> _requestIdToSession = {}; // For temporary orders
+  Timer? _cleanupTimer;
+
+  // Reads from user settings, falls back to Config.sessionExpirationHours (720h)
+  // Value of 0 means "never" (no automatic cleanup)
+  int get _expirationHours =>
+      _settings.sessionExpirationHours ?? Config.sessionExpirationHours;
+
+  bool get _isForever => _expirationHours == 0;
+
+  Future<void> init() async {
+    final allSessions = await _storage.getAllSessions();
+    if (_isForever) {
+      // "Never" mode: load all sessions without filtering
+      for (final session in allSessions) {
+        _sessions[session.orderId!] = session;
+      }
+    } else {
+      final cutoff = DateTime.now()
+          .subtract(Duration(hours: _expirationHours));
+      for (final session in allSessions) {
+        if (session.startTime.isAfter(cutoff)) {
+          _sessions[session.orderId!] = session;
+        } else {
+          await _storage.deleteSession(session.orderId!);
+          _sessions.remove(session.orderId!);
+          await _cleanupSessionData(session); // Cascade delete all associated data
+        }
+      }
+    }
+    _emitState();
+    _scheduleCleanup();
+  }
+
+  void _cleanup() async {
+    if (_isForever) return; // Skip cleanup entirely in "never" mode
+    // ... same cascade logic as init()
+  }
+
+  /// Deletes all data associated with an expired session
+  Future<void> _cleanupSessionData(Session session) async {
+    final orderId = session.orderId!;
+    // 1. Chat events from eventStore (keyed by order_id)
+    await eventStore.deleteWhere(Filter.equals('order_id', orderId));
+    // 2. Dispute chat events from eventStore (keyed by dispute_id)
+    if (session.disputeId != null) {
+      await eventStore.deleteWhere(Filter.equals('dispute_id', session.disputeId));
+    }
+    // 3. Mostro protocol messages from mostroStorage
+    await mostroStore.deleteAllMessagesByOrderId(orderId);
+    // 4. Notifications from notificationsRepository
+    await notificationsStore.deleteWhere(Filter.equals('orderId', orderId));
+    // 5. Chat/dispute read status from SharedPreferences
+    await prefs.remove('chat_last_read_$orderId');
+    if (session.disputeId != null) {
+      await prefs.remove('dispute_last_read_${session.disputeId}');
+    }
+  }
+}
+```
+
+**Key Features**:
+- **User-configurable expiration**: Users choose retention period in Settings (1 week, 1 month, 3 months, 6 months, 1 year, or never)
+- **Default**: 1 month (720 hours), stored in `Settings.sessionExpirationHours`, falls back to `Config.sessionExpirationHours`
+- **"Never" mode**: Value `0` disables automatic cleanup entirely — sessions and data persist indefinitely
+- **Cascading cleanup**: When a session expires, ALL associated data is deleted (see below)
+- **Periodic cleanup**: Scheduled every 30 minutes (`Config.cleanupIntervalMinutes`)
+- **State synchronization**: Updates trigger automatic UI updates
+- **Storage persistence**: Sessions survive app restarts
+
+#### What Gets Cleaned Up
+
+When a session expires, the following data is deleted:
+
+| Storage | What's deleted | Filter |
+|---|---|---|
+| sessionStorage | Session record | `orderId` |
+| eventStore | Chat gift wrap events | `order_id = orderId` |
+| eventStore | Dispute chat gift wrap events | `dispute_id = disputeId` |
+| mostroStorage | Mostro protocol messages | `id = orderId` |
+| notificationsRepository | Order notifications | `orderId = orderId` |
+| SharedPreferences | Chat read status | `chat_last_read_{orderId}` |
+| SharedPreferences | Dispute read status | `dispute_last_read_{disputeId}` |
+
+#### What Is NOT Cleaned Up (by design)
+
+| Storage | What remains | Why |
+|---|---|---|
+| eventStore | MostroService dedup stubs (`id` + `created_at` only) | These are the only deduplication mechanism. Deleting them could cause duplicate event processing if a relay re-delivers old events. They have no `order_id` field and are ~100 bytes each — negligible impact. |
+
+### Session Provider Pattern
+
+The optimized session access pattern provides better performance and reactivity:
+
+```dart
+// lib/shared/providers/session_notifier_provider.dart
+final sessionProvider = StateProvider.family<Session?, String>((ref, id) {
+  final notifier = ref.watch(sessionNotifierProvider);
+  return notifier.where((s) => s.orderId == id).firstOrNull;
+});
+```
+
+**Benefits**:
+- **Automatic reactivity**: UI updates when sessions change
+- **Better performance**: Leverages Riverpod's optimization
+- **Consistent pattern**: Used throughout the codebase
+- **Future-proof**: Compatible with ongoing development
+
+### Historical Context: SessionProvider Optimization Impact
+
+#### **Before Optimization (Worked Implicitly)**
+```dart
+final sessionProvider = StateProvider.family<Session?, String>((ref, id) {
+  final notifier = ref.watch(sessionNotifierProvider.notifier);
+  return notifier.getSessionByOrderId(id); // Independent method
+});
+```
+
+#### **After Optimization (Explicit Handling Required)**  
+```dart
+final sessionProvider = StateProvider.family<Session?, String>((ref, id) {
+  final notifier = ref.watch(sessionNotifierProvider); // Directly tied to state
+  return notifier.where((s) => s.orderId == id).firstOrNull; // Direct search
+});
+```
+
+**Why The Change Required Explicit Timeout Handling**:
+
+1. **`sessionProvider` became directly tied** to `sessionNotifierProvider` state
+2. **"My Trades" depends on `sessionProvider`** to determine which orders to show
+3. **Cancellations without explicit session deletion** meant sessions continued to exist
+4. **Orphaned sessions** caused "My Trades" to show orders with stale status
+5. **Solution required explicit session deletion** when timeouts/cancellations detected
+
+---
+
+## Countdown Timer System
+
+### Optimized Time Provider Implementation
+
+The countdown system uses an optimized Stream provider with debouncing and automatic cleanup:
+
+```dart
+// lib/shared/providers/time_provider.dart
+final countdownTimeProvider = StreamProvider<DateTime>((ref) {
+  late StreamController<DateTime> controller;
+  Timer? timer;
+  DateTime? lastEmittedTime;
+
+  controller = StreamController<DateTime>.broadcast(
+    onListen: () {
+      // Start timer when first listener subscribes
+      timer = Timer.periodic(const Duration(seconds: 1), (timer) {
+        final now = DateTime.now();
+        // Debounce: only emit if seconds have actually changed
+        if (lastEmittedTime == null || 
+            now.second != lastEmittedTime!.second ||
+            now.minute != lastEmittedTime!.minute ||
+            now.hour != lastEmittedTime!.hour) {
+          lastEmittedTime = now;
+          controller.add(now);
+        }
+      });
+      // Emit initial value immediately
+      controller.add(DateTime.now());
+    },
+    onCancel: () {
+      // Cleanup when last listener unsubscribes
+      timer?.cancel();
+      timer = null;
+      lastEmittedTime = null;
+    },
+  );
+
+  ref.onDispose(() {
+    timer?.cancel();
+    controller.close();
+  });
+
+  return controller.stream;
+});
+```
+
+**Optimizations**:
+- **Debouncing**: Only emits when time values actually change
+- **Automatic cleanup**: Cancels timer when no listeners
+- **Resource efficiency**: Single timer supports multiple subscribers
+- **Memory leak prevention**: Proper disposal handling
+
+### Dynamic Countdown Timer System
+
+The application now uses a unified `DynamicCountdownWidget` for all pending order countdown timers, providing intelligent scaling and precise timestamp calculations.
+
+#### **DynamicCountdownWidget Architecture**
+
+```dart
+// lib/shared/widgets/dynamic_countdown_widget.dart
+class DynamicCountdownWidget extends ConsumerWidget {
+  final DateTime expiration;
+  final DateTime createdAt;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final remainingTime = expiration.isAfter(now) ? expiration.difference(now) : Duration.zero;
+    final useDayScale = remainingTime.inHours > 24;
+
+    if (useDayScale) {
+      // Day scale: "14d 20h 06m" format for >24 hours
+      final daysLeft = (remainingTime.inHours / 24).floor();
+      final hoursLeftInDay = remainingTime.inHours % 24;
+      final minutesLeftInHour = remainingTime.inMinutes % 60;
+      return CircularCountdown(countdownTotal: totalDays, countdownRemaining: daysLeft);
+    } else {
+      // Hour scale: "HH:MM:SS" format for ≤24 hours
+      final hoursLeft = remainingTime.inHours.clamp(0, totalHours);
+      final minutesLeft = remainingTime.inMinutes % 60;
+      final secondsLeft = remainingTime.inSeconds % 60;
+      return CircularCountdown(countdownTotal: totalHours, countdownRemaining: hoursLeft);
+    }
+  }
+}
+```
+
+#### **Key Features**
+
+1. **Automatic Scaling**: Switches between day/hour formats based on remaining time
+2. **Exact Timestamps**: Uses `expires_at` tag for precise calculations
+3. **Dynamic Display**: 
+   - **>24 hours**: Day scale with "14d 20h 06m" format
+   - **≤24 hours**: Hour scale with "HH:MM:SS" format
+4. **Intelligent Rounding**: Circle divisions use intelligent rounding (28.2h → 28h, 23.7h → 24h)
+5. **Shared Component**: Eliminates 96 lines of duplicated countdown code
+
+#### **Integration Points**
+
+**TakeOrderScreen Usage**:
+```dart
+// lib/features/order/screens/take_order_screen.dart - _buildCountDownTime method
+return DynamicCountdownWidget(
+  expiration: DateTime.fromMillisecondsSinceEpoch(expiresAtTimestamp * 1000),
+  createdAt: order.createdAt!,
+);
+```
+
+**TradeDetailScreen Usage**:
+```dart
+// lib/features/trades/screens/trade_detail_screen.dart - trade details widget tree
+_CountdownWidget(
+  orderId: orderId,
+  tradeState: tradeState,
+  expiresAtTimestamp: orderPayload.expiresAt != null ? orderPayload.expiresAt! * 1000 : null,
+),
+```
+
+#### **Scope and Limitations**
+
+- **Pending Orders Only**: DynamicCountdownWidget is specifically designed for orders in `Status.pending`
+- **Waiting Orders Use Different System**: Orders in `Status.waitingBuyerInvoice` and `Status.waitingPayment` use separate countdown logic based on `expirationSeconds` + message timestamps
+- **Data Source**: Uses `expires_at` Nostr tag for exact expiration timestamps rather than calculated values
+
+#### **Real-time Countdown Widget**
+
+```dart
+// lib/features/trades/screens/trade_detail_screen.dart - _CountdownWidget class
+class _CountdownWidget extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final timeAsync = ref.watch(countdownTimeProvider); // Updates every second
+    final messagesAsync = ref.watch(mostroMessageHistoryProvider(orderId));
+    
+    return timeAsync.when(
+      data: (currentTime) {
+        return messagesAsync.maybeWhen(
+          data: (messages) {
+            final countdownWidget = _buildCountDownTime(
+              context, ref, tradeState, messages, expiresAtTimestamp
+            );
+            return countdownWidget != null 
+              ? Column(children: [countdownWidget, const SizedBox(height: 36)])
+              : const SizedBox(height: 12);
+          },
+          orElse: () => const SizedBox(height: 12),
+        );
+      },
+      loading: () => const SizedBox(height: 12),
+      error: (error, stack) => const SizedBox(height: 12),
+    );
+  }
+}
+```
+
+#### **State-Specific Countdown Logic**
+
+The countdown displays different behaviors based on order status:
+
+```dart
+// _buildCountDownTime method: Countdown logic by order status
+Widget? _buildCountDownTime(BuildContext context, WidgetRef ref, 
+    OrderState tradeState, List<MostroMessage> messages, int? expiresAtTimestamp) {
+  
+  final status = tradeState.status;
+  final now = DateTime.now();
+  final mostroInstance = ref.read(orderRepositoryProvider).mostroInstance;
+  
+  if (status == Status.pending) {
+    // PENDING ORDERS: Use expirationHours (default 24h)
+    final expHours = mostroInstance?.expirationHours ?? 24;
+    final expiration = expiresAtTimestamp != null
+        ? DateTime.fromMillisecondsSinceEpoch(expiresAtTimestamp)
+        : now.add(Duration(hours: expHours));
+    
+    final difference = expiration.isAfter(now) 
+        ? expiration.difference(now) 
+        : const Duration();
+    
+    final hoursLeft = difference.inHours.clamp(0, expHours);
+    final minutesLeft = difference.inMinutes % 60;
+    final secondsLeft = difference.inSeconds % 60;
+    
+    return CircularCountdown(
+      countdownTotal: expHours,
+      countdownRemaining: hoursLeft,
+      text: '$hoursLeft:${minutesLeft.toString().padLeft(2, '0')}:${secondsLeft.toString().padLeft(2, '0')}',
+    );
+    
+  } else if (status == Status.waitingBuyerInvoice || status == Status.waitingPayment) {
+    // WAITING STATES: Use expirationSeconds (default 15 minutes)
+    final stateMessage = _findMessageForState(messages, status);
+    if (stateMessage == null || !isValidTimestamp(stateMessage.timestamp)) {
+      return null;
+    }
+    
+    final expSecs = mostroInstance?.expirationSeconds ?? 900;
+    final messageTime = DateTime.fromMillisecondsSinceEpoch(stateMessage.timestamp!);
+    final expiration = messageTime.add(Duration(seconds: expSecs));
+    
+    final difference = expiration.isAfter(now) 
+        ? expiration.difference(now) 
+        : const Duration();
+    
+    final expMinutes = (expSecs / 60).ceil();
+    final minutesLeft = difference.inMinutes.clamp(0, expMinutes);
+    final secondsLeft = difference.inSeconds % 60;
+    
+    return CircularCountdown(
+      countdownTotal: expMinutes,
+      countdownRemaining: minutesLeft,
+      text: '$minutesLeft:${secondsLeft.toString().padLeft(2, '0')}',
+    );
+  } else {
+    return null; // All other states: NO countdown displayed
+  }
+}
+```
+
+#### **Message State Detection**
+
+```dart
+// _findMessageForState method: Find the message that caused the current state
+MostroMessage? _findMessageForState(List<MostroMessage> messages, Status status) {
+  // Sort messages by timestamp (most recent first)
+  final sortedMessages = List<MostroMessage>.from(messages)
+    ..sort((a, b) => (b.timestamp ?? 0).compareTo(a.timestamp ?? 0));
+
+  // Find message that caused the state
+  for (final message in sortedMessages) {
+    if (status == Status.waitingBuyerInvoice && 
+        (message.action == Action.addInvoice || 
+         message.action == Action.waitingBuyerInvoice)) {
+      return message;
+    } else if (status == Status.waitingPayment && 
+        (message.action == Action.payInvoice || 
+         message.action == Action.waitingSellerToPay)) {
+      return message;
+    }
+  }
+  return null;
+}
+```
+
+**Countdown Display Rules**:
+- **Status.pending**: Shows HH:MM:SS format with hours, uses Mostro instance `expirationHours`
+- **Status.waitingBuyerInvoice**: Shows MM:SS format, uses `expirationSeconds` from state message timestamp  
+- **Status.waitingPayment**: Shows MM:SS format, uses `expirationSeconds` from state message timestamp
+- **All other statuses**: No countdown displayed (returns null)
+
+---
+
+## Gift Wrap Communication Architecture
+
+### Direct Mostro Communication
+
+The system receives timeout and cancellation instructions directly from Mostro via encrypted gift wrap messages:
+
+#### **Gift Wrap Message Handling**
+
+```dart
+// All timeout/cancellation handling flows through SubscriptionManager
+// which processes encrypted Kind 1059 events and delivers them to OrderNotifier
+// via the existing mostroMessageStreamProvider system
+```
+
+#### **Public Event Providers (Order Book Only)**
+
+Public events are now only used for Order Book display, not timeout detection:
+
+```dart
+// lib/shared/providers/order_repository_provider.dart
+final orderEventsProvider = StreamProvider<List<NostrEvent>>((ref) {
+  final orderRepository = ref.read(orderRepositoryProvider);
+  return orderRepository.eventsStream; // Stream of 38383 public events - ORDER BOOK ONLY
+});
+```
+
+### Order Notifier Provider
+
+```dart
+// lib/features/order/providers/order_notifier_provider.dart
+final orderNotifierProvider =
+    StateNotifierProvider.family<OrderNotifier, OrderState, String>((ref, orderId) {
+  return OrderNotifier(orderId, ref);
+});
+```
+
+**Integration Points**:
+- **OrderNotifier**: Handles gift wrap message processing and session cleanup
+- **OrderState**: Maintains current order state and action
+- **SubscriptionManager**: Delivers encrypted timeout/cancellation messages
+
+---
+
+## Data Flow and Integration
+
+### Complete Gift Wrap Flow
+
+```
+1. Order in waiting state (waitingBuyerInvoice or waitingPayment)
+2. Timeout occurs on Mostro server
+3. Mostro sends direct gift wrap message:
+   - Action.newOrder to maker (timeout reactivation)
+   - Action.canceled to taker (timeout cancellation)
+4. SubscriptionManager receives and decrypts gift wrap
+5. OrderNotifier.handleEvent() processes the instruction
+6. System applies appropriate action based on gift wrap content
+7. UI updates automatically through Riverpod reactive system
+```
+
+### State Management Flow
+
+```dart
+// Complete reactive chain
+Gift Wrap (1059) → SubscriptionManager → mostroMessageStreamProvider → OrderNotifier
+                                                                      ↓
+Session state ← sessionNotifier.deleteSession() ← gift wrap instruction processing
+     ↓
+sessionProvider(orderId) → UI components → automatic updates
+```
+
+### Persistence and Recovery
+
+**Session Persistence**: Sessions are stored in Sembast database and survive app restarts.
+
+**Gift Wrap Message Persistence**: All gift wrap messages (including timeout/cancellation instructions) are automatically persisted by the existing message storage system, ensuring proper state recovery after app restart without requiring synthetic messages.
+
+
+---
+
+## Error Handling and Resilience
+
+### Race Condition Protection
+
+The system implements multiple levels of protection against concurrent processing:
+
+```dart
+// Separate flags for different operations
+bool _isSyncing = false;              // Only for sync() method  
+bool _isProcessingTimeout = false;     // Only for timeout processing
+
+// Protected timeout processing
+if (_isProcessingTimeout) {
+  logger.d('Timeout processing already in progress for order $orderId');
+  return;
+}
+
+try {
+  _isProcessingTimeout = true;
+  // ... timeout detection logic
+} finally {
+  _isProcessingTimeout = false; // Always clean up
+}
+```
+
+### Operation Timeouts
+
+All critical operations include timeout protection:
+
+```dart
+// Session cleanup with timeout
+await sessionNotifier.deleteSession(orderId)
+    .timeout(const Duration(seconds: 5));
+
+// Storage operations with timeout  
+await storage.addMessage(messageKey, timeoutMessage)
+    .timeout(const Duration(seconds: 8));
+```
+
+### Validation and Edge Cases
+
+**Timestamp Validation**:
+```dart
+bool isValidTimestamp(int? timestamp) {
+  if (timestamp == null || timestamp <= 0) return false;
+  
+  final now = DateTime.now();
+  final messageTime = DateTime.fromMillisecondsSinceEpoch(timestamp);
+  
+  // Reject future timestamps (with 1 hour tolerance for CI/network latency)
+  if (messageTime.isAfter(now.add(const Duration(hours: 1)))) return false;
+  
+  // Reject very old timestamps (older than 7 days)
+  if (messageTime.isBefore(now.subtract(const Duration(days: 7)))) return false;
+  
+  return true;
+}
+```
+
+**State Validation**:
+```dart
+// Multiple state checks before processing
+if (!mounted || currentSession == null) return;
+
+if (state.status != Status.waitingBuyerInvoice && 
+    state.status != Status.waitingPayment) return;
+```
+
+### Graceful Degradation
+
+The system continues functioning even when individual operations fail:
+
+- **Storage failures**: Continue execution, log errors
+- **Network issues**: Retry logic with exponential backoff  
+- **Provider disposal**: Proper cleanup prevents memory leaks
+- **Invalid data**: Validation and fallback values
+
+---
+
+## Configuration and Customization
+
+### Dynamic Configuration
+
+The system uses dynamic configuration from the Mostro Instance Nostr event:
+
+```dart
+// Timeout durations from Mostro instance
+final expHours = mostroInstance?.expirationHours ?? 24;       // Default 24h for pending
+final expSecs = mostroInstance?.expirationSeconds ?? 900;     // Default 15min for waiting
+
+// Session expiration (user-configurable, this is the default fallback)
+const sessionExpirationHours = 720; // Defined in Config class (lib/core/config.dart)
+const cleanupIntervalMinutes = 30;  // Cleanup frequency
+```
+
+### Configurable Constants
+
+```dart
+// lib/core/config.dart
+class Config {
+  static const int sessionExpirationHours = 720; // Default: 30 days
+  static const int cleanupIntervalMinutes = 30;
+}
+
+// User-configurable presets (stored in Settings.sessionExpirationHours):
+//   168  = 1 week
+//   720  = 1 month (default)
+//   2160 = 3 months
+//   4320 = 6 months
+//   8760 = 1 year
+//   0    = never (no automatic cleanup)
+
+// Timeout durations (currently hardcoded, could be made configurable)
+static const Duration sessionCleanupTimeout = Duration(seconds: 5);
+static const Duration storageOperationTimeout = Duration(seconds: 8);
+```
+
+### Internationalization
+
+The system supports localized timeout notifications:
+
+```dart
+// lib/l10n/intl_*.arb files
+{
+  "orderTimeoutTaker": "You didn't respond in time. The order will be republished",
+  "orderTimeoutMaker": "Your counterpart didn't respond in time. The order will be republished"
+}
+
+// Spanish
+"orderTimeoutTaker": "No respondiste a tiempo. La orden será republicada"
+"orderTimeoutMaker": "Tu contraparte no respondió a tiempo. La orden será republicada"
+
+// Italian  
+"orderTimeoutTaker": "Non hai risposto in tempo. L'ordine sarà ripubblicato"
+"orderTimeoutMaker": "La tua controparte non ha risposto in tempo. L'ordine sarà ripubblicato"
+```
+
+---
+
+## Development Guidelines
+
+### Best Practices
+
+**Session Access Pattern**:
+```dart
+// ✅ Correct - Use optimized provider pattern
+final session = ref.read(sessionProvider(orderId));
+
+// ❌ Avoid - Old pattern (inconsistent with main)
+final session = ref.read(sessionNotifierProvider.notifier).getSessionByOrderId(orderId);
+```
+
+**Timeout Detection**:
+- The system is fully automatic - no manual intervention needed
+- Detection is status-based, not timestamp-based for reliability
+- Always handle both maker and taker scenarios differently
+
+**Error Handling**:
+- Use timeout wrappers for all async operations
+- Implement proper cleanup in finally blocks
+- Validate all external data before processing
+
+### Testing Considerations
+
+**Key Test Scenarios**:
+1. **Maker timeout**: Verify session preserved, state updated to pending
+2. **Taker timeout**: Verify session deleted, order disappears from My Trades
+3. **Synthetic event creation**: Verify artificial messages are created and stored correctly
+4. **App restart recovery**: Verify synthetic events are loaded and processed like real messages
+5. **Cancellation detection**: Verify proper session handling based on order state
+6. **Race conditions**: Verify concurrent processing is prevented
+7. **Invalid data**: Verify graceful handling of corrupt timestamps/events
+
+**Mocking Strategy**:
+- Mock orderEventsProvider for event simulation
+- Mock sessionNotifierProvider for session state testing
+- Mock time providers for countdown testing
+- Use real timestamp validation functions (not constant expressions)
+
+### Performance Considerations
+
+**Optimization Points**:
+- Timer debouncing prevents unnecessary UI updates
+- Single timer supports multiple countdown subscribers
+- Session provider optimization reduces lookup overhead
+- Event filtering reduces processing of irrelevant events
+
+**Memory Management**:
+- Automatic timer cleanup when no listeners
+- Proper provider disposal handling
+- Session cleanup removes expired entries and all associated data (events, messages, notifications, read status)
+- Race condition flags prevent resource leaks
+- MostroService dedup stubs are intentionally retained to prevent duplicate event processing
+
+---
+
+## Related Documentation
+
+### Implementation Files
+- **`lib/features/order/notifiers/order_notifier.dart`** - Core timeout detection and synthetic event creation
+- **`lib/data/models/mostro_message.dart`** - MostroMessage.createTimeoutReversal() factory
+- **`lib/shared/providers/time_provider.dart`** - Countdown timer system  
+- **`lib/shared/notifiers/session_notifier.dart`** - Session management
+- **`lib/features/trades/screens/trade_detail_screen.dart`** - Countdown UI
+
+---
+
+## Orphan Session Prevention System
+
+### Overview
+
+A comprehensive 10-second timeout cleanup system that prevents orphan sessions when Mostro instances are unresponsive or offline. This system provides dual protection for both order creation and order taking scenarios, working alongside the real-time timeout detection to provide comprehensive session management.
+
+### Implementation
+
+#### **10-Second Cleanup Timer**
+
+The system automatically starts cleanup timers for both order creation and order taking scenarios to prevent sessions from becoming orphaned if Mostro doesn't respond:
+
+**Order Taking Protection**:
+When users take orders, a cleanup timer is automatically started to prevent sessions from becoming orphaned if Mostro doesn't respond:
+
+```dart
+// lib/features/order/notifiers/abstract_mostro_notifier.dart - startSessionTimeoutCleanup method
+static void startSessionTimeoutCleanup(String orderId, Ref ref) {
+  // Cancel existing timer if any
+  _sessionTimeouts[orderId]?.cancel();
+  
+  _sessionTimeouts[orderId] = Timer(const Duration(seconds: 10), () {
+    try {
+      ref.read(sessionNotifierProvider.notifier).deleteSession(orderId);
+      Logger().i('Session cleaned up after 10s timeout: $orderId');
+      
+      // Show timeout message to user and navigate to order book
+      _showTimeoutNotificationAndNavigate(ref);
+    } catch (e) {
+      Logger().e('Failed to cleanup session: $orderId', error: e);
+    }
+    _sessionTimeouts.remove(orderId);
+  });
+  
+  Logger().i('Started 10s timeout timer for order: $orderId');
+}
+```
+
+#### **Timer Cancellation on Response**
+
+The cleanup timer is automatically cancelled when any response is received from Mostro:
+
+```dart
+// lib/features/order/notifiers/abstract_mostro_notifier.dart:92-93
+void handleEvent(MostroMessage event) {
+  // Cancel timer on ANY response from Mostro for this order
+  _cancelSessionTimeoutCleanup(orderId);
+  // ... rest of event handling
+}
+```
+
+**Order Creation Protection**:
+When users create new orders, a similar cleanup timer prevents orphan sessions if Mostro doesn't respond to the order creation request:
+
+```dart
+// lib/features/order/notifiers/abstract_mostro_notifier.dart
+static void startSessionTimeoutCleanupForRequestId(int requestId, Ref ref) {
+  final key = 'request:$requestId';
+  // Cancel existing timer if any
+  _sessionTimeouts[key]?.cancel();
+  
+  _sessionTimeouts[key] = Timer(const Duration(seconds: 10), () {
+    try {
+      ref.read(sessionNotifierProvider.notifier).deleteSessionByRequestId(requestId);
+      Logger().i('Session cleaned up after 10s timeout for requestId: $requestId');
+      
+      // Show timeout message to user and navigate to order book
+      _showTimeoutNotificationAndNavigate(ref);
+    } catch (e) {
+      Logger().e('Failed to cleanup session for requestId: $requestId', error: e);
+    }
+    _sessionTimeouts.remove(key);
+  });
+  
+  Logger().i('Started 10s timeout timer for requestId: $requestId');
+}
+```
+
+#### **Timer Integration**
+
+**Order Taking**:
+The cleanup timer is started automatically when users take orders:
+
+```dart
+// lib/features/order/notifiers/order_notifier.dart:107-108
+Future<void> takeSellOrder(String orderId, int? amount, String? lnAddress) async {
+  // ... session creation
+  
+  // Start 10s timeout cleanup timer for phantom session prevention
+  AbstractMostroNotifier.startSessionTimeoutCleanup(orderId, ref);
+  
+  await mostroService.takeSellOrder(orderId, amount, lnAddress);
+}
+```
+
+**Order Creation**:
+The cleanup timer is started automatically when users create orders:
+
+```dart
+// lib/features/order/notifiers/add_order_notifier.dart
+Future<void> submitOrder(Order order) async {
+  // ... session creation
+  
+  // Start 10s timeout cleanup timer for create orders
+  AbstractMostroNotifier.startSessionTimeoutCleanupForRequestId(requestId, ref);
+  
+  await mostroService.submitOrder(message);
+}
+```
+
+### User Experience
+
+#### **Timeout Notification and Navigation**
+
+When the 10-second timer expires, users receive a localized notification and are automatically navigated back to the order book:
+
+```dart
+// lib/features/order/notifiers/abstract_mostro_notifier.dart:381-393
+static void _showTimeoutNotificationAndNavigate(Ref ref) {
+  try {
+    // Show snackbar with localized timeout message
+    final notificationNotifier = ref.read(notificationActionsProvider.notifier);
+    notificationNotifier.showCustomMessage('sessionTimeoutMessage');
+    
+    // Navigate to main order book screen (home)
+    final navProvider = ref.read(navigationProvider.notifier);
+    navProvider.go('/');
+  } catch (e) {
+    Logger().e('Failed to show timeout notification or navigate', error: e);
+  }
+}
+```
+
+#### **Localized Messages**
+
+The system includes localized timeout messages in all supported languages:
+
+```json
+// English
+"sessionTimeoutMessage": "No response received, check your connection and try again later"
+
+// Spanish  
+"sessionTimeoutMessage": "No hubo respuesta, verifica tu conexión e inténtalo más tarde"
+
+// Italian
+"sessionTimeoutMessage": "Nessuna risposta ricevuta, verifica la tua connessione e riprova più tardi"
+```
+
+### Integration with Gift Wrap Detection
+
+The orphan session prevention system works in conjunction with the gift wrap-based timeout detection:
+
+1. **Gift wrap detection**: Processes direct timeout/cancellation instructions from Mostro via encrypted messages
+2. **10-second cleanup**: Acts as a fallback to prevent orphan sessions when Mostro is completely unresponsive
+3. **Dual protection**: Ensures sessions are cleaned up either through gift wrap instructions or automatic timeout
+4. **Differentiated handling**: Order creation uses `requestId`-based cleanup while order taking uses `orderId`-based cleanup
+
+### Timer Management
+
+#### **Static Timer Storage**
+
+```dart
+// Timer storage for phantom session cleanup
+// Keys: orderId for order taking, 'request:requestId' for order creation
+static final Map<String, Timer> _sessionTimeouts = {};
+```
+
+#### **Proper Cleanup on Disposal**
+
+```dart
+// For OrderNotifier (order taking)
+@override
+void dispose() {
+  subscription?.close();
+  // Cancel timer for this specific orderId if it exists
+  _sessionTimeouts[orderId]?.cancel();
+  _sessionTimeouts.remove(orderId);
+  super.dispose();
+}
+
+// For AddOrderNotifier (order creation)
+@override
+void dispose() {
+  // Cancel timer for requestId when notifier is disposed
+  AbstractMostroNotifier.cancelSessionTimeoutCleanupForRequestId(requestId);
+  super.dispose();
+}
+```
+
+This ensures that timers are properly cleaned up when notifiers are disposed to prevent memory leaks, with differentiated cleanup methods for each session type.
+
+### Key Differences: Order Creation vs Order Taking
+
+| **Aspect** | **Order Taking** | **Order Creation** |
+|------------|------------------|-------------------|
+| **Timer Method** | `startSessionTimeoutCleanup(orderId, ref)` | `startSessionTimeoutCleanupForRequestId(requestId, ref)` |
+| **Cleanup Method** | `deleteSession(orderId)` | `deleteSessionByRequestId(requestId)` |
+| **Timer Key** | `orderId` | `'request:${requestId}'` |
+| **Session Type** | Permanent (stored in database) | Temporary (memory only) |
+| **Storage Impact** | Deletes from Sembast database | Removes from memory map only |
+| **Use Case** | Taking existing orders | Creating new orders |
+
+**Last Updated**: October 8, 2025 
+

--- a/.specify/v1-reference/WALKTHROUGH_SCREEN.md
+++ b/.specify/v1-reference/WALKTHROUGH_SCREEN.md
@@ -32,6 +32,12 @@ When user taps "Done" or "Skip":
 2. `backupReminderProvider.showBackupReminder()` → activates the persistent backup notification (red dot on bell)
 3. Navigate to `/` (home screen)
 
+> **Pending in v2 — not yet implemented.** In v1, completing the walkthrough navigates
+> to `/community_selector` (first-launch node/community choice), and the redirect chain
+> only reaches `/` once a community is selected. v2 currently goes straight to `/` (step 3
+> above) — the community selector step is not built yet.
+> Target behavior: [MULTI_MOSTRO_SUPPORT.md](./MULTI_MOSTRO_SUPPORT.md#entry-point-1-first-launch-community-selector).
+
 ---
 
 ## Slides (6 pages)


### PR DESCRIPTION
  Re-syncs the v1-reference documentation:
  - Multi-mostro support and node selection
  - Dispute system, order filter and order limits
  - Relay sync and session cleanup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Days of use" filter to order book for filtering by maker account age.
  * Introduced configurable session retention presets (1 week–never; default 1 month).
  * Added Trade History card in settings for managing data retention.

* **Improvements**
  * Enhanced notification clarity for order cancellations based on context.
  * Optimized relay synchronization and session lifecycle handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->