### PR TITLE
 docs(transport-v2): add migration reference and implementation plan

### DIFF
--- a/.specify/v1-reference/TRANSPORT_V2_MIGRATION.md
+++ b/.specify/v1-reference/TRANSPORT_V2_MIGRATION.md
@@ -1,0 +1,190 @@
+# Transport v2 — NIP-44 Direct Messaging (Protocol Migration)
+
+How this app (appv2) adopts the Mostro **protocol-v2 transport** (NIP-44 direct,
+kind `14`), replacing protocol-v1 gift wrap (kind `1059`). This document is the
+**behavioural reference**: it explains the protocol change, how the canonical
+client (`mostro-cli`) implemented it on top of `mostro-core`, why `mostro-cli`
+— not the mobile app — is our reference, and why this app targets **protocol v2
+only** with no v1 compatibility.
+
+> **Two "v1/v2" axes — do not conflate them.** This folder documents *app* v1
+> (Mostro Mobile) as a reference for *app* v2 (this Rust + Flutter client).
+> This document instead concerns the *protocol* transport: *protocol* v1 (gift
+> wrap) → *protocol* v2 (NIP-44 direct). Throughout, "v1"/"v2" mean the
+> **protocol transport** unless prefixed with "app".
+
+> **Reference exception (deliberate).** Every other doc in this folder derives
+> from Mostro Mobile v1. This one derives from **`mostro-cli`** instead — see
+> §4 for why. Mobile's transport implementation is *not* a useful reference for
+> us because mobile does not use `mostro-core`.
+
+> **Status — pending in v2.** This app is still on `mostro-core 0.10` and speaks
+> protocol v1 today. This document is the parity/design reference for the
+> migration; the concrete, repo-specific implementation plan lives in the specs
+> (`specs/005-transport-v2-migration/`).
+
+> **Scope.** The transport is a **protocol-level** change to the *envelope only*.
+> The logical Mostro messages, the action set, payload shapes and key derivation
+> are identical across v1 and v2. NIP-17 peer-to-peer chat and dispute-admin chat
+> are **out of scope** — they stay on gift wrap (§7).
+
+---
+
+## 1. Why the protocol is changing
+
+Mostro historically used NIP-59 gift wrap (kind `1059`) as its only transport.
+Gift wraps give strong metadata privacy but are *opaque*: the outer event is
+signed by a random throwaway key, so neither relays nor the daemon can tell
+legitimate traffic from spam without paying the full NIP-44 decrypt cost. That
+exposes Mostro to spam floods relays cannot rate-limit by sender ("Gift Wrap
+Apocalypse").
+
+Protocol **v2** trades a bounded amount of metadata for abuse-resistance: a
+signed kind-`14` event whose content is NIP-44 encrypted, **authored by the
+trade key**. Because trade keys are already single-trade and rotated, exposing
+one leaks little — while it lets relays rate-limit by sender and lets the daemon
+pre-validate cheaply before decrypting.
+
+- **Official source:** https://mostro.network/protocol/transport_migration.html
+- **Daemon spec:** mostro issue #626; `mostro-core#152` (the `transport` module,
+  released in **mostro-core 0.13.0**).
+
+## 2. Wire format: v1 vs v2
+
+| | protocol v1 (`gift-wrap`) | protocol v2 (`nip44`) |
+|---|---|---|
+| event kind | `1059` | `14` |
+| outer author | throwaway ephemeral key | **the trade key** (signature load-bearing) |
+| layers | rumor (k1) → seal (k13) → wrap (k1059) | single k14 event, NIP-44 encrypted content |
+| inner payload | 2-tuple `[message, tradeSig?]` | 3-tuple `[message, tradeSig?, identityProof?]` |
+| identity proof | carried inside the seal | carried **inside** the NIP-44 ciphertext |
+| `message.version` | `1` | `2` |
+| expiration | none | NIP-40 `expiration` tag (default 30 days) |
+
+The v2 **identity proof** (3rd tuple element) is `["<identity pubkey>",
+"<identity sig>"]`, or `null` for full-privacy mode. The signature is over a
+domain-tagged payload binding the proof to the authoring trade key:
+
+```text
+mostro-transport-v2-identity:<trade pubkey hex>:<message JSON>
+```
+
+**All of the above is implemented by `mostro-core` 0.13.0** — tuple building,
+identity proof, NIP-44 encryption, event signing, and signature verification on
+receive. A client on `mostro-core` does not write any of it (this is the crux
+of §4).
+
+## 3. Capability discovery (and why we don't use it)
+
+Nodes advertise their transport in the kind-`38385` instance-info event:
+
+```text
+["protocol_version", "1"]   → gift wrap (kind 1059), DEPRECATED
+["protocol_version", "2"]   → NIP-44 direct (kind 14)
+(tag absent)                → legacy daemon → treat as v1
+```
+
+Clients meant to bridge the migration window read this tag and pick the wire
+format per node. **This app does not** — it is v2-only (§5), so it neither
+parses `protocol_version` nor resolves a per-node transport.
+
+## 4. Why `mostro-cli` is the reference, not mobile
+
+| | uses `mostro-core`? | what its transport code is |
+|---|---|---|
+| **this app (appv2)** | **yes** (Rust core) | thin wiring over `mostro-core` |
+| **`mostro-cli`** | **yes** (Rust) | thin wiring over `mostro-core` — *our analogue* |
+| **mobile** | **no** | hand-rolled crypto in Dart |
+
+Mobile reimplements the entire transport by hand in Dart — building the 3-tuple,
+computing the identity proof, signing, NIP-44 encrypting, verifying event
+signatures. None of that maps to this app, because `mostro-core` already does
+it. Copying mobile would mean reimplementing the library.
+
+`mostro-cli` solved the *same* problem we have: it consumes `mostro-core`'s
+`transport` module and only wires it into send/receive. Its code shows the exact
+APIs and call patterns we will use.
+
+## 5. Decision: protocol v2 only (no dual v1/v2 support)
+
+`mostro-cli` and mobile both implement **dual** v1+v2 support and auto-detect per
+node. That is a **transition safeguard for real users** who may connect to a not-
+yet-upgraded daemon. This app has no such constraint:
+
+- it is **in development with no users**, and
+- the Mostro node it targets **already runs protocol v2**.
+
+So dual support would be dead code. This app implements **protocol v2 only**,
+which is also where the ecosystem lands at mostrod **v0.19.0** (v1 removed
+entirely). Consequences vs. the dual design:
+
+| Dual-support concern | In this app (v2-only) |
+|---|---|
+| `Transport` enum + per-node resolution | **removed** — always v2 |
+| `protocol_version` parse (kind 38385) | **removed** |
+| version-skew guard / downgrade logging | **removed** |
+| dual subscription / re-subscribe | subscribe to kind `14` only, author-pinned |
+| `version` field derived from transport | constant `2` |
+
+No log/guard for a v1 node is kept: the target node only speaks v2 (decision
+confirmed with the maintainer).
+
+## 6. How `mostro-cli` implemented it (the reference)
+
+All transport APIs come from `mostro_core::prelude::*`. The wiring:
+
+| Concern | `mostro-cli` location | `mostro-core` API |
+|---|---|---|
+| Send (wrap + publish) | `src/util/messaging.rs` (`publish_wrapped`) | `wrap_message_with(transport, msg, identity_keys, trade_keys, receiver, WrapOptions { pow, expiration, signed })` |
+| Receive (unwrap) | `src/parser/dms.rs` (`parse_dm_events`) | `unwrap_incoming(event, keys)` → `UnwrappedMessage` (dispatches by kind) |
+| Subscription kind | `src/util/messaging.rs` (`wait_for_dm`) | `transport.event_kind()` (1059 / 14) |
+| Transport selection | `src/cli.rs` (`resolve_transport`) | `Transport::from_str`, default `GiftWrap` |
+| `protocol_version` probe | `src/util/events.rs` (`fetch_protocol_version_with`) | reads kind-38385 tag |
+
+Two patterns from `mostro-cli` matter to us even though we drop its dual logic:
+
+1. **v2 kind-14 must pin the author.** kind `14` is shared with NIP-17 peer chat,
+   so the receive filter pins `authors = [mostro_pubkey]` and re-checks
+   `event.pubkey == mostro_pubkey` on each event (`wait_for_dm`). A v2 Mostro
+   reply is authored by Mostro and `p`-tagged to the trade key.
+2. **Mostro traffic and peer chat are unwrapped on separate paths.**
+   `parse_dm_events` routes Mostro messages through `unwrap_incoming`, but peer
+   chat through its own decrypt path — never `unwrap_incoming`. This keeps peer
+   chat from being misparsed as a Mostro message now that both are kind 14.
+
+For full-privacy mode, `mostro-cli` passes the same `Keys` for both identity and
+trade — identical to v1 and to this app's current behaviour.
+
+## 7. What stays on gift wrap (unchanged)
+
+NIP-17 peer-to-peer chat and dispute-admin chat are **not** part of this
+migration. In this app these are the local `wrap` / `unwrap` helpers in
+`rust/src/nostr/gift_wrap.rs` (used by `api/messages.rs` and `api/disputes.rs`).
+They keep using kind `1059`. v2 Mostro kind-14 traffic is disambiguated from
+peer chat by **author = Mostro pubkey** + `p` tag (§6). All three clients
+(mobile, `mostro-cli`, this app) agree chat is out of scope.
+
+## 8. What this means for this app (high level)
+
+The detailed, ordered implementation plan lives in the specs
+(`specs/005-transport-v2-migration/`). At a glance, the work is almost entirely
+Rust-side and small once `mostro-core` is current:
+
+1. **Bump `mostro-core` 0.10 → 0.13.0** — the real bulk (the `0.10`→`0.13`
+   breaking changes), independent of the transport switch.
+2. **Switch the two Mostro-protocol functions** in `rust/src/nostr/gift_wrap.rs`
+   (`wrap_mostro_message` / `unwrap_mostro_message`) to the `mostro-core` v2
+   path (`wrap_message_with` / `unwrap_incoming`), with a NIP-40 expiration.
+3. **Make the subscription kind-14 + author-pinned** in
+   `rust/src/nostr/relay_pool.rs` (today hard-codes `KIND_GIFT_WRAP = 1059`).
+4. **Leave the peer-chat `wrap`/`unwrap` helpers untouched** (§7).
+
+The Dart layer is essentially untouched: with v2-only there is no
+`protocol_version` parsing or transport resolution to add.
+
+---
+
+**Sources**
+- Official: https://mostro.network/protocol/transport_migration.html
+- Daemon: mostro issue #626; `mostro-core#152` (transport module, 0.13.0)
+- Reference client: `MostroP2P/mostro-cli` (PRs #176–#178)

--- a/.specify/v1-reference/TRANSPORT_V2_MIGRATION.md
+++ b/.specify/v1-reference/TRANSPORT_V2_MIGRATION.md
@@ -59,7 +59,7 @@ pre-validate cheaply before decrypting.
 | inner payload | 2-tuple `[message, tradeSig?]` | 3-tuple `[message, tradeSig?, identityProof?]` |
 | identity proof | carried inside the seal | carried **inside** the NIP-44 ciphertext |
 | `message.version` | `1` | `2` |
-| expiration | none | NIP-40 `expiration` tag (default 30 days) |
+| expiration | none | NIP-40 `expiration` tag (default 30 days, filled by the daemon; this app sends `expiration: None` — see §8) |
 
 The v2 **identity proof** (3rd tuple element) is `["<identity pubkey>",
 "<identity sig>"]`, or `null` for full-privacy mode. The signature is over a
@@ -174,7 +174,8 @@ Rust-side and small once `mostro-core` is current:
    breaking changes), independent of the transport switch.
 2. **Switch the two Mostro-protocol functions** in `rust/src/nostr/gift_wrap.rs`
    (`wrap_mostro_message` / `unwrap_mostro_message`) to the `mostro-core` v2
