### PR TITLE
chore(deps): bump mostro-core 0.10 to 0.13.1

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1616,9 +1616,9 @@ dependencies = [
 
 [[package]]
 name = "mostro-core"
-version = "0.10.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76f4936f520e410ba2abf47113548ae231322209261a9b3a8aefbd10a869082"
+checksum = "f9203616a4dbad09ac504d6e29348f2dbef78d96c2d47b2413e1efb0273ef5f4"
 dependencies = [
  "bitcoin",
  "chrono",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,7 +11,7 @@ flutter_rust_bridge = "=2.11.1"
 
 # Nostr & Mostro protocol
 nostr-sdk = { version = "0.44", default-features = false, features = ["nip44", "nip47", "nip59"] }
-mostro-core = "0.10"
+mostro-core = "0.13.1"
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -1541,6 +1541,10 @@ fn map_core_status(s: mostro_core::order::Status) -> Option<OrderStatus> {
         S::SettledByAdmin => OrderStatus::SettledByAdmin,
         S::CompletedByAdmin => OrderStatus::CompletedByAdmin,
         S::Dispute => OrderStatus::Dispute,
+        // Anti-abuse bond is out of scope; these statuses have no local
+        // OrderStatus mapping. No wildcard, so future Status variants keep
+        // forcing this match to be revisited.
+        S::WaitingTakerBond | S::WaitingMakerBond => return None,
     })
 }
 


### PR DESCRIPTION
  Bumps `mostro-core` from 0.10.0 to 0.13.1, bringing in the `transport` module (kind-14 NIP-44 direct messaging). This is the isolated dependency bump — **PR #1 of 2** for the protocol v2 migration (spec `005-transport-v2-migration`). The actual transport switch lands in the follow-up `feat/transport-v2`.

  The app still speaks protocol v1 (gift wrap, kind 1059) after this PR; it compiles and tests pass but is not yet E2E-functional against the v2 node.

  ## Changes

  - `rust/Cargo.toml` / `Cargo.lock` — `mostro-core = "0.13.1"`
  - `rust/src/api/orders.rs` — fix the only compile breakage in `map_core_status`: `order::Status` gains the additive `WaitingTakerBond` and `WaitingMakerBond` variants. Both map to `None` (anti-abuse bond is out of scope), with no wildcard arm so future `Status` variants keep forcing the match to be revisited.

  ## Why straight to 0.13.1

  The `transport` module exists only from 0.13.0; 0.12.1 lacks it and keeps `PROTOCOL_VER = 1`, so stepping through it adds no value. 0.13.1 is the latest patch.

  ## Verification

  - `nip59` wrap/unwrap signatures and `WrapOptions` are unchanged across the range → gift-wrap path compiles and behaves identically.
  - No transitive `nostr-sdk` bump (stays 0.44.1).
  - `cargo build` ✓ · `cargo test` ✓ (81 passed) · `cargo clippy` ✓ (0 errors).
  - No FRB regen — changes are internal to `crate::api`, signatures unchanged.

  ## Scope

  Out of scope (→ `feat/transport-v2`): the gift_wrap.rs wrap/unwrap switch, kind-14 subscriptions + author-pin, receive-handler changes. Peer/dispute chat stays on gift wrap throughout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core dependencies to the latest stable version for improved system stability and security
  * Enhanced internal status handling for increased reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->