### PR TITLE
feat(transport): switch Mostro protocol traffic to NIP-44 direct (kind 14)

### DIFF
--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -928,10 +928,11 @@ pub async fn cancel_order(order_id: String) -> Result<()> {
     Ok(())
 }
 
-// ── Gift-wrap (Kind 1059) subscription ───────────────────────────────────────
+// ── Mostro reply (Kind 14, protocol v2) subscription ─────────────────────────
 
-/// Subscribe to NIP-59 Gift Wrap (Kind 1059) events addressed to a maker's
-/// trade key, spawning a background task that decrypts daemon responses.
+/// Subscribe to kind-14 NIP-44 Mostro replies (authored by the node) addressed
+/// to a maker's trade key, spawning a background task that decrypts daemon
+/// responses.
 ///
 /// Called immediately after creating a new maker order. Handles:
 /// - `Action::NewOrder` — daemon confirmed the order; bridges daemon UUID into
@@ -957,12 +958,24 @@ pub(crate) async fn subscribe_gift_wraps(trade_pubkey: nostr_sdk::PublicKey, tra
     };
     let client = pool.client();
 
+    let mostro_pubkey =
+        match nostr_sdk::PublicKey::from_hex(&crate::config::active_mostro_pubkey()) {
+            Ok(pk) => pk,
+            Err(e) => {
+                log::error!("[orders] subscribe_gift_wraps: invalid mostro pubkey: {e}");
+                return;
+            }
+        };
+
     // Obtain the notifications receiver BEFORE subscribing to avoid a
     // window where daemon responses arrive but aren't captured.
     let mut rx = client.notifications();
 
+    // Protocol v2: kind-14 NIP-44 replies authored by Mostro, p-tagged to
+    // this trade key.
     let filter = nostr_sdk::Filter::new()