-   path (`wrap_message_with` / `unwrap_incoming`), with a NIP-40 expiration.
+   path (`wrap_message_with` / `unwrap_incoming`), with `expiration: None` (the
+   daemon fills its own; see spec FR-005).
 3. **Make the subscription kind-14 + author-pinned** in
    `rust/src/nostr/relay_pool.rs` (today hard-codes `KIND_GIFT_WRAP = 1059`).
 4. **Leave the peer-chat `wrap`/`unwrap` helpers untouched** (§7).

--- a/.specify/v1-reference/TRANSPORT_V2_MIGRATION.md
+++ b/.specify/v1-reference/TRANSPORT_V2_MIGRATION.md
@@ -47,7 +47,7 @@ pre-validate cheaply before decrypting.
 
 - **Official source:** https://mostro.network/protocol/transport_migration.html
 - **Daemon spec:** mostro issue #626; `mostro-core#152` (the `transport` module,
-  released in **mostro-core 0.13.0**).
+  released in **mostro-core 0.13.0**; this app pins **0.13.1**, the latest patch).
 
 ## 2. Wire format: v1 vs v2
 
@@ -170,7 +170,7 @@ The detailed, ordered implementation plan lives in the specs
 (`specs/005-transport-v2-migration/`). At a glance, the work is almost entirely
 Rust-side and small once `mostro-core` is current:
 
