### PR TITLE
fix: Mostro node selection now takes effect, persists, and refreshes the order book

### DIFF
--- a/lib/features/settings/widgets/mostro_node_selector.dart
+++ b/lib/features/settings/widgets/mostro_node_selector.dart
@@ -63,13 +63,13 @@ class _MostroNodeSelectorState extends ConsumerState<MostroNodeSelector> {
     final previous = ref.read(mostroPubkeyProvider);
     ref.read(mostroPubkeyProvider.notifier).state = _defaultMostroPubkey;
     try {
-      await settings_api.setMostroPubkey(pubkey: null);
+      await settings_api.setActiveMostroNode(pubkey: _defaultMostroPubkey);
       if (!mounted) return;
       _controller.clear();
       setState(() => _errorText = null);
       Navigator.of(context).pop();
     } catch (e) {
-      debugPrint('[MostroNodeSelector] setMostroPubkey(null) failed: $e');
+      debugPrint('[MostroNodeSelector] setActiveMostroNode(default) failed: $e');
       ref.read(mostroPubkeyProvider.notifier).state = previous;
       if (!mounted) return;
       setState(() => _errorText = 'Failed to reset node');
@@ -90,11 +90,11 @@ class _MostroNodeSelectorState extends ConsumerState<MostroNodeSelector> {
     final previous = ref.read(mostroPubkeyProvider);
     ref.read(mostroPubkeyProvider.notifier).state = pubkey;
     try {
-      await settings_api.setMostroPubkey(pubkey: pubkey);
+      await settings_api.setActiveMostroNode(pubkey: pubkey);
       if (!mounted) return;
       Navigator.of(context).pop();
     } catch (e) {
-      debugPrint('[MostroNodeSelector] setMostroPubkey failed: $e');
+      debugPrint('[MostroNodeSelector] setActiveMostroNode failed: $e');
       ref.read(mostroPubkeyProvider.notifier).state = previous;
       if (!mounted) return;
       setState(() => _errorText = 'Invalid pubkey or bridge error');

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,8 +6,10 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:mostro/core/app.dart';
+import 'package:mostro/core/mostro_defaults.dart';
 import 'package:mostro/core/services/identity_service.dart';
 import 'package:mostro/features/settings/providers/settings_provider.dart';
+import 'package:mostro/features/settings/widgets/mostro_node_selector.dart';
 import 'package:mostro/features/walkthrough/providers/first_run_provider.dart';
 import 'package:mostro/features/account/providers/backup_reminder_provider.dart';
 import 'package:mostro/firebase_options.dart';
@@ -51,8 +53,12 @@ Future<void> main() async {
   // Load the persisted active Mostro node into the Rust override before the
   // relay pool starts, so the first subscription targets the user's selected
   // node. No-op when none was saved (the compiled-in default then applies).
+  // The resolved pubkey seeds mostroPubkeyProvider so Settings shows the real
+  // active node on launch.
+  String activeMostroPubkey = defaultMostroPubkey;
   try {
     await settings_api.rehydrateActiveMostroNode();
+    activeMostroPubkey = await settings_api.getMostroPubkey();
   } catch (e) {
     debugPrint('[main] rehydrate active Mostro node failed: $e');
   }
@@ -104,6 +110,7 @@ Future<void> main() async {
       nwcProvider.overrideWith(
         (ref) => NwcNotifier(prefs: prefs),
       ),
+      mostroPubkeyProvider.overrideWith((ref) => activeMostroPubkey),
     ],
   );
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,6 +18,7 @@ import 'package:mostro/src/rust/api/nwc.dart' as nwc_api;
 import 'package:mostro/src/rust/api/logging.dart' as logging_api;
 import 'package:mostro/src/rust/api/nostr.dart' as nostr_api;
 import 'package:mostro/src/rust/api/orders.dart' as orders_api;
+import 'package:mostro/src/rust/api/settings.dart' as settings_api;
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -45,6 +46,15 @@ Future<void> main() async {
       // messages.  All Rust callers already handle db() == None gracefully.
       debugPrint('[main] DB init failed — running in memory-only mode: $e\n$st');
     }
+  }
+
+  // Load the persisted active Mostro node into the Rust override before the
+  // relay pool starts, so the first subscription targets the user's selected
+  // node. No-op when none was saved (the compiled-in default then applies).
+  try {
+    await settings_api.rehydrateActiveMostroNode();
+  } catch (e) {
+    debugPrint('[main] rehydrate active Mostro node failed: $e');
   }
 
   // Initialize identity: creates on first launch, reloads on subsequent launches.

--- a/rust/src/api/nostr.rs
+++ b/rust/src/api/nostr.rs
@@ -211,9 +211,9 @@ pub async fn fetch_mostro_instance_tags(
 }
 
 /// Fetch the Mostro daemon's PoW requirement from its Kind 38385 event
-/// and store it globally.  Called each time the relay pool goes Online so
-/// the value stays current if the daemon updates its configuration.
-async fn fetch_and_set_pow() {
+/// and store it globally.  Called each time the relay pool goes Online, and
+/// after a node switch, so the value stays current for the active node.
+pub(crate) async fn fetch_and_set_pow() {
     let mostro_pubkey_hex = crate::config::active_mostro_pubkey();
     match fetch_mostro_instance_tags(mostro_pubkey_hex).await {
         Ok(Some(tags)) => {

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -236,6 +236,15 @@ impl OrderBook {
         let _ = self.tx.send(orders);
     }
 
+    /// Empty the cached order list and notify listeners with an empty book.
+    ///
+    /// Used on a node switch so orders belonging to the previously-active node
+    /// disappear from the UI immediately, before the new node's orders arrive.
+    pub async fn clear(&self) {
+        self.orders.write().await.clear();
+        let _ = self.tx.send(Vec::new());
+    }
+
     /// Insert or update a single order and notify listeners.
     pub async fn upsert_order(&self, order: OrderInfo) {
         let mut orders = self.orders.write().await;
@@ -1816,6 +1825,98 @@ pub async fn restart_orders_subscription() {
     subscribe_orders().await;
 }
 
+/// Stable subscription ID for the Kind 38383 order-book feed.
+fn orders_subscription_id() -> nostr_sdk::SubscriptionId {
+    nostr_sdk::SubscriptionId::new("mostro-orders")
+}
+
+/// Stable subscription ID for the Kind 14 Mostro-reply feed.
+fn mostro_dm_subscription_id() -> nostr_sdk::SubscriptionId {
+    nostr_sdk::SubscriptionId::new("mostro-dm")
+}
+
+/// (Re)subscribe the order-book (Kind 38383) and Mostro-reply (Kind 14)
+/// filters, author-pinned to `mostro_pubkey`.
+///
+/// Uses **stable** subscription IDs so that calling this again for a different
+/// node REPLACES the existing author-pinned filters in place (the relay pool
+/// overwrites the subscription for a known ID) instead of leaking a second
+/// subscription that keeps the old node's events flowing.
+async fn subscribe_node_filters(
+    client: &nostr_sdk::Client,
+    mostro_pubkey: nostr_sdk::PublicKey,
+    trade_pubkeys: Vec<nostr_sdk::PublicKey>,
+) -> Result<()> {
+    let order_filter = crate::nostr::order_events::all_orders_filter(&mostro_pubkey);
+    client
+        .subscribe_with_id(orders_subscription_id(), order_filter, None)
+        .await
+        .map_err(|e| anyhow::anyhow!("order subscribe failed: {e}"))?;
+
+    // Kind-14 NIP-44 replies authored by Mostro for all known trade pubkeys.
+    // The author pin disambiguates from NIP-17 peer chat (also kind 14).
+    if !trade_pubkeys.is_empty() {
+        let dm_filter = nostr_sdk::Filter::new()
+            .kind(nostr_sdk::Kind::PrivateDirectMessage)
+            .author(mostro_pubkey)
+            .pubkeys(trade_pubkeys);
+        client
+            .subscribe_with_id(mostro_dm_subscription_id(), dm_filter, None)
+            .await
+            .map_err(|e| anyhow::anyhow!("dm subscribe failed: {e}"))?;
+    }
+    Ok(())
+}
+
+/// Re-target the live order-book and Mostro-reply subscriptions to the
+/// currently-active Mostro node, after the active pubkey has changed.
+///
+/// Clears the order book (cached orders belong to the previous node),
+/// re-subscribes the author-pinned filters with stable IDs (replacing the old
+/// ones in place), and refreshes the node's PoW requirement. The long-lived
+/// subscription loop keeps running and picks up the new node via its
+/// per-event active-pubkey check — no loop restart, so no duplicate loops.
+pub(crate) async fn refresh_subscriptions_for_active_node() {
+    // Drop stale orders immediately so the UI doesn't show the old node's book.
+    order_book().clear().await;
+
+    let Ok(pool) = crate::api::nostr::get_pool() else {
+        log::warn!(
+            "[orders] node switch: relay pool not initialized; \
+             subscriptions will start with the new node once online"
+        );
+        return;
+    };
+    let client = pool.client();
+
+    let mostro_pubkey = match nostr_sdk::PublicKey::from_hex(&active_mostro_pubkey()) {
+        Ok(pk) => pk,
+        Err(e) => {
+            log::error!("[orders] node switch: invalid mostro pubkey: {e}");
+            return;
+        }
+    };
+
+    let trade_key_map = build_trade_key_map().await;
+    let trade_pubkeys: Vec<nostr_sdk::PublicKey> = trade_key_map
+        .keys()
+        .filter_map(|hex| nostr_sdk::PublicKey::from_hex(hex).ok())
+        .collect();
+
+    if let Err(e) = subscribe_node_filters(&client, mostro_pubkey, trade_pubkeys).await {
+        log::error!("[orders] node switch: re-subscribe failed: {e}");
+        return;
+    }
+
+    // Outgoing messages must use the new node's PoW difficulty.
+    crate::api::nostr::fetch_and_set_pow().await;
+
+    crate::api::logging::blog_info(
+        "orders",
+        format!("switched subscriptions to mostro={}", mostro_pubkey.to_hex()),
+    );
+}
+
 /// Build a map of `trade_pubkey_hex → (Keys, trade_index)` for all derived
 /// trade keys so the global subscription can decrypt any gift-wrap.
 async fn build_trade_key_map() -> HashMap<String, (nostr_sdk::Keys, u32)> {
@@ -1928,29 +2029,13 @@ async fn _run_order_subscription() {
     // events that arrive between the subscribe call and receiver creation.
     let mut rx = client.notifications();
 
-    // Subscribe to ALL orders (no status restriction) so we receive status-change
-    // events (e.g. pending → canceled) and can remove them from the order book.
-    // Display-level filtering (show only pending) is handled in the Dart layer.
-    let order_filter = crate::nostr::order_events::all_orders_filter(&mostro_pubkey);
-    if let Err(e) = client.subscribe(order_filter, None).await {
+    // Subscribe to ALL orders (Kind 38383, no status restriction so we receive
+    // status changes) and the bulk Kind-14 Mostro-reply feed, both author-pinned
+    // to the active node via stable subscription IDs (so a later node switch can
+    // replace them in place). Display-level filtering is handled in Dart.
+    if let Err(e) = subscribe_node_filters(&client, mostro_pubkey, trade_pubkeys).await {
         log::error!("[orders] subscribe failed: {e}");
         return;
-    }
-
-    // Subscribe to kind-14 NIP-44 replies (protocol v2) authored by Mostro for
-    // ALL known trade pubkeys so we capture daemon responses even for trades
-    // started in previous sessions. The author pin disambiguates from NIP-17
-    // peer chat (also kind 14).
-    if !trade_pubkeys.is_empty() {
-        let gw_filter = nostr_sdk::Filter::new()
-            .kind(nostr_sdk::Kind::PrivateDirectMessage)
-            .author(mostro_pubkey)
-            .pubkeys(trade_pubkeys);
-        if let Err(e) = client.subscribe(gw_filter, None).await {
-            crate::api::logging::blog_warn("orders", format!("kind-14 bulk subscribe failed: {e}"));
-        } else {
-            crate::api::logging::blog_info("orders", format!("Kind 14 bulk subscription active for {} trade keys", trade_key_map.len()));
-        }
     }
 
     crate::api::logging::blog_info("orders", format!("subscriptions active — waiting for events"));
@@ -1960,11 +2045,19 @@ async fn _run_order_subscription() {
     loop {
         match rx.recv().await {
             Ok(RelayPoolNotification::Event { event, .. }) => {
+                // Resolve the *current* active node for each event so a node
+                // switch is respected without restarting this loop.
+                let Ok(active_mostro) =
+                    nostr_sdk::PublicKey::from_hex(&active_mostro_pubkey())
+                else {
+                    continue;
+                };
+
                 // ── Kind 14 NIP-44 Mostro reply: decrypt and dispatch ──
                 if event.kind == nostr_sdk::Kind::PrivateDirectMessage {
                     // Disambiguate from NIP-17 peer chat (also kind 14): only
-                    // the node may author a Mostro reply.
-                    if event.pubkey != mostro_pubkey {
+                    // the active node may author a Mostro reply.
+                    if event.pubkey != active_mostro {
                         continue;
                     }
                     handle_global_gift_wrap(&event, &trade_key_map).await;
@@ -1972,6 +2065,12 @@ async fn _run_order_subscription() {
                 }
 
                 // ── Kind 38383 order book event ──
+                // Ignore stale orders from a previously-active node (e.g. events
+                // buffered across a node switch); the book only ever holds the
+                // active node's orders.
+                if event.pubkey != active_mostro {
+                    continue;
+                }
                 log::debug!(
                     "[orders] event kind={} author={}",
                     event.kind,

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -1814,15 +1814,55 @@ pub async fn subscribe_orders() {
     });
 }
 
-/// Force-restart the orders subscription.
+/// Refresh the order book on demand (UI "Refresh" action).
 ///
-/// Tears down the existing subscription (if any) by resetting the guard,
-/// then spawns a fresh subscription loop. Used by the UI "Refresh" action
-/// so users get a real re-subscribe instead of a silent no-op.
+/// Ensures the long-lived subscription loop is running — idempotent: it does
+/// NOT clear `SUBSCRIPTION_ACTIVE`, which the previous version did and which
+/// spawned a *second* loop while the old one kept consuming notifications.
+/// Then it re-pulls the active node's current orders: a plain re-subscribe
+/// wouldn't repopulate already-seen orders (nostr-sdk dedups them from the live
+/// stream), so the explicit refetch is what actually refreshes the book.
 pub async fn restart_orders_subscription() {
-    // Clear the guard so subscribe_orders can acquire it again.
-    SUBSCRIPTION_ACTIVE.store(false, Ordering::Release);
     subscribe_orders().await;
+    refetch_active_node_orders().await;
+}
+
+/// Fetch the active node's current Kind 38383 orders and ingest them.
+///
+/// The live subscription's notification stream does not redeliver events the
+/// session has already seen (nostr-sdk dedups them), so an explicit fetch is
+/// needed to (re)populate the book — both on a node switch and on a manual
+/// refresh. `fetch_events` collects from the raw relay-message channel, which
+/// is not subject to that dedup.
+async fn refetch_active_node_orders() {
+    let Ok(pool) = crate::api::nostr::get_pool() else {
+        log::warn!("[orders] refetch: relay pool not initialized");
+        return;
+    };
+    let mostro_pubkey = match nostr_sdk::PublicKey::from_hex(&active_mostro_pubkey()) {
+        Ok(pk) => pk,
+        Err(e) => {
+            log::error!("[orders] refetch: invalid mostro pubkey: {e}");
+            return;
+        }
+    };
+    let order_filter = crate::nostr::order_events::all_orders_filter(&mostro_pubkey);
+    match pool
+        .client()
+        .fetch_events(order_filter, std::time::Duration::from_secs(10))
+        .await
+    {
+        Ok(events) => {
+            crate::api::logging::blog_info(
+                "orders",
+                format!("refetched {} current orders for active node", events.len()),
+            );
+            for event in events.into_iter() {
+                ingest_order_event(&event).await;
+            }
+        }
+        Err(e) => log::warn!("[orders] refetch: fetch current orders failed: {e}"),
+    }
 }
 
 /// Stable subscription ID for the Kind 38383 order-book feed.
@@ -1908,29 +1948,9 @@ pub(crate) async fn refresh_subscriptions_for_active_node() {
         return;
     }
 
-    // Repopulate the cleared book with the new node's current orders.
-    //
-    // The live subscription alone won't do this: nostr-sdk's per-session event
-    // database suppresses already-seen events from the notification stream, so
-    // returning to a node visited earlier would deliver nothing until a fresh
-    // order arrives. `fetch_events` collects from the raw relay-message channel,
-    // which is not subject to that dedup, so it returns the stored orders too.
-    let order_filter = crate::nostr::order_events::all_orders_filter(&mostro_pubkey);
-    match client
-        .fetch_events(order_filter, std::time::Duration::from_secs(10))
-        .await
-    {
-        Ok(events) => {
-            crate::api::logging::blog_info(
-                "orders",
-                format!("node switch: fetched {} current orders", events.len()),
-            );
-            for event in events.into_iter() {
-                ingest_order_event(&event).await;
-            }
-        }
-        Err(e) => log::warn!("[orders] node switch: fetch current orders failed: {e}"),
-    }
+    // Repopulate the cleared book with the new node's current orders (the live
+    // stream won't redeliver already-seen events — see refetch_active_node_orders).
+    refetch_active_node_orders().await;
 
     // Outgoing messages must use the new node's PoW difficulty.
     crate::api::nostr::fetch_and_set_pow().await;

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -1782,7 +1782,7 @@ static SUBSCRIPTION_ACTIVE: AtomicBool = AtomicBool::new(false);
 /// loop exits (pool shutdown or channel closed).
 ///
 /// Internally spawns a background Tokio task that:
-/// 1. Subscribes to `pending_orders_filter()` via the relay pool client.
+/// 1. Subscribes to `all_orders_filter()` via the relay pool client.
 /// 2. Loops over `RelayPoolNotification::Event` messages.
 /// 3. Parses each Kind 38383 event via `parse_order_event` and upserts it
 ///    into the order book, which broadcasts the update to all `OrdersStream`

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -1908,6 +1908,30 @@ pub(crate) async fn refresh_subscriptions_for_active_node() {
         return;
     }
 
+    // Repopulate the cleared book with the new node's current orders.
+    //
+    // The live subscription alone won't do this: nostr-sdk's per-session event
+    // database suppresses already-seen events from the notification stream, so
+    // returning to a node visited earlier would deliver nothing until a fresh
+    // order arrives. `fetch_events` collects from the raw relay-message channel,
+    // which is not subject to that dedup, so it returns the stored orders too.
+    let order_filter = crate::nostr::order_events::all_orders_filter(&mostro_pubkey);
+    match client
+        .fetch_events(order_filter, std::time::Duration::from_secs(10))
+        .await
+    {
+        Ok(events) => {
+            crate::api::logging::blog_info(
+                "orders",
+                format!("node switch: fetched {} current orders", events.len()),
+            );
+            for event in events.into_iter() {
+                ingest_order_event(&event).await;
+            }
+        }
+        Err(e) => log::warn!("[orders] node switch: fetch current orders failed: {e}"),
+    }
+
     // Outgoing messages must use the new node's PoW difficulty.
     crate::api::nostr::fetch_and_set_pow().await;
 
@@ -1997,6 +2021,109 @@ async fn handle_global_gift_wrap(
     }
 }
 
+/// Parse a Kind 38383 event and upsert it into the order book, applying
+/// maker-order reconciliation (is_mine detection, local→daemon id bridging,
+/// trade-status sync).
+///
+/// Shared by the live subscription loop and the node-switch refetch so both
+/// paths populate the book identically.
+async fn ingest_order_event(event: &nostr_sdk::Event) {
+    log::debug!(
+        "[orders] event kind={} author={}",
+        event.kind,
+        &event.pubkey.to_hex()[..8]
+    );
+    match parse_order_event(event, None) {
+        Some(mut info) => {
+            log::info!(
+                "[orders] parsed order id={} kind={:?} status={:?}",
+                info.id,
+                info.kind,
+                info.status
+            );
+            // Restore is_mine=true for maker orders on cold start by
+            // comparing against the content fingerprint stored at creation time.
+            if !info.is_mine {
+                let ck = order_content_key(
+                    &info.kind,
+                    &info.fiat_code,
+                    info.fiat_amount,
+                    info.fiat_amount_min,
+                    info.fiat_amount_max,
+                    &info.payment_method,
+                );
+                log::debug!("[orders] fingerprint check order={} ck={ck}", info.id);
+                if let Some(trade_idx) = get_trade_key_index(&ck).await {
+                    info.is_mine = true;
+                    // Bridge content fingerprint → daemon UUID so subsequent
+                    // actions (cancel) can look up the trade key by real order ID.
+                    store_trade_key_index(&info.id, trade_idx).await;
+                    // The maker order is no longer inserted into the
+                    // book optimistically (see `create_order`), so there
+                    // is nothing to remove here — just bridge the local
+                    // UUID → daemon UUID in the DB so tradeStatusProvider
+                    // polls with the real order ID.
+                    if let Some(local_id) = take_pending_local_id(&ck) {
+                        if let Some(db) = crate::db::app_db::db() {
+                            if let Err(e) =
+                                db.update_trade_order_id(&local_id, &info.id).await
+                            {
+                                log::warn!(
+                                    "[orders] failed to update trade order_id \
+                                     {local_id} → {}: {e}",
+                                    info.id
+                                );
+                            }
+                        }
+                        log::info!(
+                            "[orders] reconciled local order={local_id} → daemon order={}",
+                            info.id
+                        );
+                    } else {
+                        log::info!(
+                            "[orders] own order={} detected via content match trade_index={trade_idx}",
+                            info.id
+                        );
+                    }
+                }
+            }
+            // Sync trade status in DB for own orders so My Trades
+            // reflects status changes even without gift-wrap delivery.
+            if info.is_mine && info.status != crate::api::types::OrderStatus::Pending {
+                if let Some(db) = crate::db::app_db::db() {
+                    if let Err(e) = db
+                        .update_trade_fields(
+                            &info.id,
+                            Some(info.status.clone()),
+                            None,
+                            info.amount_sats,
+                        )
+                        .await
+                    {
+                        log::warn!(
+                            "[orders] failed to sync trade status for order={}: {e}",
+                            info.id
+                        );
+                    }
+                }
+            }
+            order_book().upsert_order(info).await;
+        }
+        None => {
+            log::warn!(
+                "[orders] event kind={} rejected by parser (tags: {:?})",
+                event.kind,
+                event
+                    .tags
+                    .iter()
+                    .take(6)
+                    .map(|t| t.as_slice().first().map(|s| s.as_str()).unwrap_or("?"))
+                    .collect::<Vec<_>>()
+            );
+        }
+    }
+}
+
 async fn _run_order_subscription() {
     let Ok(pool) = crate::api::nostr::get_pool() else {
         log::error!("[orders] subscription failed: relay pool not initialized");
@@ -2071,101 +2198,7 @@ async fn _run_order_subscription() {
                 if event.pubkey != active_mostro {
                     continue;
                 }
-                log::debug!(
-                    "[orders] event kind={} author={}",
-                    event.kind,
-                    &event.pubkey.to_hex()[..8]
-                );
-                match parse_order_event(&event, None) {
-                    Some(mut info) => {
-                        log::info!(
-                            "[orders] parsed order id={} kind={:?} status={:?}",
-                            info.id,
-                            info.kind,
-                            info.status
-                        );
-                        // Restore is_mine=true for maker orders on cold start by
-                        // comparing against the content fingerprint stored at creation time.
-                        if !info.is_mine {
-                            let ck = order_content_key(
-                                &info.kind,
-                                &info.fiat_code,
-                                info.fiat_amount,
-                                info.fiat_amount_min,
-                                info.fiat_amount_max,
-                                &info.payment_method,
-                            );
-                            log::debug!("[orders] fingerprint check order={} ck={ck}", info.id);
-                            if let Some(trade_idx) = get_trade_key_index(&ck).await {
-                                info.is_mine = true;
-                                // Bridge content fingerprint → daemon UUID so subsequent
-                                // actions (cancel) can look up the trade key by real order ID.
-                                store_trade_key_index(&info.id, trade_idx).await;
-                                // The maker order is no longer inserted into the
-                                // book optimistically (see `create_order`), so there
-                                // is nothing to remove here — just bridge the local
-                                // UUID → daemon UUID in the DB so tradeStatusProvider
-                                // polls with the real order ID.
-                                if let Some(local_id) = take_pending_local_id(&ck) {
-                                    if let Some(db) = crate::db::app_db::db() {
-                                        if let Err(e) = db
-                                            .update_trade_order_id(&local_id, &info.id)
-                                            .await
-                                        {
-                                            log::warn!(
-                                                "[orders] failed to update trade order_id \
-                                                 {local_id} → {}: {e}",
-                                                info.id
-                                            );
-                                        }
-                                    }
-                                    log::info!(
-                                        "[orders] reconciled local order={local_id} → daemon order={}",
-                                        info.id
-                                    );
-                                } else {
-                                    log::info!(
-                                        "[orders] own order={} detected via content match trade_index={trade_idx}",
-                                        info.id
-                                    );
-                                }
-                            }
-                        }
-                        // Sync trade status in DB for own orders so My Trades
-                        // reflects status changes even without gift-wrap delivery.
-                        if info.is_mine && info.status != crate::api::types::OrderStatus::Pending {
-                            if let Some(db) = crate::db::app_db::db() {
-                                if let Err(e) = db
-                                    .update_trade_fields(
-                                        &info.id,
-                                        Some(info.status.clone()),
-                                        None,
-                                        info.amount_sats,
-                                    )
-                                    .await
-                                {
-                                    log::warn!(
-                                        "[orders] failed to sync trade status for order={}: {e}",
-                                        info.id
-                                    );
-                                }
-                            }
-                        }
-                        order_book().upsert_order(info).await;
-                    }
-                    None => {
-                        log::warn!(
-                            "[orders] event kind={} rejected by parser (tags: {:?})",
-                            event.kind,
-                            event
-                                .tags
-                                .iter()
-                                .take(6)
-                                .map(|t| t.as_slice().first().map(|s| s.as_str()).unwrap_or("?"))
-                                .collect::<Vec<_>>()
-                        );
-                    }
-                }
+                ingest_order_event(&event).await;
             }
             Ok(RelayPoolNotification::Shutdown) => {
                 log::info!("[orders] relay pool shutdown — subscription loop exiting");

--- a/rust/src/api/settings.rs
+++ b/rust/src/api/settings.rs
@@ -181,21 +181,6 @@ pub async fn set_default_lightning_address(address: Option<String>) -> Result<()
     Ok(())
 }
 
-/// Set or clear the active Mostro node pubkey.
-///
-/// Pass `Some("hex...")` to route orders to a custom Mostro node, or `None`
-/// to revert to the compiled-in default.
-///
-/// **Errors**: `InvalidPubkey` if `pubkey` is Some but not a valid 64-char hex key.
-pub fn set_mostro_pubkey(pubkey: Option<String>) -> Result<()> {
-    if let Some(ref pk) = pubkey {
-        nostr_sdk::PublicKey::from_hex(pk)
-            .map_err(|e| anyhow::anyhow!("InvalidPubkey: {e}"))?;
-    }
-    crate::config::set_active_mostro_pubkey(pubkey);
-    Ok(())
-}
-
 /// Return the currently active Mostro node pubkey (override or default).
 pub fn get_mostro_pubkey() -> String {
     crate::config::active_mostro_pubkey()
@@ -235,33 +220,6 @@ pub async fn rehydrate_active_mostro_node() -> Result<()> {
             crate::config::set_active_mostro_pubkey(Some(pubkey));
         }
     }
-    Ok(())
-}
-
-/// Return the active Mostro node info, falling back to the compiled
-/// default if none has been persisted yet.
-pub async fn get_mostro_node() -> Result<crate::api::types::MostroNodeInfo> {
-    if let Some(db) = crate::db::app_db::db() {
-        if let Ok(Some(node)) = db.get_active_mostro_node().await {
-            return Ok(node);
-        }
-    }
-    Ok(crate::db::seeds::get_default_mostro_node())
-}
-
-/// Persist a new active Mostro node selection.
-///
-/// Also updates the in-memory pubkey override so the relay pool and
-/// outgoing events use the new node immediately.
-///
-/// TODO(#93): After updating the pubkey, refresh relay subscriptions so
-/// `subscribe_order_and_dm_feeds` re-subscribes with the new node's key.
-pub async fn set_mostro_node(node: crate::api::types::MostroNodeInfo) -> Result<()> {
-    let pubkey = node.pubkey.clone();
-    if let Some(db) = crate::db::app_db::db() {
-        db.save_mostro_node(&node).await?;
-    }
-    crate::config::set_active_mostro_pubkey(Some(pubkey));
     Ok(())
 }
 

--- a/rust/src/api/settings.rs
+++ b/rust/src/api/settings.rs
@@ -201,6 +201,28 @@ pub fn get_mostro_pubkey() -> String {
     crate::config::active_mostro_pubkey()
 }
 
+/// Activate a Mostro node by pubkey — the single entry point for node selection.
+///
+/// Validates the hex pubkey, persists it as the active node's identity,
+/// updates the in-memory override so outgoing events target the new node
+/// immediately, and re-targets the live order-book / Mostro-reply
+/// subscriptions (clearing stale orders and refreshing PoW) to it.
+///
+/// Pass `DEFAULT_MOSTRO_PUBKEY` to return to the default node.
+///
+/// **Errors**: `InvalidPubkey` if `pubkey` is not a valid 64-char hex key.
+pub async fn set_active_mostro_node(pubkey: String) -> Result<()> {
+    nostr_sdk::PublicKey::from_hex(&pubkey)
+        .map_err(|e| anyhow::anyhow!("InvalidPubkey: {e}"))?;
+
+    if let Some(db) = crate::db::app_db::db() {
+        db.save_active_mostro_pubkey(&pubkey).await?;
+    }
+    crate::config::set_active_mostro_pubkey(Some(pubkey));
+    crate::api::orders::refresh_subscriptions_for_active_node().await;
+    Ok(())
+}
+
 /// Return the active Mostro node info, falling back to the compiled
 /// default if none has been persisted yet.
 pub async fn get_mostro_node() -> Result<crate::api::types::MostroNodeInfo> {

--- a/rust/src/api/settings.rs
+++ b/rust/src/api/settings.rs
@@ -223,6 +223,21 @@ pub async fn set_active_mostro_node(pubkey: String) -> Result<()> {
     Ok(())
 }
 
+/// Load the persisted active Mostro node pubkey into the in-memory override.
+///
+/// Call once at startup, after `init_db` and **before** the relay pool starts
+/// subscribing, so the first order-book / Mostro-reply subscription already
+/// targets the user's selected node. No-op when nothing has been persisted
+/// (the compiled-in default then applies) or when the DB is unavailable.
+pub async fn rehydrate_active_mostro_node() -> Result<()> {
+    if let Some(db) = crate::db::app_db::db() {
+        if let Some(pubkey) = db.get_active_mostro_pubkey().await? {
+            crate::config::set_active_mostro_pubkey(Some(pubkey));
+        }
+    }
+    Ok(())
+}
+
 /// Return the active Mostro node info, falling back to the compiled
 /// default if none has been persisted yet.
 pub async fn get_mostro_node() -> Result<crate::api::types::MostroNodeInfo> {

--- a/rust/src/api/types.rs
+++ b/rust/src/api/types.rs
@@ -351,7 +351,13 @@ pub struct AppState {
     pub logging_enabled: bool,
 }
 
-/// Mostro daemon node information.
+/// Mostro daemon node information (name, version, fees, limits, currencies).
+///
+/// Intentionally retained though currently unused: the active node's *identity*
+/// is just its pubkey (see `set_active_mostro_node`), while this richer record
+/// is the metadata model for the M5 multi-Mostro node registry — populated from
+/// the node's kind 0 / 38385 events. Kept here so M5 builds on a stable type
+/// instead of re-deriving it.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct MostroNodeInfo {
     pub pubkey: String,

--- a/rust/src/db/indexeddb.rs
+++ b/rust/src/db/indexeddb.rs
@@ -109,6 +109,18 @@ impl Storage for IndexedDbStorage {
         Ok(None)
     }
 
+    async fn save_active_mostro_pubkey(&self, _pubkey: &str) -> Result<()> {
+        // IndexedDB not yet implemented — node selection will not survive reload.
+        log::warn!("save_active_mostro_pubkey: IndexedDB backend not implemented — node selection will not survive reload");
+        Ok(())
+    }
+
+    async fn get_active_mostro_pubkey(&self) -> Result<Option<String>> {
+        // IndexedDB not yet implemented — callers fall back to the default.
+        log::warn!("get_active_mostro_pubkey: IndexedDB backend not implemented — falling back to default");
+        Ok(None)
+    }
+
     async fn get_trade_by_order_id(
         &self,
         _order_id: &str,

--- a/rust/src/db/indexeddb.rs
+++ b/rust/src/db/indexeddb.rs
@@ -97,18 +97,6 @@ impl Storage for IndexedDbStorage {
         Ok(()) // IndexedDB not yet implemented
     }
 
-    async fn save_mostro_node(&self, _node: &crate::api::types::MostroNodeInfo) -> Result<()> {
-        log::warn!("save_mostro_node: IndexedDB backend not implemented — node selection will not survive reload");
-        // TODO(#93): implement IndexedDB persistence for Mostro node selection
-        Ok(())
-    }
-
-    async fn get_active_mostro_node(&self) -> Result<Option<crate::api::types::MostroNodeInfo>> {
-        log::warn!("get_active_mostro_node: IndexedDB backend not implemented — falling back to default");
-        // TODO(#93): implement IndexedDB persistence for Mostro node selection
-        Ok(None)
-    }
-
     async fn save_active_mostro_pubkey(&self, _pubkey: &str) -> Result<()> {
         // IndexedDB not yet implemented — node selection will not survive reload.
         log::warn!("save_active_mostro_pubkey: IndexedDB backend not implemented — node selection will not survive reload");

--- a/rust/src/db/mod.rs
+++ b/rust/src/db/mod.rs
@@ -76,6 +76,14 @@ pub trait Storage: Send + Sync {
     /// Return the currently active Mostro node, or `None` if none has been saved.
     async fn get_active_mostro_node(&self) -> Result<Option<crate::api::types::MostroNodeInfo>>;
 
+    /// Persist the active Mostro node's pubkey (hex). This is the *identity* of
+    /// the selected node — node metadata (kind 0 / 38385) is a separate concern.
+    async fn save_active_mostro_pubkey(&self, pubkey: &str) -> Result<()>;
+
+    /// Return the persisted active Mostro node pubkey, or `None` if the user has
+    /// not selected one (callers fall back to the compiled-in default).
+    async fn get_active_mostro_pubkey(&self) -> Result<Option<String>>;
+
     /// Look up a persisted trade by the order ID it is associated with.
     async fn get_trade_by_order_id(
         &self,

--- a/rust/src/db/mod.rs
+++ b/rust/src/db/mod.rs
@@ -70,12 +70,6 @@ pub trait Storage: Send + Sync {
 
     // ── Settings / Mostro node ────────────────────────────────────────────────
 
-    /// Persist a Mostro node info record, replacing any existing one.
-    async fn save_mostro_node(&self, node: &crate::api::types::MostroNodeInfo) -> Result<()>;
-
-    /// Return the currently active Mostro node, or `None` if none has been saved.
-    async fn get_active_mostro_node(&self) -> Result<Option<crate::api::types::MostroNodeInfo>>;
-
     /// Persist the active Mostro node's pubkey (hex). This is the *identity* of
     /// the selected node — node metadata (kind 0 / 38385) is a separate concern.
     async fn save_active_mostro_pubkey(&self, pubkey: &str) -> Result<()>;

--- a/rust/src/db/seeds.rs
+++ b/rust/src/db/seeds.rs
@@ -4,14 +4,13 @@
 /// All operations are idempotent (IF NOT EXISTS / skip-if-present).
 use anyhow::Result;
 
-use crate::api::types::{MostroNodeInfo, RelayInfo, RelaySource, RelayStatus};
+use crate::api::types::{RelayInfo, RelaySource, RelayStatus};
 use crate::config;
 use crate::db::Storage;
 
-/// Seed default relays and the default Mostro node if not already present.
+/// Seed default relays if not already present.
 pub async fn seed_defaults<S: Storage>(storage: &S) -> Result<()> {
     seed_default_relays(storage).await?;
-    seed_default_mostro_node(storage).await?;
     Ok(())
 }
 
@@ -37,33 +36,4 @@ async fn seed_default_relays<S: Storage>(storage: &S) -> Result<()> {
     }
 
     Ok(())
-}
-
-/// Seed the default Mostro node if no active node is configured.
-async fn seed_default_mostro_node<S: Storage>(storage: &S) -> Result<()> {
-    if storage.get_active_mostro_node().await?.is_some() {
-        return Ok(());
-    }
-    let node = get_default_mostro_node();
-    storage.save_mostro_node(&node).await?;
-    log::info!("[seeds] default Mostro node seeded: {}", node.pubkey);
-    Ok(())
-}
-
-/// Get the default Mostro node info from compiled constants.
-pub fn get_default_mostro_node() -> MostroNodeInfo {
-    MostroNodeInfo {
-        pubkey: config::DEFAULT_MOSTRO_PUBKEY.to_string(),
-        name: Some(config::DEFAULT_MOSTRO_NAME.to_string()),
-        version: None,
-        expiration_hours: 24,
-        expiration_seconds: 900,
-        fee_pct: None,
-        max_order_amount: None,
-        min_order_amount: None,
-        supported_currencies: None,
-        ln_node_id: None,
-        ln_node_alias: None,
-        is_active: true,
-    }
 }

--- a/rust/src/db/sqlite.rs
+++ b/rust/src/db/sqlite.rs
@@ -399,6 +399,25 @@ impl Storage for SqliteStorage {
         }
     }
 
+    async fn save_active_mostro_pubkey(&self, pubkey: &str) -> Result<()> {
+        sqlx::query(
+            "INSERT OR REPLACE INTO settings (key, value) VALUES ('active_mostro_pubkey', ?)",
+        )
+        .bind(pubkey)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn get_active_mostro_pubkey(&self) -> Result<Option<String>> {
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT value FROM settings WHERE key = 'active_mostro_pubkey'",
+        )
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.map(|(v,)| v))
+    }
+
     async fn get_trade_by_order_id(&self, order_id: &str) -> Result<Option<TradeInfo>> {
         // The `data` column holds the full JSON-serialised TradeInfo; use
         // SQLite's json_extract to filter by the nested order id without
@@ -487,5 +506,47 @@ impl Storage for SqliteStorage {
         query = query.bind(order_id);
         query.execute(&self.pool).await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    /// Build a unique temp DB path so parallel tests never collide.
+    fn temp_db_path() -> std::path::PathBuf {
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!("mostro_test_{}_{n}.db", std::process::id()))
+    }
+
+    #[tokio::test]
+    async fn active_mostro_pubkey_round_trip() {
+        let path = temp_db_path();
+        let path_str = path.to_str().unwrap().to_string();
+        let storage = SqliteStorage::open(&path_str).await.unwrap();
+
+        // Absent until the user selects a node.
+        assert_eq!(storage.get_active_mostro_pubkey().await.unwrap(), None);
+
+        // Save then read back.
+        let pk = "82fa8cb978b43c79b2156585bac2c011176a21d2aead6d9f7c575c005be88390";
+        storage.save_active_mostro_pubkey(pk).await.unwrap();
+        assert_eq!(
+            storage.get_active_mostro_pubkey().await.unwrap().as_deref(),
+            Some(pk)
+        );
+
+        // INSERT OR REPLACE overwrites in place — no duplicate "active" row.
+        let pk2 = "0000000000000000000000000000000000000000000000000000000000000001";
+        storage.save_active_mostro_pubkey(pk2).await.unwrap();
+        assert_eq!(
+            storage.get_active_mostro_pubkey().await.unwrap().as_deref(),
+            Some(pk2)
+        );
+
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
     }
 }

--- a/rust/src/db/sqlite.rs
+++ b/rust/src/db/sqlite.rs
@@ -374,31 +374,6 @@ impl Storage for SqliteStorage {
         Ok(())
     }
 
-    async fn save_mostro_node(&self, node: &crate::api::types::MostroNodeInfo) -> Result<()> {
-        let json = serde_json::to_string(node)?;
-        sqlx::query(
-            "INSERT OR REPLACE INTO settings (key, value) VALUES ('active_mostro_node', ?)",
-        )
-        .bind(&json)
-        .execute(&self.pool)
-        .await?;
-        Ok(())
-    }
-
-    async fn get_active_mostro_node(
-        &self,
-    ) -> Result<Option<crate::api::types::MostroNodeInfo>> {
-        let row: Option<(String,)> = sqlx::query_as(
-            "SELECT value FROM settings WHERE key = 'active_mostro_node'",
-        )
-        .fetch_optional(&self.pool)
-        .await?;
-        match row {
-            None => Ok(None),
-            Some((json,)) => Ok(Some(serde_json::from_str(&json)?)),
-        }
-    }
-
     async fn save_active_mostro_pubkey(&self, pubkey: &str) -> Result<()> {
         sqlx::query(
             "INSERT OR REPLACE INTO settings (key, value) VALUES ('active_mostro_pubkey', ?)",

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -45,7 +45,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 424169504;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1076654506;
 
 // Section: executor
 
@@ -333,6 +333,63 @@ fn wire__crate__api__messages__MessageStream_next_impl(
                         let output_ok = Result::<_, ()>::Ok(
                             crate::api::messages::MessageStream::next(&mut *api_that_guard).await,
                         )?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__orders__OrderBook_clear_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "OrderBook_clear",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<OrderBook>,
+            >>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, ()>(
+                    (move || async move {
+                        let mut api_that_guard = None;
+                        let decode_indices_ =
+                            flutter_rust_bridge::for_generated::lockable_compute_decode_order(
+                                vec![flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                    &api_that, 0, false,
+                                )],
+                            );
+                        for i in decode_indices_ {
+                            match i {
+                                0 => {
+                                    api_that_guard =
+                                        Some(api_that.lockable_decode_async_ref().await)
+                                }
+                                _ => unreachable!(),
+                            }
+                        }
+                        let api_that_guard = api_that_guard.unwrap();
+                        let output_ok = Result::<_, ()>::Ok({
+                            crate::api::orders::OrderBook::clear(&*api_that_guard).await;
+                        })?;
                         Ok(output_ok)
                     })()
                     .await,
@@ -3548,6 +3605,43 @@ fn wire__crate__api__messages__send_message_impl(
         },
     )
 }
+fn wire__crate__api__settings__set_active_mostro_node_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "set_active_mostro_node",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_pubkey = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || async move {
+                        let output_ok =
+                            crate::api::settings::set_active_mostro_node(api_pubkey).await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
 fn wire__crate__api__settings__set_default_fiat_code_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -5450,217 +5544,224 @@ fn pde_ffi_dispatcher_primary_impl(
         3 => wire__crate__api__disputes__DisputeStream_next_impl(port, ptr, rust_vec_len, data_len),
         4 => wire__crate__api__logging__LogEntryStream_next_impl(port, ptr, rust_vec_len, data_len),
         5 => wire__crate__api__messages__MessageStream_next_impl(port, ptr, rust_vec_len, data_len),
-        6 => wire__crate__api__orders__OrderBook_default_impl(port, ptr, rust_vec_len, data_len),
-        7 => wire__crate__api__orders__OrderBook_get_order_impl(port, ptr, rust_vec_len, data_len),
-        8 => wire__crate__api__orders__OrderBook_get_orders_impl(port, ptr, rust_vec_len, data_len),
-        9 => wire__crate__api__orders__OrderBook_new_impl(port, ptr, rust_vec_len, data_len),
-        10 => {
+        6 => wire__crate__api__orders__OrderBook_clear_impl(port, ptr, rust_vec_len, data_len),
+        7 => wire__crate__api__orders__OrderBook_default_impl(port, ptr, rust_vec_len, data_len),
+        8 => wire__crate__api__orders__OrderBook_get_order_impl(port, ptr, rust_vec_len, data_len),
+        9 => wire__crate__api__orders__OrderBook_get_orders_impl(port, ptr, rust_vec_len, data_len),
+        10 => wire__crate__api__orders__OrderBook_new_impl(port, ptr, rust_vec_len, data_len),
+        11 => {
             wire__crate__api__orders__OrderBook_remove_order_impl(port, ptr, rust_vec_len, data_len)
         }
-        11 => {
+        12 => {
             wire__crate__api__orders__OrderBook_set_orders_impl(port, ptr, rust_vec_len, data_len)
         }
-        12 => wire__crate__api__orders__OrderBook_update_order_status_impl(
+        13 => wire__crate__api__orders__OrderBook_update_order_status_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        13 => {
+        14 => {
             wire__crate__api__orders__OrderBook_upsert_order_impl(port, ptr, rust_vec_len, data_len)
         }
-        14 => wire__crate__api__orders__OrdersStream_next_impl(port, ptr, rust_vec_len, data_len),
-        15 => {
+        15 => wire__crate__api__orders__OrdersStream_next_impl(port, ptr, rust_vec_len, data_len),
+        16 => {
             wire__crate__api__reputation__RatingStream_next_impl(port, ptr, rust_vec_len, data_len)
         }
-        16 => {
+        17 => {
             wire__crate__api__nostr__RelayStatusStream_next_impl(port, ptr, rust_vec_len, data_len)
         }
-        17 => {
+        18 => {
             wire__crate__api__settings__SettingsStream_next_impl(port, ptr, rust_vec_len, data_len)
         }
-        18 => wire__crate__api__messages__UnreadCountStream_next_impl(
+        19 => wire__crate__api__messages__UnreadCountStream_next_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        19 => {
+        20 => {
             wire__crate__api__nwc__WalletStatusStream_next_impl(port, ptr, rust_vec_len, data_len)
         }
-        20 => wire__crate__api__nostr__add_relay_impl(port, ptr, rust_vec_len, data_len),
-        21 => wire__crate__api__orders__cancel_order_impl(port, ptr, rust_vec_len, data_len),
-        22 => wire__crate__api__nwc__connect_wallet_impl(port, ptr, rust_vec_len, data_len),
-        23 => wire__crate__api__identity__create_identity_impl(port, ptr, rust_vec_len, data_len),
-        24 => wire__crate__api__orders__create_order_impl(port, ptr, rust_vec_len, data_len),
-        25 => wire__crate__api__identity__delete_identity_impl(port, ptr, rust_vec_len, data_len),
-        26 => wire__crate__api__identity__derive_trade_key_impl(port, ptr, rust_vec_len, data_len),
-        27 => wire__crate__api__nwc__disconnect_wallet_impl(port, ptr, rust_vec_len, data_len),
-        28 => {
+        21 => wire__crate__api__nostr__add_relay_impl(port, ptr, rust_vec_len, data_len),
+        22 => wire__crate__api__orders__cancel_order_impl(port, ptr, rust_vec_len, data_len),
+        23 => wire__crate__api__nwc__connect_wallet_impl(port, ptr, rust_vec_len, data_len),
+        24 => wire__crate__api__identity__create_identity_impl(port, ptr, rust_vec_len, data_len),
+        25 => wire__crate__api__orders__create_order_impl(port, ptr, rust_vec_len, data_len),
+        26 => wire__crate__api__identity__delete_identity_impl(port, ptr, rust_vec_len, data_len),
+        27 => wire__crate__api__identity__derive_trade_key_impl(port, ptr, rust_vec_len, data_len),
+        28 => wire__crate__api__nwc__disconnect_wallet_impl(port, ptr, rust_vec_len, data_len),
+        29 => {
             wire__crate__api__messages__download_attachment_impl(port, ptr, rust_vec_len, data_len)
         }
-        29 => wire__crate__api__identity__export_encrypted_backup_impl(
+        30 => wire__crate__api__identity__export_encrypted_backup_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        30 => wire__crate__api__nostr__fetch_mostro_instance_tags_impl(
+        31 => wire__crate__api__nostr__fetch_mostro_instance_tags_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        31 => wire__crate__api__nostr__flush_message_queue_impl(port, ptr, rust_vec_len, data_len),
-        32 => wire__crate__api__get_app_version_impl(port, ptr, rust_vec_len, data_len),
-        33 => wire__crate__api__messages__get_attachment_status_impl(
+        32 => wire__crate__api__nostr__flush_message_queue_impl(port, ptr, rust_vec_len, data_len),
+        33 => wire__crate__api__get_app_version_impl(port, ptr, rust_vec_len, data_len),
+        34 => wire__crate__api__messages__get_attachment_status_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        34 => wire__crate__api__nwc__get_balance_impl(port, ptr, rust_vec_len, data_len),
-        35 => wire__crate__api__nostr__get_connection_state_impl(port, ptr, rust_vec_len, data_len),
-        36 => wire__crate__api__disputes__get_dispute_impl(port, ptr, rust_vec_len, data_len),
-        37 => wire__crate__api__identity__get_identity_impl(port, ptr, rust_vec_len, data_len),
-        38 => wire__crate__api__messages__get_messages_impl(port, ptr, rust_vec_len, data_len),
-        39 => wire__crate__api__settings__get_mostro_node_impl(port, ptr, rust_vec_len, data_len),
-        40 => wire__crate__api__settings__get_mostro_pubkey_impl(port, ptr, rust_vec_len, data_len),
-        41 => wire__crate__api__identity__get_nym_identity_impl(port, ptr, rust_vec_len, data_len),
-        42 => wire__crate__api__orders__get_order_impl(port, ptr, rust_vec_len, data_len),
-        43 => wire__crate__api__orders__get_orders_impl(port, ptr, rust_vec_len, data_len),
-        44 => {
+        35 => wire__crate__api__nwc__get_balance_impl(port, ptr, rust_vec_len, data_len),
+        36 => wire__crate__api__nostr__get_connection_state_impl(port, ptr, rust_vec_len, data_len),
+        37 => wire__crate__api__disputes__get_dispute_impl(port, ptr, rust_vec_len, data_len),
+        38 => wire__crate__api__identity__get_identity_impl(port, ptr, rust_vec_len, data_len),
+        39 => wire__crate__api__messages__get_messages_impl(port, ptr, rust_vec_len, data_len),
+        40 => wire__crate__api__settings__get_mostro_node_impl(port, ptr, rust_vec_len, data_len),
+        41 => wire__crate__api__settings__get_mostro_pubkey_impl(port, ptr, rust_vec_len, data_len),
+        42 => wire__crate__api__identity__get_nym_identity_impl(port, ptr, rust_vec_len, data_len),
+        43 => wire__crate__api__orders__get_order_impl(port, ptr, rust_vec_len, data_len),
+        44 => wire__crate__api__orders__get_orders_impl(port, ptr, rust_vec_len, data_len),
+        45 => {
             wire__crate__api__reputation__get_privacy_mode_impl(port, ptr, rust_vec_len, data_len)
         }
-        45 => wire__crate__api__reputation__get_rating_for_trade_impl(
+        46 => wire__crate__api__reputation__get_rating_for_trade_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        46 => wire__crate__api__nostr__get_relays_impl(port, ptr, rust_vec_len, data_len),
-        47 => wire__crate__api__settings__get_settings_impl(port, ptr, rust_vec_len, data_len),
-        48 => wire__crate__api__identity__get_trade_key_impl(port, ptr, rust_vec_len, data_len),
-        49 => wire__crate__api__orders__get_trade_role_impl(port, ptr, rust_vec_len, data_len),
-        50 => wire__crate__api__messages__get_unread_count_impl(port, ptr, rust_vec_len, data_len),
-        51 => wire__crate__api__nwc__get_wallet_impl(port, ptr, rust_vec_len, data_len),
-        52 => wire__crate__api__disputes__handle_admin_canceled_impl(
+        47 => wire__crate__api__nostr__get_relays_impl(port, ptr, rust_vec_len, data_len),
+        48 => wire__crate__api__settings__get_settings_impl(port, ptr, rust_vec_len, data_len),
+        49 => wire__crate__api__identity__get_trade_key_impl(port, ptr, rust_vec_len, data_len),
+        50 => wire__crate__api__orders__get_trade_role_impl(port, ptr, rust_vec_len, data_len),
+        51 => wire__crate__api__messages__get_unread_count_impl(port, ptr, rust_vec_len, data_len),
+        52 => wire__crate__api__nwc__get_wallet_impl(port, ptr, rust_vec_len, data_len),
+        53 => wire__crate__api__disputes__handle_admin_canceled_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        53 => {
+        54 => {
             wire__crate__api__disputes__handle_admin_settled_impl(port, ptr, rust_vec_len, data_len)
         }
-        54 => wire__crate__api__disputes__handle_admin_took_dispute_impl(
+        55 => wire__crate__api__disputes__handle_admin_took_dispute_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        55 => wire__crate__api__reputation__handle_rating_received_impl(
+        56 => wire__crate__api__reputation__handle_rating_received_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        56 => {
+        57 => {
             wire__crate__api__identity__import_from_mnemonic_impl(port, ptr, rust_vec_len, data_len)
         }
-        57 => wire__crate__api__identity__import_from_nsec_impl(port, ptr, rust_vec_len, data_len),
-        58 => wire__crate__api__init_db_impl(port, ptr, rust_vec_len, data_len),
-        59 => wire__crate__api__nostr__initialize_impl(port, ptr, rust_vec_len, data_len),
-        60 => wire__crate__api__logging__install_log_bridge_impl(port, ptr, rust_vec_len, data_len),
-        61 => wire__crate__api__orders__list_trades_impl(port, ptr, rust_vec_len, data_len),
-        62 => wire__crate__api__identity__load_identity_from_mnemonic_impl(
+        58 => wire__crate__api__identity__import_from_nsec_impl(port, ptr, rust_vec_len, data_len),
+        59 => wire__crate__api__init_db_impl(port, ptr, rust_vec_len, data_len),
+        60 => wire__crate__api__nostr__initialize_impl(port, ptr, rust_vec_len, data_len),
+        61 => wire__crate__api__logging__install_log_bridge_impl(port, ptr, rust_vec_len, data_len),
+        62 => wire__crate__api__orders__list_trades_impl(port, ptr, rust_vec_len, data_len),
+        63 => wire__crate__api__identity__load_identity_from_mnemonic_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        63 => wire__crate__api__nwc__make_invoice_impl(port, ptr, rust_vec_len, data_len),
-        64 => wire__crate__api__messages__mark_as_read_impl(port, ptr, rust_vec_len, data_len),
-        65 => wire__crate__api__messages__on_attachment_progress_impl(
+        64 => wire__crate__api__nwc__make_invoice_impl(port, ptr, rust_vec_len, data_len),
+        65 => wire__crate__api__messages__mark_as_read_impl(port, ptr, rust_vec_len, data_len),
+        66 => wire__crate__api__messages__on_attachment_progress_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        66 => wire__crate__api__nostr__on_connection_state_changed_impl(
+        67 => wire__crate__api__nostr__on_connection_state_changed_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        67 => {
+        68 => {
             wire__crate__api__disputes__on_dispute_updated_impl(port, ptr, rust_vec_len, data_len)
         }
-        68 => wire__crate__api__logging__on_log_entry_impl(port, ptr, rust_vec_len, data_len),
-        69 => wire__crate__api__messages__on_new_message_impl(port, ptr, rust_vec_len, data_len),
-        70 => wire__crate__api__orders__on_orders_updated_impl(port, ptr, rust_vec_len, data_len),
-        71 => {
+        69 => wire__crate__api__logging__on_log_entry_impl(port, ptr, rust_vec_len, data_len),
+        70 => wire__crate__api__messages__on_new_message_impl(port, ptr, rust_vec_len, data_len),
+        71 => wire__crate__api__orders__on_orders_updated_impl(port, ptr, rust_vec_len, data_len),
+        72 => {
             wire__crate__api__reputation__on_rating_received_impl(port, ptr, rust_vec_len, data_len)
         }
-        72 => {
+        73 => {
             wire__crate__api__nostr__on_relay_status_changed_impl(port, ptr, rust_vec_len, data_len)
         }
-        73 => {
+        74 => {
             wire__crate__api__settings__on_settings_changed_impl(port, ptr, rust_vec_len, data_len)
         }
-        74 => wire__crate__api__messages__on_unread_count_changed_impl(
+        75 => wire__crate__api__messages__on_unread_count_changed_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        75 => {
+        76 => {
             wire__crate__api__nwc__on_wallet_status_changed_impl(port, ptr, rust_vec_len, data_len)
         }
-        76 => wire__crate__api__disputes__open_dispute_impl(port, ptr, rust_vec_len, data_len),
-        77 => {
+        77 => wire__crate__api__disputes__open_dispute_impl(port, ptr, rust_vec_len, data_len),
+        78 => {
             wire__crate__api__orders__order_filters_default_impl(port, ptr, rust_vec_len, data_len)
         }
-        78 => wire__crate__api__nwc__pay_invoice_impl(port, ptr, rust_vec_len, data_len),
-        79 => wire__crate__api__orders__release_order_impl(port, ptr, rust_vec_len, data_len),
-        80 => wire__crate__api__nostr__remove_relay_impl(port, ptr, rust_vec_len, data_len),
-        81 => wire__crate__api__orders__resolve_maker_order_impl(port, ptr, rust_vec_len, data_len),
-        82 => wire__crate__api__orders__restart_orders_subscription_impl(
+        79 => wire__crate__api__nwc__pay_invoice_impl(port, ptr, rust_vec_len, data_len),
+        80 => wire__crate__api__orders__release_order_impl(port, ptr, rust_vec_len, data_len),
+        81 => wire__crate__api__nostr__remove_relay_impl(port, ptr, rust_vec_len, data_len),
+        82 => wire__crate__api__orders__resolve_maker_order_impl(port, ptr, rust_vec_len, data_len),
+        83 => wire__crate__api__orders__restart_orders_subscription_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        83 => wire__crate__api__orders__send_fiat_sent_impl(port, ptr, rust_vec_len, data_len),
-        84 => wire__crate__api__messages__send_file_impl(port, ptr, rust_vec_len, data_len),
-        85 => wire__crate__api__orders__send_invoice_impl(port, ptr, rust_vec_len, data_len),
-        86 => wire__crate__api__messages__send_message_impl(port, ptr, rust_vec_len, data_len),
-        87 => wire__crate__api__settings__set_default_fiat_code_impl(
+        84 => wire__crate__api__orders__send_fiat_sent_impl(port, ptr, rust_vec_len, data_len),
+        85 => wire__crate__api__messages__send_file_impl(port, ptr, rust_vec_len, data_len),
+        86 => wire__crate__api__orders__send_invoice_impl(port, ptr, rust_vec_len, data_len),
+        87 => wire__crate__api__messages__send_message_impl(port, ptr, rust_vec_len, data_len),
+        88 => wire__crate__api__settings__set_active_mostro_node_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        88 => wire__crate__api__settings__set_default_lightning_address_impl(
+        89 => wire__crate__api__settings__set_default_fiat_code_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        89 => wire__crate__api__settings__set_language_impl(port, ptr, rust_vec_len, data_len),
-        90 => {
+        90 => wire__crate__api__settings__set_default_lightning_address_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        91 => wire__crate__api__settings__set_language_impl(port, ptr, rust_vec_len, data_len),
+        92 => {
             wire__crate__api__settings__set_logging_enabled_impl(port, ptr, rust_vec_len, data_len)
         }
-        91 => wire__crate__api__settings__set_mostro_node_impl(port, ptr, rust_vec_len, data_len),
-        92 => wire__crate__api__settings__set_mostro_pubkey_impl(port, ptr, rust_vec_len, data_len),
-        93 => {
+        93 => wire__crate__api__settings__set_mostro_node_impl(port, ptr, rust_vec_len, data_len),
+        94 => wire__crate__api__settings__set_mostro_pubkey_impl(port, ptr, rust_vec_len, data_len),
+        95 => {
             wire__crate__api__reputation__set_privacy_mode_impl(port, ptr, rust_vec_len, data_len)
         }
-        94 => wire__crate__api__settings__set_theme_impl(port, ptr, rust_vec_len, data_len),
-        95 => wire__crate__api__disputes__submit_evidence_impl(port, ptr, rust_vec_len, data_len),
-        96 => wire__crate__api__reputation__submit_rating_impl(port, ptr, rust_vec_len, data_len),
-        97 => wire__crate__api__orders__subscribe_orders_impl(port, ptr, rust_vec_len, data_len),
-        98 => wire__crate__api__orders__take_order_impl(port, ptr, rust_vec_len, data_len),
+        96 => wire__crate__api__settings__set_theme_impl(port, ptr, rust_vec_len, data_len),
+        97 => wire__crate__api__disputes__submit_evidence_impl(port, ptr, rust_vec_len, data_len),
+        98 => wire__crate__api__reputation__submit_rating_impl(port, ptr, rust_vec_len, data_len),
+        99 => wire__crate__api__orders__subscribe_orders_impl(port, ptr, rust_vec_len, data_len),
+        100 => wire__crate__api__orders__take_order_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -45,7 +45,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1636138478;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 426373470;
 
 // Section: executor
 
@@ -1845,41 +1845,6 @@ fn wire__crate__api__messages__get_messages_impl(
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
                     (move || async move {
                         let output_ok = crate::api::messages::get_messages(api_trade_id).await?;
-                        Ok(output_ok)
-                    })()
-                    .await,
-                )
-            }
-        },
-    )
-}
-fn wire__crate__api__settings__get_mostro_node_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "get_mostro_node",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            deserializer.end();
-            move |context| async move {
-                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
-                    (move || async move {
-                        let output_ok = crate::api::settings::get_mostro_node().await?;
                         Ok(output_ok)
                     })()
                     .await,
@@ -3824,77 +3789,6 @@ fn wire__crate__api__settings__set_logging_enabled_impl(
         },
     )
 }
-fn wire__crate__api__settings__set_mostro_node_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "set_mostro_node",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_node = <crate::api::types::MostroNodeInfo>::sse_decode(&mut deserializer);
-            deserializer.end();
-            move |context| async move {
-                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
-                    (move || async move {
-                        let output_ok = crate::api::settings::set_mostro_node(api_node).await?;
-                        Ok(output_ok)
-                    })()
-                    .await,
-                )
-            }
-        },
-    )
-}
-fn wire__crate__api__settings__set_mostro_pubkey_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "set_mostro_pubkey",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_pubkey = <Option<String>>::sse_decode(&mut deserializer);
-            deserializer.end();
-            move |context| {
-                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
-                    (move || {
-                        let output_ok = crate::api::settings::set_mostro_pubkey(api_pubkey)?;
-                        Ok(output_ok)
-                    })(),
-                )
-            }
-        },
-    )
-}
 fn wire__crate__api__reputation__set_privacy_mode_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -4817,38 +4711,6 @@ impl SseDecode for crate::api::types::MessageType {
     }
 }
 
-impl SseDecode for crate::api::types::MostroNodeInfo {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_pubkey = <String>::sse_decode(deserializer);
-        let mut var_name = <Option<String>>::sse_decode(deserializer);
-        let mut var_version = <Option<String>>::sse_decode(deserializer);
-        let mut var_expirationHours = <u32>::sse_decode(deserializer);
-        let mut var_expirationSeconds = <u32>::sse_decode(deserializer);
-        let mut var_feePct = <Option<f64>>::sse_decode(deserializer);
-        let mut var_maxOrderAmount = <Option<u64>>::sse_decode(deserializer);
-        let mut var_minOrderAmount = <Option<u64>>::sse_decode(deserializer);
-        let mut var_supportedCurrencies = <Option<Vec<String>>>::sse_decode(deserializer);
-        let mut var_lnNodeId = <Option<String>>::sse_decode(deserializer);
-        let mut var_lnNodeAlias = <Option<String>>::sse_decode(deserializer);
-        let mut var_isActive = <bool>::sse_decode(deserializer);
-        return crate::api::types::MostroNodeInfo {
-            pubkey: var_pubkey,
-            name: var_name,
-            version: var_version,
-            expiration_hours: var_expirationHours,
-            expiration_seconds: var_expirationSeconds,
-            fee_pct: var_feePct,
-            max_order_amount: var_maxOrderAmount,
-            min_order_amount: var_minOrderAmount,
-            supported_currencies: var_supportedCurrencies,
-            ln_node_id: var_lnNodeId,
-            ln_node_alias: var_lnNodeAlias,
-            is_active: var_isActive,
-        };
-    }
-}
-
 impl SseDecode for crate::api::types::NewOrderParams {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -5655,155 +5517,152 @@ fn pde_ffi_dispatcher_primary_impl(
         37 => wire__crate__api__disputes__get_dispute_impl(port, ptr, rust_vec_len, data_len),
         38 => wire__crate__api__identity__get_identity_impl(port, ptr, rust_vec_len, data_len),
         39 => wire__crate__api__messages__get_messages_impl(port, ptr, rust_vec_len, data_len),
-        40 => wire__crate__api__settings__get_mostro_node_impl(port, ptr, rust_vec_len, data_len),
-        41 => wire__crate__api__settings__get_mostro_pubkey_impl(port, ptr, rust_vec_len, data_len),
-        42 => wire__crate__api__identity__get_nym_identity_impl(port, ptr, rust_vec_len, data_len),
-        43 => wire__crate__api__orders__get_order_impl(port, ptr, rust_vec_len, data_len),
-        44 => wire__crate__api__orders__get_orders_impl(port, ptr, rust_vec_len, data_len),
-        45 => {
+        40 => wire__crate__api__settings__get_mostro_pubkey_impl(port, ptr, rust_vec_len, data_len),
+        41 => wire__crate__api__identity__get_nym_identity_impl(port, ptr, rust_vec_len, data_len),
+        42 => wire__crate__api__orders__get_order_impl(port, ptr, rust_vec_len, data_len),
+        43 => wire__crate__api__orders__get_orders_impl(port, ptr, rust_vec_len, data_len),
+        44 => {
             wire__crate__api__reputation__get_privacy_mode_impl(port, ptr, rust_vec_len, data_len)
         }
-        46 => wire__crate__api__reputation__get_rating_for_trade_impl(
+        45 => wire__crate__api__reputation__get_rating_for_trade_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        47 => wire__crate__api__nostr__get_relays_impl(port, ptr, rust_vec_len, data_len),
-        48 => wire__crate__api__settings__get_settings_impl(port, ptr, rust_vec_len, data_len),
-        49 => wire__crate__api__identity__get_trade_key_impl(port, ptr, rust_vec_len, data_len),
-        50 => wire__crate__api__orders__get_trade_role_impl(port, ptr, rust_vec_len, data_len),
-        51 => wire__crate__api__messages__get_unread_count_impl(port, ptr, rust_vec_len, data_len),
-        52 => wire__crate__api__nwc__get_wallet_impl(port, ptr, rust_vec_len, data_len),
-        53 => wire__crate__api__disputes__handle_admin_canceled_impl(
+        46 => wire__crate__api__nostr__get_relays_impl(port, ptr, rust_vec_len, data_len),
+        47 => wire__crate__api__settings__get_settings_impl(port, ptr, rust_vec_len, data_len),
+        48 => wire__crate__api__identity__get_trade_key_impl(port, ptr, rust_vec_len, data_len),
+        49 => wire__crate__api__orders__get_trade_role_impl(port, ptr, rust_vec_len, data_len),
+        50 => wire__crate__api__messages__get_unread_count_impl(port, ptr, rust_vec_len, data_len),
+        51 => wire__crate__api__nwc__get_wallet_impl(port, ptr, rust_vec_len, data_len),
+        52 => wire__crate__api__disputes__handle_admin_canceled_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        54 => {
+        53 => {
             wire__crate__api__disputes__handle_admin_settled_impl(port, ptr, rust_vec_len, data_len)
         }
-        55 => wire__crate__api__disputes__handle_admin_took_dispute_impl(
+        54 => wire__crate__api__disputes__handle_admin_took_dispute_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        56 => wire__crate__api__reputation__handle_rating_received_impl(
+        55 => wire__crate__api__reputation__handle_rating_received_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        57 => {
+        56 => {
             wire__crate__api__identity__import_from_mnemonic_impl(port, ptr, rust_vec_len, data_len)
         }
-        58 => wire__crate__api__identity__import_from_nsec_impl(port, ptr, rust_vec_len, data_len),
-        59 => wire__crate__api__init_db_impl(port, ptr, rust_vec_len, data_len),
-        60 => wire__crate__api__nostr__initialize_impl(port, ptr, rust_vec_len, data_len),
-        61 => wire__crate__api__logging__install_log_bridge_impl(port, ptr, rust_vec_len, data_len),
-        62 => wire__crate__api__orders__list_trades_impl(port, ptr, rust_vec_len, data_len),
-        63 => wire__crate__api__identity__load_identity_from_mnemonic_impl(
+        57 => wire__crate__api__identity__import_from_nsec_impl(port, ptr, rust_vec_len, data_len),
+        58 => wire__crate__api__init_db_impl(port, ptr, rust_vec_len, data_len),
+        59 => wire__crate__api__nostr__initialize_impl(port, ptr, rust_vec_len, data_len),
+        60 => wire__crate__api__logging__install_log_bridge_impl(port, ptr, rust_vec_len, data_len),
+        61 => wire__crate__api__orders__list_trades_impl(port, ptr, rust_vec_len, data_len),
+        62 => wire__crate__api__identity__load_identity_from_mnemonic_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        64 => wire__crate__api__nwc__make_invoice_impl(port, ptr, rust_vec_len, data_len),
-        65 => wire__crate__api__messages__mark_as_read_impl(port, ptr, rust_vec_len, data_len),
-        66 => wire__crate__api__messages__on_attachment_progress_impl(
+        63 => wire__crate__api__nwc__make_invoice_impl(port, ptr, rust_vec_len, data_len),
+        64 => wire__crate__api__messages__mark_as_read_impl(port, ptr, rust_vec_len, data_len),
+        65 => wire__crate__api__messages__on_attachment_progress_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        67 => wire__crate__api__nostr__on_connection_state_changed_impl(
+        66 => wire__crate__api__nostr__on_connection_state_changed_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        68 => {
+        67 => {
             wire__crate__api__disputes__on_dispute_updated_impl(port, ptr, rust_vec_len, data_len)
         }
-        69 => wire__crate__api__logging__on_log_entry_impl(port, ptr, rust_vec_len, data_len),
-        70 => wire__crate__api__messages__on_new_message_impl(port, ptr, rust_vec_len, data_len),
-        71 => wire__crate__api__orders__on_orders_updated_impl(port, ptr, rust_vec_len, data_len),
-        72 => {
+        68 => wire__crate__api__logging__on_log_entry_impl(port, ptr, rust_vec_len, data_len),
+        69 => wire__crate__api__messages__on_new_message_impl(port, ptr, rust_vec_len, data_len),
+        70 => wire__crate__api__orders__on_orders_updated_impl(port, ptr, rust_vec_len, data_len),
+        71 => {
             wire__crate__api__reputation__on_rating_received_impl(port, ptr, rust_vec_len, data_len)
         }
-        73 => {
+        72 => {
             wire__crate__api__nostr__on_relay_status_changed_impl(port, ptr, rust_vec_len, data_len)
         }
-        74 => {
+        73 => {
             wire__crate__api__settings__on_settings_changed_impl(port, ptr, rust_vec_len, data_len)
         }
-        75 => wire__crate__api__messages__on_unread_count_changed_impl(
+        74 => wire__crate__api__messages__on_unread_count_changed_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        76 => {
+        75 => {
             wire__crate__api__nwc__on_wallet_status_changed_impl(port, ptr, rust_vec_len, data_len)
         }
-        77 => wire__crate__api__disputes__open_dispute_impl(port, ptr, rust_vec_len, data_len),
-        78 => {
+        76 => wire__crate__api__disputes__open_dispute_impl(port, ptr, rust_vec_len, data_len),
+        77 => {
             wire__crate__api__orders__order_filters_default_impl(port, ptr, rust_vec_len, data_len)
         }
-        79 => wire__crate__api__nwc__pay_invoice_impl(port, ptr, rust_vec_len, data_len),
-        80 => wire__crate__api__settings__rehydrate_active_mostro_node_impl(
+        78 => wire__crate__api__nwc__pay_invoice_impl(port, ptr, rust_vec_len, data_len),
+        79 => wire__crate__api__settings__rehydrate_active_mostro_node_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        81 => wire__crate__api__orders__release_order_impl(port, ptr, rust_vec_len, data_len),
-        82 => wire__crate__api__nostr__remove_relay_impl(port, ptr, rust_vec_len, data_len),
-        83 => wire__crate__api__orders__resolve_maker_order_impl(port, ptr, rust_vec_len, data_len),
-        84 => wire__crate__api__orders__restart_orders_subscription_impl(
+        80 => wire__crate__api__orders__release_order_impl(port, ptr, rust_vec_len, data_len),
+        81 => wire__crate__api__nostr__remove_relay_impl(port, ptr, rust_vec_len, data_len),
+        82 => wire__crate__api__orders__resolve_maker_order_impl(port, ptr, rust_vec_len, data_len),
+        83 => wire__crate__api__orders__restart_orders_subscription_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        85 => wire__crate__api__orders__send_fiat_sent_impl(port, ptr, rust_vec_len, data_len),
-        86 => wire__crate__api__messages__send_file_impl(port, ptr, rust_vec_len, data_len),
-        87 => wire__crate__api__orders__send_invoice_impl(port, ptr, rust_vec_len, data_len),
-        88 => wire__crate__api__messages__send_message_impl(port, ptr, rust_vec_len, data_len),
-        89 => wire__crate__api__settings__set_active_mostro_node_impl(
+        84 => wire__crate__api__orders__send_fiat_sent_impl(port, ptr, rust_vec_len, data_len),
+        85 => wire__crate__api__messages__send_file_impl(port, ptr, rust_vec_len, data_len),
+        86 => wire__crate__api__orders__send_invoice_impl(port, ptr, rust_vec_len, data_len),
+        87 => wire__crate__api__messages__send_message_impl(port, ptr, rust_vec_len, data_len),
+        88 => wire__crate__api__settings__set_active_mostro_node_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        90 => wire__crate__api__settings__set_default_fiat_code_impl(
+        89 => wire__crate__api__settings__set_default_fiat_code_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        91 => wire__crate__api__settings__set_default_lightning_address_impl(
+        90 => wire__crate__api__settings__set_default_lightning_address_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        92 => wire__crate__api__settings__set_language_impl(port, ptr, rust_vec_len, data_len),
-        93 => {
+        91 => wire__crate__api__settings__set_language_impl(port, ptr, rust_vec_len, data_len),
+        92 => {
             wire__crate__api__settings__set_logging_enabled_impl(port, ptr, rust_vec_len, data_len)
         }
-        94 => wire__crate__api__settings__set_mostro_node_impl(port, ptr, rust_vec_len, data_len),
-        95 => wire__crate__api__settings__set_mostro_pubkey_impl(port, ptr, rust_vec_len, data_len),
-        96 => {
+        93 => {
             wire__crate__api__reputation__set_privacy_mode_impl(port, ptr, rust_vec_len, data_len)
         }
-        97 => wire__crate__api__settings__set_theme_impl(port, ptr, rust_vec_len, data_len),
-        98 => wire__crate__api__disputes__submit_evidence_impl(port, ptr, rust_vec_len, data_len),
-        99 => wire__crate__api__reputation__submit_rating_impl(port, ptr, rust_vec_len, data_len),
-        100 => wire__crate__api__orders__subscribe_orders_impl(port, ptr, rust_vec_len, data_len),
-        101 => wire__crate__api__orders__take_order_impl(port, ptr, rust_vec_len, data_len),
+        94 => wire__crate__api__settings__set_theme_impl(port, ptr, rust_vec_len, data_len),
+        95 => wire__crate__api__disputes__submit_evidence_impl(port, ptr, rust_vec_len, data_len),
+        96 => wire__crate__api__reputation__submit_rating_impl(port, ptr, rust_vec_len, data_len),
+        97 => wire__crate__api__orders__subscribe_orders_impl(port, ptr, rust_vec_len, data_len),
+        98 => wire__crate__api__orders__take_order_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -6398,37 +6257,6 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::types::MessageType>
     for crate::api::types::MessageType
 {
     fn into_into_dart(self) -> crate::api::types::MessageType {
-        self
-    }
-}
-// Codec=Dco (DartCObject based), see doc to use other codecs
-impl flutter_rust_bridge::IntoDart for crate::api::types::MostroNodeInfo {
-    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        [
-            self.pubkey.into_into_dart().into_dart(),
-            self.name.into_into_dart().into_dart(),
-            self.version.into_into_dart().into_dart(),
-            self.expiration_hours.into_into_dart().into_dart(),
-            self.expiration_seconds.into_into_dart().into_dart(),
-            self.fee_pct.into_into_dart().into_dart(),
-            self.max_order_amount.into_into_dart().into_dart(),
-            self.min_order_amount.into_into_dart().into_dart(),
-            self.supported_currencies.into_into_dart().into_dart(),
-            self.ln_node_id.into_into_dart().into_dart(),
-            self.ln_node_alias.into_into_dart().into_dart(),
-            self.is_active.into_into_dart().into_dart(),
-        ]
-        .into_dart()
-    }
-}
-impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
-    for crate::api::types::MostroNodeInfo
-{
-}
-impl flutter_rust_bridge::IntoIntoDart<crate::api::types::MostroNodeInfo>
-    for crate::api::types::MostroNodeInfo
-{
-    fn into_into_dart(self) -> crate::api::types::MostroNodeInfo {
         self
     }
 }
@@ -7518,24 +7346,6 @@ impl SseEncode for crate::api::types::MessageType {
             },
             serializer,
         );
-    }
-}
-
-impl SseEncode for crate::api::types::MostroNodeInfo {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <String>::sse_encode(self.pubkey, serializer);
-        <Option<String>>::sse_encode(self.name, serializer);
-        <Option<String>>::sse_encode(self.version, serializer);
-        <u32>::sse_encode(self.expiration_hours, serializer);
-        <u32>::sse_encode(self.expiration_seconds, serializer);
-        <Option<f64>>::sse_encode(self.fee_pct, serializer);
-        <Option<u64>>::sse_encode(self.max_order_amount, serializer);
-        <Option<u64>>::sse_encode(self.min_order_amount, serializer);
-        <Option<Vec<String>>>::sse_encode(self.supported_currencies, serializer);
-        <Option<String>>::sse_encode(self.ln_node_id, serializer);
-        <Option<String>>::sse_encode(self.ln_node_alias, serializer);
-        <bool>::sse_encode(self.is_active, serializer);
     }
 }
 

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -45,7 +45,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1076654506;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1636138478;
 
 // Section: executor
 
@@ -3291,6 +3291,42 @@ fn wire__crate__api__nwc__pay_invoice_impl(
         },
     )
 }
+fn wire__crate__api__settings__rehydrate_active_mostro_node_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "rehydrate_active_mostro_node",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || async move {
+                        let output_ok =
+                            crate::api::settings::rehydrate_active_mostro_node().await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
 fn wire__crate__api__orders__release_order_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -5717,51 +5753,57 @@ fn pde_ffi_dispatcher_primary_impl(
             wire__crate__api__orders__order_filters_default_impl(port, ptr, rust_vec_len, data_len)
         }
         79 => wire__crate__api__nwc__pay_invoice_impl(port, ptr, rust_vec_len, data_len),
-        80 => wire__crate__api__orders__release_order_impl(port, ptr, rust_vec_len, data_len),
-        81 => wire__crate__api__nostr__remove_relay_impl(port, ptr, rust_vec_len, data_len),
-        82 => wire__crate__api__orders__resolve_maker_order_impl(port, ptr, rust_vec_len, data_len),
-        83 => wire__crate__api__orders__restart_orders_subscription_impl(
+        80 => wire__crate__api__settings__rehydrate_active_mostro_node_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        84 => wire__crate__api__orders__send_fiat_sent_impl(port, ptr, rust_vec_len, data_len),
-        85 => wire__crate__api__messages__send_file_impl(port, ptr, rust_vec_len, data_len),
-        86 => wire__crate__api__orders__send_invoice_impl(port, ptr, rust_vec_len, data_len),
-        87 => wire__crate__api__messages__send_message_impl(port, ptr, rust_vec_len, data_len),
-        88 => wire__crate__api__settings__set_active_mostro_node_impl(
+        81 => wire__crate__api__orders__release_order_impl(port, ptr, rust_vec_len, data_len),
+        82 => wire__crate__api__nostr__remove_relay_impl(port, ptr, rust_vec_len, data_len),
+        83 => wire__crate__api__orders__resolve_maker_order_impl(port, ptr, rust_vec_len, data_len),
+        84 => wire__crate__api__orders__restart_orders_subscription_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        89 => wire__crate__api__settings__set_default_fiat_code_impl(
+        85 => wire__crate__api__orders__send_fiat_sent_impl(port, ptr, rust_vec_len, data_len),
+        86 => wire__crate__api__messages__send_file_impl(port, ptr, rust_vec_len, data_len),
+        87 => wire__crate__api__orders__send_invoice_impl(port, ptr, rust_vec_len, data_len),
+        88 => wire__crate__api__messages__send_message_impl(port, ptr, rust_vec_len, data_len),
+        89 => wire__crate__api__settings__set_active_mostro_node_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        90 => wire__crate__api__settings__set_default_lightning_address_impl(
+        90 => wire__crate__api__settings__set_default_fiat_code_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        91 => wire__crate__api__settings__set_language_impl(port, ptr, rust_vec_len, data_len),
-        92 => {
+        91 => wire__crate__api__settings__set_default_lightning_address_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        92 => wire__crate__api__settings__set_language_impl(port, ptr, rust_vec_len, data_len),
+        93 => {
             wire__crate__api__settings__set_logging_enabled_impl(port, ptr, rust_vec_len, data_len)
         }
-        93 => wire__crate__api__settings__set_mostro_node_impl(port, ptr, rust_vec_len, data_len),
-        94 => wire__crate__api__settings__set_mostro_pubkey_impl(port, ptr, rust_vec_len, data_len),
-        95 => {
+        94 => wire__crate__api__settings__set_mostro_node_impl(port, ptr, rust_vec_len, data_len),
+        95 => wire__crate__api__settings__set_mostro_pubkey_impl(port, ptr, rust_vec_len, data_len),
+        96 => {
             wire__crate__api__reputation__set_privacy_mode_impl(port, ptr, rust_vec_len, data_len)
         }
-        96 => wire__crate__api__settings__set_theme_impl(port, ptr, rust_vec_len, data_len),
-        97 => wire__crate__api__disputes__submit_evidence_impl(port, ptr, rust_vec_len, data_len),
-        98 => wire__crate__api__reputation__submit_rating_impl(port, ptr, rust_vec_len, data_len),
-        99 => wire__crate__api__orders__subscribe_orders_impl(port, ptr, rust_vec_len, data_len),
-        100 => wire__crate__api__orders__take_order_impl(port, ptr, rust_vec_len, data_len),
+        97 => wire__crate__api__settings__set_theme_impl(port, ptr, rust_vec_len, data_len),
+        98 => wire__crate__api__disputes__submit_evidence_impl(port, ptr, rust_vec_len, data_len),
+        99 => wire__crate__api__reputation__submit_rating_impl(port, ptr, rust_vec_len, data_len),
+        100 => wire__crate__api__orders__subscribe_orders_impl(port, ptr, rust_vec_len, data_len),
+        101 => wire__crate__api__orders__take_order_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/rust/src/nostr/order_events.rs
+++ b/rust/src/nostr/order_events.rs
@@ -128,22 +128,6 @@ fn parse_fiat_range(raw: &Option<String>) -> (Option<f64>, Option<f64>) {
     }
 }
 
-/// Build a Nostr filter for Kind 38383 pending orders from a specific Mostro node.
-///
-/// The Mostro daemon is the **author** of all Kind 38383 events — it publishes
-/// orders on behalf of makers after they send a `new-order` NIP-59 message.
-/// Filtering by `author = mostro_pubkey` ensures we only receive orders that
-/// belong to the trusted Mostro instance configured in the app.
-///
-/// The `s` tag value is `"pending"` (kebab-case) — mostro-core serialises
-/// the `Status` enum with `#[serde(rename_all = "kebab-case")]`.
-pub fn pending_orders_filter(mostro_pubkey: &PublicKey) -> Filter {
-    Filter::new()
-        .kind(Kind::from(KIND_ORDER))
-        .author(*mostro_pubkey)
-        .custom_tag(SingleLetterTag::lowercase(Alphabet::S), "pending")
-}
-
 /// Build a Nostr filter for **all** Kind 38383 orders from a specific Mostro node,
 /// regardless of status.
 ///
@@ -159,8 +143,8 @@ pub fn all_orders_filter(mostro_pubkey: &PublicKey) -> Filter {
 
 /// Build a Nostr filter for a **single** Kind 38383 order by `d`-tag (order ID).
 ///
-/// Unlike `pending_orders_filter`, this filter has **no status restriction** —
-/// it captures every K38383 update for the given order ID regardless of status.
+/// Unlike `all_orders_filter`, this filter is scoped to a single order ID and
+/// captures every K38383 update for it regardless of status.
 /// Use this after taking an order to track status changes: `pending` →
 /// `in-progress` → `waiting-buyer-invoice` / `waiting-payment` → `active` etc.
 pub fn trade_order_filter(mostro_pubkey: &PublicKey, order_id: &str) -> Filter {

--- a/rust/src/nostr/relay_pool.rs
+++ b/rust/src/nostr/relay_pool.rs
@@ -17,7 +17,6 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::{broadcast, RwLock};
 
 use crate::api::types::{ConnectionState, RelayInfo, RelaySource, RelayStatus};
-use crate::nostr::order_events::pending_orders_filter;
 
 /// How often the background task polls each relay's SDK status (seconds).
 const STATUS_POLL_INTERVAL_SECS: u64 = 2;
@@ -136,56 +135,6 @@ impl RelayPool {
 
     pub fn subscribe_relay_status(&self) -> broadcast::Receiver<RelayInfo> {
         self.relay_tx.subscribe()
-    }
-
-    /// Re-subscribe to Kind 38383 (public orders) and Kind 14 (protocol-v2
-    /// Mostro replies) after a reconnect or cold start, respawning per-trade
-    /// workers.
-    ///
-    /// `trade_keys` is a list of `(trade_pubkey, trade_index)` pairs gathered
-    /// from persisted state (e.g. the trade-key DB table).  For each pair this
-    /// method:
-    /// 1. Adds the pubkey to the bulk Kind 14 relay filter (author-pinned to
-    ///    Mostro) so events are delivered to this client.
-    /// 2. Spawns a `subscribe_gift_wraps` worker (same as `create_order` does)
-    ///    so decryption keys are available and daemon responses are routed.
-    ///
-    /// Kind 38383 processing is handled by `orders::subscribe_orders()`.
-    pub async fn subscribe_order_and_dm_feeds(
-        &self,
-        trade_keys: Vec<(PublicKey, u32)>,
-    ) -> Result<()> {
-        let mostro_pubkey = nostr_sdk::PublicKey::from_hex(&crate::config::active_mostro_pubkey())
-            .map_err(|e| anyhow!("invalid mostro pubkey: {e}"))?;
-        let order_filter = pending_orders_filter(&mostro_pubkey);
-        self.client
-            .subscribe(order_filter, None)
-            .await
-            .map_err(|e| anyhow!("order subscribe failed: {e}"))?;
-
-        let pubkeys: Vec<PublicKey> = trade_keys.iter().map(|(pk, _)| *pk).collect();
-        if !pubkeys.is_empty() {
-            // Protocol v2: Mostro replies are kind-14 NIP-44 direct events
-            // authored by the node and p-tagged to our trade keys. Pin the
-            // author to disambiguate from NIP-17 peer chat (also kind 14).
-            let dm_filter = Filter::new()
-                .kind(Kind::PrivateDirectMessage)
-                .author(mostro_pubkey)
-                .pubkeys(pubkeys);
-            self.client
-                .subscribe(dm_filter, None)
-                .await
-                .map_err(|e| anyhow!("dm subscribe failed: {e}"))?;
-
-            // Respawn per-trade gift-wrap workers so each trade key's decrypt
-            // path is live.  Without this, the relay delivers events but no
-            // worker is running to unwrap and route them.
-            for (pubkey, trade_index) in trade_keys {
-                crate::api::orders::subscribe_gift_wraps(pubkey, trade_index).await;
-            }
-        }
-
-        Ok(())
     }
 
     pub fn client(&self) -> Arc<Client> {

--- a/specs/004-mostro-p2p-client/contracts/settings.md
+++ b/specs/004-mostro-p2p-client/contracts/settings.md
@@ -78,6 +78,47 @@ resets to false on next app launch.
 
 ---
 
+## Mostro Node Selection
+
+### get_mostro_pubkey() → String
+Return the active Mostro node's pubkey (hex) — the user-selected override, or
+the compiled-in `DEFAULT_MOSTRO_PUBKEY` when none has been selected.
+
+---
+
+### set_active_mostro_node(pubkey: String) → ()
+The single entry point for selecting / switching the active Mostro node.
+
+Validates `pubkey`, persists it as the active node's **identity**, updates the
+in-memory override (so outgoing events target the new node immediately), and
+re-targets the live feeds to it: the order book is cleared, the Kind 38383
+(orders) and Kind 14 (Mostro replies) filters are re-subscribed — author-pinned
+to the new node via stable subscription IDs so the old filters are replaced in
+place — the node's current orders are refetched, and its PoW requirement is
+refreshed.
+
+The switch is **purely local**: no Nostr message is sent to either node. Pass
+`DEFAULT_MOSTRO_PUBKEY` to return to the default node.
+
+**Persistence**: only the pubkey is stored, under key `active_mostro_pubkey` in
+the generic `settings` key-value table. Node **metadata** (name, fees, accepted
+currencies, limits — the `MostroNodeInfo` model) is a separate concern deferred
+to the M5 node registry; it is NOT persisted as the active selection.
+
+**Errors**: `InvalidPubkey` if `pubkey` is not a valid 64-char hex key;
+`StorageError` on a persistence failure.
+
+---
+
+### rehydrate_active_mostro_node() → ()
+Load the persisted active pubkey into the in-memory override. Call once at
+startup, after `init_db` and **before** the relay pool starts subscribing, so
+the first subscription already targets the user's selected node. No-op when
+nothing has been persisted (the compiled-in default then applies) or when the
+DB is unavailable.
+
+---
+
 ## Streams
 
 ### on_settings_changed() → Stream<AppSettings>
@@ -107,10 +148,10 @@ can be disabled.
 |-------|-------|
 | `pubkey` | `82fa8cb978b43c79b2156585bac2c011176a21d2aead6d9f7c575c005be88390` |
 | `name` | `Mostro` |
-| `is_default` | `true` |
 
-This node is pre-selected on first launch. The user can add more nodes or switch
-to a different one from Settings → Mostro Node.
+When no `active_mostro_pubkey` has been persisted (first launch, or after the
+user picks "Use Default"), this compiled-in pubkey is the active node. The user
+switches to another one from Settings → Mostro Node via `set_active_mostro_node`.
 
 ### Rust Constants (suggested location: `rust/src/config.rs`)
 


### PR DESCRIPTION
fix #158 
Selecting a Mostro node in Settings did nothing: the order book kept showing the previous node. Three compounding defects:

1. **No refresh** — the inbound subscriptions (Kind 38383 order book + Kind 14 Mostro replies) were author-pinned to thribed.
2. **Half-changed** — outgoing actions readthey targeted the new node), while the inboun.
3. **No persistence / rehydration** — the smemory override; it was never written to the DB nor loaded at startup, so any change was lost on relaunch.

## Approach

Single source of truth = the active node's **pubkey** (identity); node metadata (kind 0 / 38385) is a separate concern defe One activation entry, `set_active_mostro_node(p updates the override, and re-targets the live subscriptions. The switch is purely local (no daemon messages), matching v1 behavior.

Notable design points:
- Re-subscribe with **stable subscription IDs** so a switch replaces the old author-pinned filters in place (no leakedrt); the long-lived loop resolves the active node per event.
- nostr-sdk suppresses already-seen events ream, so returning to a previously-visited node would show an empty book. The switch therefore **refetches** the node's currenraw message channel, not subject to that dedup) and feeds them through the same ingestion path as live events.

## Out of scope (later / M5)
Relay auto-discovery (kind 10002 sync), full session recovery, and guarding a switch made mid-trade. No relay state is changed on switch.