-        .kind(nostr_sdk::Kind::from(1059u16))
+        .kind(nostr_sdk::Kind::PrivateDirectMessage)
+        .author(mostro_pubkey)
         .pubkey(trade_pubkey);
     if let Err(e) = client.subscribe(filter, None).await {
         log::warn!("[orders] subscribe_gift_wraps subscribe failed: {e}");
@@ -992,7 +1005,12 @@ pub(crate) async fn subscribe_gift_wraps(trade_pubkey: nostr_sdk::PublicKey, tra
 
             match timeout(remaining, rx.recv()).await {
                 Ok(Ok(RelayPoolNotification::Event { event, .. })) => {
-                    if event.kind != nostr_sdk::Kind::from(1059u16) {
+                    if event.kind != nostr_sdk::Kind::PrivateDirectMessage {
+                        continue;
+                    }
+                    // Disambiguate Mostro replies from NIP-17 peer chat (also
+                    // kind 14): only the node may author a Mostro reply.
+                    if event.pubkey != mostro_pubkey {
                         continue;
                     }
                     let is_for_us = event.tags.iter().any(|t| {
@@ -1009,7 +1027,7 @@ pub(crate) async fn subscribe_gift_wraps(trade_pubkey: nostr_sdk::PublicKey, tra
                         continue;
                     }
                     crate::api::logging::blog_info("gift-wrap", format!(
-                        "Kind 1059 received (per-trade) for trade={} from={} event_id={}",
+                        "Kind 14 received (per-trade) for trade={} from={} event_id={}",
                         &trade_pubkey_hex[..8],
                         &event.pubkey.to_hex()[..8],
                         &eid[..16],
@@ -1046,13 +1064,13 @@ pub(crate) async fn subscribe_gift_wraps(trade_pubkey: nostr_sdk::PublicKey, tra
     });
 }
 
-/// Dispatch a Mostro `Message` recovered from a gift-wrap.
+/// Dispatch a Mostro `Message` recovered from a kind-14 NIP-44 reply.
 ///
 /// The caller recovers the `UnwrappedMessage` via
-/// `crate::nostr::gift_wrap::unwrap_mostro_message`, which verifies the seal
-/// signature so the `identity` field is cryptographically attributable.
-/// This function authenticates that seal signer's `identity` against the
-/// active Mostro pubkey (never the self-asserted rumor `sender`), runs the
+/// `crate::nostr::gift_wrap::unwrap_mostro_message`, which verifies the kind-14
+/// event signature so the `identity` field is cryptographically attributable.
+/// This function authenticates that `identity` against the active Mostro pubkey
+/// (defense-in-depth behind the receive handler's author pin), runs the
 /// centralized `validate_response` check (catches `CantDo` responses and
 /// malformed `request_id` fields), then routes by action.
 async fn dispatch_mostro_message(
@@ -1062,19 +1080,16 @@ async fn dispatch_mostro_message(
 ) {
     use mostro_core::message::Action;
 
-    // mostro-core 0.10 splits the wrap into two pubkeys:
+    // The protocol-v2 unwrap exposes two pubkeys:
     //
-    //   * `identity` — seal signer, proven by `seal.verify_signature()` in
-    //     `unwrap_message`. This is the only field a forger cannot spoof.
-    //   * `sender`   — rumor author. Self-asserted unless an inner
-    //     `signature` is present and verifies against the rumor pubkey.
+    //   * `identity` — the proven identity-proof pubkey, or the event author
+    //     itself when no proof is attached. Mostro's replies carry no proof,
+    //     so `identity` is the node's kind-14 author pubkey, whose event
+    //     signature is verified inside `unwrap_incoming`.
+    //   * `sender`   — the event author (the kind-14 signer).
     //
-    // In Mostro's reputation-mode key split `sender` (per-trade key) and
-    // `identity` (long-lived seal key) are expected to differ, and protocol
-    // responses commonly omit the inner signature, so we cannot use a
-    // sender/identity equality check to gate dispatch. Authenticate against
-    // `identity` only — a forger who seals with their own key cannot make
-    // it match the configured Mostro pubkey.
+    // Authenticate `identity` against the configured Mostro pubkey — a forger
+    // cannot sign a kind-14 event as the node.
     let mostro_core::nip59::UnwrappedMessage {
         message: msg,
         sender: _,
@@ -1083,9 +1098,9 @@ async fn dispatch_mostro_message(
         created_at: _,
     } = unwrapped;
 
-    // Daemon authentication: the seal signer must be the active Mostro
-    // pubkey. The seal signature is verified inside `unwrap_message`, so
-    // `identity` is the cryptographically authoritative origin.
+    // Daemon authentication: the kind-14 event author must be the active
+    // Mostro pubkey. The event signature is verified inside `unwrap_incoming`,
+    // so `identity` is the cryptographically authoritative origin.
     match nostr_sdk::PublicKey::from_hex(&crate::config::active_mostro_pubkey()) {
         Ok(expected) if expected == identity => {}
         Ok(expected) => {
@@ -1814,10 +1829,11 @@ async fn build_trade_key_map() -> HashMap<String, (nostr_sdk::Keys, u32)> {
     map
 }
 
-/// Handle a Kind 1059 event received on the global subscription.
+/// Handle a kind-14 Mostro reply received on the global subscription.
 ///
+/// The caller has already pinned the author to the active Mostro pubkey.
 /// Finds which trade key the event is addressed to (via `p` tag), decrypts
-/// via `mostro_core::nip59::unwrap_message`, and dispatches the recovered
+/// via `mostro_core::transport::unwrap_incoming`, and dispatches the recovered
 /// `Message` through `dispatch_mostro_message`.
 async fn handle_global_gift_wrap(
     event: &nostr_sdk::Event,
@@ -1851,7 +1867,7 @@ async fn handle_global_gift_wrap(
         return;
     }
     crate::api::logging::blog_info("gift-wrap", format!(
-        "Kind 1059 received (global) for trade={} from={} event_id={}",
+        "Kind 14 received (global) for trade={} from={} event_id={}",
         &recipient_hex[..8],
         &event.pubkey.to_hex()[..8],
         &eid[..16],
@@ -1892,8 +1908,8 @@ async fn _run_order_subscription() {
     };
     crate::api::logging::blog_info("orders", format!("subscribing to Kind 38383 from mostro={}", mostro_pubkey.to_hex()));
 
-    // Build a map of all known trade keys so we can decrypt ANY Kind 1059
-    // gift-wrap from Mostro, not just those from the current session.
+    // Build a map of all known trade keys so we can decrypt ANY kind-14
+    // Mostro reply, not just those from the current session.
     let trade_key_map = build_trade_key_map().await;
     let trade_pubkeys: Vec<nostr_sdk::PublicKey> = trade_key_map
         .keys()
@@ -1914,16 +1930,19 @@ async fn _run_order_subscription() {
         return;
     }
 
-    // Subscribe to Kind 1059 (gift-wrap) for ALL known trade pubkeys so we
-    // capture daemon responses even for trades started in previous sessions.
+    // Subscribe to kind-14 NIP-44 replies (protocol v2) authored by Mostro for
+    // ALL known trade pubkeys so we capture daemon responses even for trades
+    // started in previous sessions. The author pin disambiguates from NIP-17
+    // peer chat (also kind 14).
     if !trade_pubkeys.is_empty() {
         let gw_filter = nostr_sdk::Filter::new()
-            .kind(nostr_sdk::Kind::from(1059u16))
+            .kind(nostr_sdk::Kind::PrivateDirectMessage)
+            .author(mostro_pubkey)
             .pubkeys(trade_pubkeys);
         if let Err(e) = client.subscribe(gw_filter, None).await {
-            crate::api::logging::blog_warn("orders", format!("gift-wrap bulk subscribe failed: {e}"));
+            crate::api::logging::blog_warn("orders", format!("kind-14 bulk subscribe failed: {e}"));
         } else {
-            crate::api::logging::blog_info("orders", format!("Kind 1059 bulk subscription active for {} trade keys", trade_key_map.len()));
+            crate::api::logging::blog_info("orders", format!("Kind 14 bulk subscription active for {} trade keys", trade_key_map.len()));
         }
     }
 
@@ -1934,8 +1953,13 @@ async fn _run_order_subscription() {
     loop {
         match rx.recv().await {
             Ok(RelayPoolNotification::Event { event, .. }) => {
-                // ── Kind 1059 gift-wrap: decrypt and dispatch ──
-                if event.kind == nostr_sdk::Kind::from(1059u16) {
+                // ── Kind 14 NIP-44 Mostro reply: decrypt and dispatch ──
+                if event.kind == nostr_sdk::Kind::PrivateDirectMessage {
+                    // Disambiguate from NIP-17 peer chat (also kind 14): only
+                    // the node may author a Mostro reply.
+                    if event.pubkey != mostro_pubkey {
+                        continue;
+                    }
                     handle_global_gift_wrap(&event, &trade_key_map).await;
                     continue;
                 }

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -1068,11 +1068,11 @@ pub(crate) async fn subscribe_gift_wraps(trade_pubkey: nostr_sdk::PublicKey, tra
 ///
 /// The caller recovers the `UnwrappedMessage` via
 /// `crate::nostr::gift_wrap::unwrap_mostro_message`, which verifies the kind-14
-/// event signature so the `identity` field is cryptographically attributable.
-/// This function authenticates that `identity` against the active Mostro pubkey
-/// (defense-in-depth behind the receive handler's author pin), runs the
-/// centralized `validate_response` check (catches `CantDo` responses and
-/// malformed `request_id` fields), then routes by action.
+/// event signature so the `sender` field (the event author) is cryptographically
+/// attributable. This function authenticates that `sender` against the active
+/// Mostro pubkey (defense-in-depth behind the receive handler's author pin),
+/// runs the centralized `validate_response` check (catches `CantDo` responses
+/// and malformed `request_id` fields), then routes by action.
 async fn dispatch_mostro_message(
     unwrapped: mostro_core::nip59::UnwrappedMessage,
     trade_pubkey_hex: &str,
@@ -1082,31 +1082,33 @@ async fn dispatch_mostro_message(
 
     // The protocol-v2 unwrap exposes two pubkeys:
     //
-    //   * `identity` — the proven identity-proof pubkey, or the event author
-    //     itself when no proof is attached. Mostro's replies carry no proof,
-    //     so `identity` is the node's kind-14 author pubkey, whose event
-    //     signature is verified inside `unwrap_incoming`.
-    //   * `sender`   — the event author (the kind-14 signer).
+    //   * `sender`   — the kind-14 event author, whose signature is verified
+    //     inside `unwrap_incoming`. This is the load-bearing, always-stable
+    //     origin in v2 and the field we authenticate against.
+    //   * `identity` — the proven identity-proof pubkey when a proof is
+    //     attached, or the event author when not. Its meaning is conditional,
+    //     so it is not the right anchor for the daemon-auth gate.
     //
-    // Authenticate `identity` against the configured Mostro pubkey — a forger
-    // cannot sign a kind-14 event as the node.
+    // A forger cannot sign a kind-14 event as the node, so `sender == mostro`
+    // is the authoritative check.
     let mostro_core::nip59::UnwrappedMessage {
         message: msg,
-        sender: _,
-        identity,
+        sender,
+        identity: _,
         signature: _,
         created_at: _,
     } = unwrapped;
 
-    // Daemon authentication: the kind-14 event author must be the active
-    // Mostro pubkey. The event signature is verified inside `unwrap_incoming`,
-    // so `identity` is the cryptographically authoritative origin.
+    // Daemon authentication: the kind-14 event author (`sender`) must be the
+    // active Mostro pubkey. The event signature is verified inside
+    // `unwrap_incoming`, so `sender` is the cryptographically authoritative
+    // origin.
     match nostr_sdk::PublicKey::from_hex(&crate::config::active_mostro_pubkey()) {
-        Ok(expected) if expected == identity => {}
+        Ok(expected) if expected == sender => {}
         Ok(expected) => {
             crate::api::logging::blog_warn("gift-wrap", format!(
-                "rejecting gift-wrap: identity={} != active mostro={} (trade={})",
-                &identity.to_hex()[..8],
+                "rejecting gift-wrap: sender={} != active mostro={} (trade={})",
+                &sender.to_hex()[..8],
                 &expected.to_hex()[..8],
                 &trade_pubkey_hex[..8],
             ));

--- a/rust/src/nostr/gift_wrap.rs
+++ b/rust/src/nostr/gift_wrap.rs
@@ -1,35 +1,39 @@
-/// NIP-59 Gift Wrap transport.
+/// Mostro message transport.
 ///
 /// Two entry points:
 ///
 /// * `wrap_mostro_message` / `unwrap_mostro_message` — typed Mostro protocol
-///   traffic, delegated to `mostro_core::nip59` so every Mostro client shares
-///   one NIP-59 implementation (seal construction, ephemeral keys, timestamp
-///   tweak, PoW, inner-tuple signing/verification).
+///   traffic, delegated to `mostro_core::transport` so every Mostro client
+///   shares one implementation. This app speaks **protocol v2** (NIP-44
+///   direct, signed Kind 14, authored by the trade key); the 3-tuple, identity
+///   proof, NIP-44 encryption and event signing/verification all live in
+///   mostro-core. See `specs/005-transport-v2-migration/`.
 ///
-/// * `wrap` / `unwrap` — raw JSON content wrapped in a Kind 14 rumor, used
-///   for NIP-17-style text DMs (P2P chat, dispute admin messages). These
+/// * `wrap` / `unwrap` — raw JSON content gift-wrapped (NIP-59, Kind 1059),
+///   used for NIP-17-style text DMs (P2P chat, dispute admin messages). These
+///   are **not** part of the v2 migration: they keep using gift wrap. Their
 ///   payloads are not `mostro_core::Message` values, so they stay on the
 ///   local helper — see issue #101, "Scope".
 use anyhow::{anyhow, Result};
 use mostro_core::message::Message;
-use mostro_core::nip59::{
-    unwrap_message as core_unwrap, wrap_message as core_wrap, UnwrappedMessage, WrapOptions,
-};
+use mostro_core::nip59::{UnwrappedMessage, WrapOptions};
+use mostro_core::transport::{unwrap_incoming, wrap_message_with, Transport};
 use nostr_sdk::prelude::*;
 
 // ── Mostro protocol traffic (typed `Message`) ────────────────────────────────
 
-/// Wrap a `Message` destined for `receiver` (typically the Mostro node).
+/// Wrap a `Message` destined for `receiver` (typically the Mostro node) as a
+/// protocol-v2 NIP-44 direct event (signed Kind 14, authored by the trade key).
 ///
-/// `identity_keys` sign the Seal (Kind 13) and encrypt it to `receiver` via
-/// NIP-44; they are the long-lived identity the node uses to accumulate
-/// reputation. `trade_keys` author the rumor (Kind 1) and produce the inner
-/// tuple signature. For full-privacy mode (no reputation), callers pass the
-/// same value for both parameters — see
+/// `trade_keys` author and sign the Kind 14 event and produce the inner trade
+/// signature; `identity_keys` produce the in-ciphertext identity proof binding
+/// the long-lived identity the node uses to accumulate reputation. For
+/// full-privacy mode (no reputation), callers pass the same value for both
+/// parameters and no identity proof is attached — see
 /// <https://mostro.network/protocol/key_management.html>.
 ///
-/// `pow` is applied to the outer Kind 1059 only.
+/// `pow` (NIP-13) is applied to the Kind 14 event id; the daemon fills its own
+/// NIP-40 expiration, so this app always sends `expiration: None`.
 pub async fn wrap_mostro_message(
     identity_keys: &Keys,
     trade_keys: &Keys,
@@ -42,38 +46,42 @@ pub async fn wrap_mostro_message(
         expiration: None,
         signed: true,
     };
-    core_wrap(message, identity_keys, trade_keys, *receiver, opts)
-        .await
-        .map_err(|e| anyhow!("wrap_message failed: {e}"))
+    wrap_message_with(
+        Transport::Nip44Direct,
+        message,
+        identity_keys,
+        trade_keys,
+        *receiver,
+        opts,
+    )
+    .await
+    .map_err(|e| anyhow!("wrap_message failed: {e}"))
 }
 
-/// Try to open an incoming Kind 1059 event using `trade_keys`.
+/// Try to open an incoming Mostro event using `trade_keys`.
 ///
-/// Returns `Ok(None)` only when the outer NIP-44 layer cannot be decrypted
-/// with the given key — the canonical "not addressed to me" signal, used by
-/// the global subscription to trial-decrypt across all derived trade keys.
+/// Delegates to `mostro_core::transport::unwrap_incoming`, which dispatches by
+/// event kind: a Kind 14 event is opened on the protocol-v2 NIP-44 path, a
+/// Kind 1059 event on the legacy gift-wrap path. (This app subscribes only to
+/// Kind 14, but the dispatcher accepts both.)
 ///
-/// Transport-level checks performed here: outer decryption, seal structure
-/// and signature, and — when the sender set `signed = true` — the
-/// inner-tuple Schnorr signature against the rumor author's pubkey. Note
-/// that mostro-core 0.10 deliberately does **not** enforce
-/// `seal.pubkey == rumor.pubkey` — Mostro signs the seal with the identity
-/// key and authors the rumor with the per-trade key, so the two legitimately
-/// differ. The returned `UnwrappedMessage` exposes both (`identity` vs.
-/// `sender`) so callers can route and authorize accordingly.
+/// Returns `Ok(None)` only when the NIP-44 content cannot be decrypted with
+/// the given key — the canonical "not addressed to me" signal, used by the
+/// global subscription to trial-decrypt across all derived trade keys. Every
+/// other failure (invalid event signature, malformed tuple, non-verifying
+/// inner signatures) yields `Err`.
 ///
-/// Daemon authentication is NOT performed here. The seal signature is
-/// verified (so `identity` is cryptographically attributable) but the seal
-/// signer could in principle be any key, and the rumor pubkey (`sender`)
-/// is only meaningful when an inner signature accompanies it. The upstream
-/// dispatcher in `api/orders.rs` enforces the Mostro-pubkey check against
-/// `identity` — never against the unauthenticated `sender` — before
-/// routing the message.
+/// In v2 the Kind 14 event signature is load-bearing and is verified here, so
+/// `UnwrappedMessage::sender` (the event author) is cryptographically
+/// attributable. `identity` is the proven identity-proof pubkey, or the trade
+/// key itself in full-privacy mode. Daemon authentication (matching the author
+/// against the active Mostro pubkey) is enforced by the receive handlers and
+/// the dispatcher in `api/orders.rs` before routing.
 pub async fn unwrap_mostro_message(
     trade_keys: &Keys,
     event: &Event,
 ) -> Result<Option<UnwrappedMessage>> {
-    core_unwrap(event, trade_keys)
+    unwrap_incoming(event, trade_keys)
         .await
         .map_err(|e| anyhow!("unwrap_message failed: {e}"))
 }
@@ -178,7 +186,9 @@ mod tests {
         .await
         .expect("wrap");
 
-        assert_eq!(event.kind, Kind::GiftWrap);
+        // Protocol v2: a signed Kind 14 event authored by the trade key.
+        assert_eq!(event.kind, Kind::PrivateDirectMessage);
+        assert_eq!(event.pubkey, trade_keys.public_key());
 
         let unwrapped = unwrap_mostro_message(&receiver_keys, &event)
             .await
@@ -243,7 +253,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn pow_is_applied_to_outer_event() {
+    async fn pow_is_applied_to_event() {
         use std::time::Duration;
 
         let identity_keys = Keys::generate();

--- a/rust/src/nostr/relay_pool.rs
+++ b/rust/src/nostr/relay_pool.rs
@@ -2,7 +2,8 @@
 ///
 /// Subscribes to:
 ///   - Kind 38383 (public order book, `s=Pending` tag)
-///   - Kind 1059 (NIP-59 Gift Wrap, p-tagged to our trade keys)
+///   - Kind 14 (protocol-v2 NIP-44 direct Mostro replies, authored by the
+///     node and p-tagged to our trade keys)
 ///
 /// Connection state is derived: Online if ≥1 relay connected,
 /// Reconnecting if attempting, Offline otherwise.
@@ -18,7 +19,6 @@ use tokio::sync::{broadcast, RwLock};
 use crate::api::types::{ConnectionState, RelayInfo, RelaySource, RelayStatus};
 use crate::nostr::order_events::pending_orders_filter;
 
-const KIND_GIFT_WRAP: u16 = 1059;
 /// How often the background task polls each relay's SDK status (seconds).
 const STATUS_POLL_INTERVAL_SECS: u64 = 2;
 
@@ -138,14 +138,15 @@ impl RelayPool {
         self.relay_tx.subscribe()
     }
 
-    /// Re-subscribe to Kind 38383 (public orders) and Kind 1059 (gift wraps)
-    /// after a reconnect or cold start, respawning per-trade gift-wrap workers.
+    /// Re-subscribe to Kind 38383 (public orders) and Kind 14 (protocol-v2
+    /// Mostro replies) after a reconnect or cold start, respawning per-trade
+    /// workers.
     ///
     /// `trade_keys` is a list of `(trade_pubkey, trade_index)` pairs gathered
     /// from persisted state (e.g. the trade-key DB table).  For each pair this
     /// method:
-    /// 1. Adds the pubkey to the bulk Kind 1059 relay filter so events are
-    ///    delivered to this client.
+    /// 1. Adds the pubkey to the bulk Kind 14 relay filter (author-pinned to
+    ///    Mostro) so events are delivered to this client.
     /// 2. Spawns a `subscribe_gift_wraps` worker (same as `create_order` does)
     ///    so decryption keys are available and daemon responses are routed.
     ///
@@ -164,8 +165,12 @@ impl RelayPool {
 
         let pubkeys: Vec<PublicKey> = trade_keys.iter().map(|(pk, _)| *pk).collect();
         if !pubkeys.is_empty() {
+            // Protocol v2: Mostro replies are kind-14 NIP-44 direct events
+            // authored by the node and p-tagged to our trade keys. Pin the
+            // author to disambiguate from NIP-17 peer chat (also kind 14).
             let dm_filter = Filter::new()
-                .kind(Kind::from(KIND_GIFT_WRAP))
+                .kind(Kind::PrivateDirectMessage)
+                .author(mostro_pubkey)
                 .pubkeys(pubkeys);
             self.client
                 .subscribe(dm_filter, None)


### PR DESCRIPTION
Switches this app's Mostro-protocol transport from NIP-59 gift wrap (kind 1059) to protocol v2 — NIP-44 direct, signed kind-14 events authored by the trade key. PR number 2 of 2 for the transport migration (spec `005-transport-v2-migration`); follows the `mostro-core` 0.13.1 bump (#110).

Protocol v2 only (no dual support): the target node speaks v2 and there are no users to bridge. Peer/dispute chat is out of scope and stays on gift wrap.

  ### Changes

  **1. Wire format (`gift_wrap.rs`)**
  - `wrap_mostro_message` → `wrap_message_with(Transport::Nip44Direct, …)` (`WrapOptions` unchanged: PoW preserved, `expiration: None` — daemon fills its own, FR-005)
  - `unwrap_mostro_message` → `unwrap_incoming` (dispatches by event kind)
  - Tests assert kind 14 + author = trade key; v2 doc refresh

  **2. Wiring (`relay_pool.rs`, `orders.rs`)**
  - Three subscription filters → kind 14 + `.author(mostro_pubkey)` (relay_pool `dm_filter`, orders per-trade + global bulk)
  - Three receive handlers → kind-14 check + reject `event.pubkey != mostro_pubkey`, disambiguating Mostro replies from NIP-17 peer chat (also kind 14, FR-003)
  - Remove now-unused `KIND_GIFT_WRAP` const; refresh stale docs/logs/comments

  #### Out of scope (unchanged)

  - NIP-17 peer chat and dispute-admin chat stay on gift wrap kind 1059 (`gift_wrap.rs` `wrap`/`unwrap`, `messages.rs::subscribe_incoming_chat`) — FR-004
  - Mostro message logic, action set, payloads, key derivation
  - Internal identifier names (`subscribe_gift_wraps`, etc.) kept to keep the diff focused

  ### Verification

  - `cargo build` / `cargo test` (81 passed) / `cargo clippy` — all green, no new warnings
  - Dart untouched; no FRB regen (changes internal to `crate::nostr` / `crate::api`)
  - Manual E2E against a v2 node still pending — full order lifecycle (new-order → take → pay → fiat-sent → release)

  ### Spec

  `specs/005-transport-v2-migration/` · reference:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Refactor**
* Upgraded private message protocol from NIP-59 gift-wrap to NIP-44 direct messages, improving security, authentication, and message routing reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->