-1. **Bump `mostro-core` 0.10 → 0.13.0** — the real bulk (the `0.10`→`0.13`
+1. **Bump `mostro-core` 0.10 → 0.13.1** — the real bulk (the `0.10`→`0.13`
    breaking changes), independent of the transport switch.
 2. **Switch the two Mostro-protocol functions** in `rust/src/nostr/gift_wrap.rs`
    (`wrap_mostro_message` / `unwrap_mostro_message`) to the `mostro-core` v2

--- a/specs/005-transport-v2-migration/plan.md
+++ b/specs/005-transport-v2-migration/plan.md
@@ -1,0 +1,92 @@
+# Implementation Plan: Transport v2 — NIP-44 Direct Messaging
+
+**Branch**: `005-transport-v2-migration` | **Date**: 2026-06-19 | **Spec**: [spec.md](spec.md)
+**Reference**: [`.specify/v1-reference/TRANSPORT_V2_MIGRATION.md`](../../.specify/v1-reference/TRANSPORT_V2_MIGRATION.md)
+
+## Summary
+
+Migrate this app's Mostro-protocol transport from gift wrap (kind 1059) to NIP-44
+direct (kind 14), targeting **protocol v2 only**. The heavy lifting is in
+`mostro-core` 0.13.x (the `transport` module); this app only re-wires its two
+Mostro wrap/unwrap call paths and its three kind-1059 subscriptions. Peer chat stays
+on gift wrap. Delivered as **two PRs**: (1) the `mostro-core` 0.10 → 0.13.1 bump,
+(2) the transport switch.
+
+## Technical Context
+
+**Language/Version**: Rust stable 1.94+ (core); Dart 3.x / Flutter 3.x (UI shell)
+**Key Dependency Change**: `mostro-core` 0.10.0 → **0.13.1**
+**New APIs used** (from `mostro_core::prelude`): `Transport::Nip44Direct`,
+`wrap_message_with`, `unwrap_incoming` (`WrapOptions` reused from nip59).
+**Testing**: `cargo test && cargo clippy` (per CLAUDE.md)
+**FRB**: No regen — changes are internal to `crate::nostr`, not `crate::api`.
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| **I. Rust Core, Flutter Shell** | ✅ PASS | All transport logic stays in Rust; Dart untouched. |
+| **II. Privacy by Design** | ✅ PASS | Identity privacy unchanged (proof inside NIP-44 ciphertext). v2 exposes only the ephemeral trade key's activity — accepted, bounded by per-trade rotation. |
+| **III. Protocol Compliance** | ⚠️ DEVIATION (justified) | v2-only means **not** interoperable with v1 daemons. Justified: no users, target node is v2, aligned with mostrod v0.19.0 (v1 removed). Recorded in reference doc §5. |
+| **VI. Simplicity Over Features** | ✅ PASS | Dropping dual support removes an enum, per-node resolution, and the `protocol_version` parse path. |
+| **VII. V1 UX is Non-Negotiable** | ✅ PASS | No UX change; transport is invisible to the user. |
+
+## Phase 1 — Bump `mostro-core` 0.10.0 → 0.13.1 (PR #1)
+
+Prerequisite, isolated from the transport feature. The gift-wrap path stays in place,
+so the app compiles and tests pass; it is **not** E2E-functional against the v2 node
+yet (acceptable: no users, dev). Audit findings in [research.md](research.md).
+
+1. `rust/Cargo.toml` — `mostro-core = "0.13.1"`.
+2. Fix the **only** compile breakage: `map_core_status` (`api/orders.rs`) is an
+   exhaustive match; `order::Status` adds `WaitingTakerBond` / `WaitingMakerBond`
+   (purely additive). Add an explicit arm `S::WaitingTakerBond | S::WaitingMakerBond
+   => return None` (bond is out of scope; no wildcard, to keep exhaustiveness).
+3. `cargo build && cargo test && cargo clippy` green. (Note: `PROTOCOL_VER` becomes 2
+   automatically; messages are version 2 even while still gift-wrapped — irrelevant,
+   the v2 node ignores kind 1059.)
+
+## Phase 2 — Transport switch to v2 (PR #2)
+
+Mechanical, ~2 files. Mirrors `mostro-cli` (the reference).
+
+### Send
+
+4. `rust/src/nostr/gift_wrap.rs` (`wrap_mostro_message`): replace `nip59::wrap_message`
+   with `wrap_message_with(Transport::Nip44Direct, msg, identity_keys, trade_keys,
+   *receiver, WrapOptions { pow, expiration: None, signed: true })`.
+
+### Receive
+
+5. `rust/src/nostr/gift_wrap.rs` (`unwrap_mostro_message`): replace `nip59::unwrap_message`
+   with `unwrap_incoming(event, trade_keys)`.
+
+### Subscriptions (kind 14 + author-pin) — three filters
+
+6. `rust/src/nostr/relay_pool.rs` (`subscribe_order_and_dm_feeds`): dm_filter →
+   `Kind::PrivateDirectMessage` (14) + `.author(mostro_pubkey)` (already available).
+7. `rust/src/api/orders.rs` (`subscribe_gift_wraps`): filter → kind 14 + `.author(...)`;
+   fetch `mostro_pubkey` via `crate::config::active_mostro_pubkey()`.
+8. `rust/src/api/orders.rs` (global bulk sub): `gw_filter` → kind 14 + `.author(...)`
+   (`mostro_pubkey` already in scope).
+
+### Receive handlers (kind check + author re-check) — three sites
+
+9. `api/orders.rs` per-trade handler, global handler, and the global event loop:
+   change `event.kind == 1059` checks to kind 14 **and** reject events where
+   `event.pubkey != mostro_pubkey` (disambiguate from peer chat).
+
+### Untouched
+
+10. `gift_wrap.rs` local `wrap`/`unwrap` (peer/dispute chat) stay on kind 1059.
+
+### Verify
+
+11. Update `gift_wrap.rs` tests (assert kind 14 + author = trade key instead of
+    `Kind::GiftWrap`). `cargo test && cargo clippy` green. Manual E2E lifecycle vs
+    the v2 node.
+
+## Complexity Tracking
+
+The only deliberate complexity/deviation is **Constitution III** (v2-only, not
+v1-interoperable) — justified above and in the reference doc.

--- a/specs/005-transport-v2-migration/research.md
+++ b/specs/005-transport-v2-migration/research.md
@@ -1,0 +1,55 @@
+# Research: Transport v2 Migration
+
+Findings grounding [plan.md](plan.md). All verified against `mostro-core` tags
+0.10.0 ↔ 0.13.1, `mostro-cli` (reference client), and this app's source.
+
+## R1 — `mostro-core` 0.10.0 → 0.13.1 breaking-change audit
+
+- **nip59 API is unchanged** across the range: `wrap_message`, `unwrap_message`,
+  `WrapOptions`, `UnwrappedMessage`, `validate_response` keep identical signatures.
+  → the existing gift-wrap path compiles untouched after the bump.
+- **Only one compile breakage**: `map_core_status` (`api/orders.rs`). `order::Status`
+  gains `WaitingTakerBond` + `WaitingMakerBond` (additive, no renames/removals); the
+  exhaustive match without a wildcard fails until those arms are added.
+- Other used symbols stable: `Payload::{Order,PaymentRequest,CantDo}` (same arity),
+  `MostroError::MostroCantDo`, `new_order`/`new_dm`.
+- **`PROTOCOL_VER`** = 1 through 0.12.1, → **2 at 0.13.0**. Stamped automatically by
+  `MessageKind::new`; the app never sets `version` by hand.
+
+## R2 — Why jump straight to 0.13.1 (not via 0.12.1)
+
+The `transport` module exists **only from 0.13.0**; 0.12.1 lacks it and keeps
+`PROTOCOL_VER = 1`, so it is a useless intermediate. nip59 API stability means no
+risk-isolation benefit to stepping. Decision: **0.13.1** (latest patch).
+
+## R3 — Transport API surface (0.13.1, via `mostro_core::prelude`)
+
+`Transport { GiftWrap, Nip44Direct }`; `Transport::Nip44Direct.event_kind()` =
+`Kind::PrivateDirectMessage` (kind 14). `wrap_message_with(transport, msg,
+identity_keys, trade_keys, receiver, WrapOptions)`. `unwrap_incoming(event, keys)`
+dispatches by event kind and returns `UnwrappedMessage` (same type as today).
+
+## R4 — Subscription / receive sites in this app (Q1)
+
+`mostro_pubkey` source: `crate::config::active_mostro_pubkey()`. Three kind-1059
+subscriptions and three receive handlers to migrate:
+
+| Site | File | mostro_pubkey present? |
+|---|---|---|
+| bulk DM sub | `relay_pool.rs` (`subscribe_order_and_dm_feeds`) | yes |
+| per-trade sub | `orders.rs` (`subscribe_gift_wraps`) | add helper call |
+| global bulk sub | `orders.rs` (global loop) | yes |
+| 3 receive handlers | `orders.rs` (per-trade / global / event loop) | — change kind check + author re-check |
+
+## R5 — Expiration on outgoing v2 events (Q2)
+
+`mostro-cli` passes `expiration: None` for all command DMs to Mostro; the daemon fills
+its own outgoing expiration from `dm_days`. The anti-spam gate does not require an
+expiration on incoming events. Decision: **`expiration: None`**.
+
+## R6 — flutter_rust_bridge (Q3)
+
+FRB scans `rust_input: "crate::api"`. `gift_wrap.rs` / `relay_pool.rs` are in
+`crate::nostr` and absent from `frb_generated.rs`. The transport switch changes only
+function bodies in `crate::api`, not signatures, and the FRB boundary uses `api::types`
+(not mostro-core types). → **No regen needed.**

--- a/specs/005-transport-v2-migration/spec.md
+++ b/specs/005-transport-v2-migration/spec.md
@@ -1,0 +1,78 @@
+# Feature Specification: Transport v2 — NIP-44 Direct Messaging
+
+**Feature Branch**: `005-transport-v2-migration` (impl. across git branches `chore/mostro-core-0.13` → `feat/transport-v2`)
+**Created**: 2026-06-19
+**Status**: Draft
+**Input**: Adopt the Mostro protocol-v2 transport (NIP-44 direct, kind 14), replacing
+protocol-v1 gift wrap (kind 1059). This app targets **protocol v2 only** — no dual
+support. Behavioural reference: `.specify/v1-reference/TRANSPORT_V2_MIGRATION.md`.
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Trade against a protocol-v2 node (Priority: P1)
+
+A user creates, takes, and progresses orders against a Mostro node running protocol
+v2. Every Mostro-protocol message (commands sent and daemon replies received) travels
+as a signed kind-14 NIP-44 event authored by the trade key, instead of a kind-1059
+gift wrap. The user experiences no functional difference — the same orders, actions,
+and chat work end to end.
+
+**Why this priority**: The target node speaks only protocol v2. Without this, the app
+cannot send to or receive from the daemon at all — it is non-functional.
+
+**Independent Test**: Run a full order lifecycle (new-order → take → pay → fiat-sent →
+release) against a v2 node and confirm every command is delivered and every reply is
+received and parsed.
+
+**Acceptance Scenarios**:
+
+1. **Given** a v2 node, **When** the app sends any Mostro command, **Then** it is
+   published as a kind-14 event authored by the trade key, NIP-44 encrypted to the
+   node, with `version: 2` in the message and a `p` tag to the node.
+2. **Given** a v2 node, **When** the daemon replies, **Then** the app receives the
+   kind-14 event (authored by the node, `p`-tagged to the trade key), decrypts it,
+   and routes the message exactly as it did under gift wrap.
+3. **Given** an incoming kind-14 event **not** authored by the node, **When** received
+   on a trade-key subscription, **Then** it is ignored as a Mostro reply (it is peer
+   chat, handled separately).
+
+### User Story 2 — Peer-to-peer chat is unaffected (Priority: P1)
+
+A user in an active trade exchanges encrypted chat messages with the counterparty and
+(if disputed) with an admin. This traffic continues to use NIP-59 gift wrap (kind 1059)
+and is unchanged by the transport migration.
+
+**Why this priority**: Regression guard. The migration must not break existing chat.
+
+**Independent Test**: Exchange peer-chat messages during an active trade; confirm
+delivery and decryption are unchanged.
+
+**Acceptance Scenarios**:
+
+1. **Given** an active trade, **When** a peer chat message is sent, **Then** it is
+   still wrapped as a kind-1059 gift wrap and delivered/decrypted as before.
+
+---
+
+## Requirements *(mandatory)*
+
+- **FR-001**: All Mostro-protocol traffic (typed `Message`) MUST use protocol v2
+  (kind 14, NIP-44 direct) on both send and receive.
+- **FR-002**: The app MUST NOT retain any protocol-v1 (gift-wrap) path for Mostro
+  traffic, and MUST NOT parse `protocol_version` or resolve a per-node transport.
+- **FR-003**: Incoming kind-14 Mostro replies MUST be disambiguated from NIP-17 peer
+  chat by author = node pubkey (subscription author-pin + per-event re-check).
+- **FR-004**: NIP-17 peer-to-peer chat and dispute-admin chat MUST remain on gift
+  wrap (kind 1059), unchanged.
+- **FR-005**: Outgoing v2 events MUST carry no NIP-40 expiration tag (`expiration:
+  None`), mirroring the reference client; the daemon fills its own.
+- **FR-006**: Full-privacy mode MUST behave as today (identity key = trade key).
+
+## Out of Scope
+
+- Dual v1/v2 support, `protocol_version` auto-detection, transport selection UI.
+- Peer / dispute chat transport.
+- Mostro message logic, action set, payload shapes, key derivation (unchanged).
+- Anti-abuse bond (separate feature; see `ANTI_ABUSE_BOND.md`).

--- a/specs/005-transport-v2-migration/tasks.md
+++ b/specs/005-transport-v2-migration/tasks.md
@@ -1,0 +1,34 @@
+# Tasks: Transport v2 — NIP-44 Direct Messaging
+
+**Input**: Design documents from `specs/005-transport-v2-migration/`
+**Prerequisites**: spec.md ✅, plan.md ✅, research.md ✅
+
+**Tests**: Existing `gift_wrap.rs` unit tests are updated (not new test tasks).
+
+**Organization**: Two phases = two PRs. Phase 2 depends on Phase 1.
+
+## Phase 1 — mostro-core bump (PR #1: `chore/mostro-core-0.13`)
+
+- [ ] T001 Set `mostro-core = "0.13.1"` in `rust/Cargo.toml`; update `Cargo.lock`.
+- [ ] T002 Fix `map_core_status` in `rust/src/api/orders.rs`: add explicit arm
+      `S::WaitingTakerBond | S::WaitingMakerBond => return None` (no wildcard).
+- [ ] T003 Run `cargo build && cargo test && cargo clippy`; resolve any residual
+      fallout surfaced by the compiler. **Checkpoint**: green, app still on gift wrap.
+
+## Phase 2 — transport switch (PR #2: `feat/transport-v2`)
+
+- [ ] T004 `gift_wrap.rs::wrap_mostro_message` → `wrap_message_with(Transport::Nip44Direct,
+      …, WrapOptions { pow, expiration: None, signed: true })`.
+- [ ] T005 `gift_wrap.rs::unwrap_mostro_message` → `unwrap_incoming(event, trade_keys)`.
+- [ ] T006 [P] `relay_pool.rs::subscribe_order_and_dm_feeds` dm_filter → kind 14 +
+      `.author(mostro_pubkey)`.
+- [ ] T007 [P] `orders.rs::subscribe_gift_wraps` filter → kind 14 + `.author(...)`
+      (resolve `mostro_pubkey` via `config::active_mostro_pubkey()`).
+- [ ] T008 [P] `orders.rs` global bulk `gw_filter` → kind 14 + `.author(...)`.
+- [ ] T009 Update the three receive handlers in `orders.rs` (per-trade, global,
+      event loop): kind-14 check + reject `event.pubkey != mostro_pubkey`.
+- [ ] T010 Update `gift_wrap.rs` tests: assert kind 14 + author = trade key.
+- [ ] T011 Leave local `wrap`/`unwrap` (peer/dispute chat, kind 1059) untouched —
+      regression-verify peer chat still works.
+- [ ] T012 `cargo test && cargo clippy` green; manual E2E order lifecycle vs the v2
+      node. **Checkpoint**: full trade flow works on protocol v2.


### PR DESCRIPTION
Documentation only , no code changes. Groundwork for the protocol gift-wrap (kind 1059) → NIP-44 direct (kind 14) transport migration.

  - `.specify/v1-reference/TRANSPORT_V2_MIGRATION.md` — behavioural reference:
    the wire-format change, how mostro-cli wired it over mostro-core, why mostro-cli (not mobile) is the reference, and why this app targets protocol v2 only (no dual v1/v2 support).
  - `specs/005-transport-v2-migration/` — spec-kit plan (spec.md, plan.md, research.md, tasks.md). Two-PR implementation: bump mostro-core 0.10 → 0.13.1, then switch the transport.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive migration specification and planning documentation for protocol transport upgrade. Includes research findings, implementation plan, feature specification, and task breakdown for transitioning to the latest protocol version. Documentation covers backward-compatibility approach, relay subscription updates, and regression testing strategy for peer communication channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->