### PR TITLE
chore(clippy): resolve warnings to enable -D warnings gate

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,6 +6,11 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib", "staticlib"]
 
+# `frb_expand` is set by flutter_rust_bridge's macros during codegen expansion.
+# Declare it so `cargo clippy -- -D warnings` does not flag it as an unknown cfg.
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }
+
 [dependencies]
 flutter_rust_bridge = "=2.11.1"
 

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -526,7 +526,7 @@ pub async fn create_order(params: NewOrderParams) -> Result<OrderInfo> {
         if let Ok(mut m) = pending_maker_keys().write() { m.remove(&trade_pk_hex); }
         if let Ok(mut m) = pending_local_ids().write() { m.remove(&ck); }
         if let Ok(mut m) = pending_confirmations().lock() { m.remove(&trade_pk_hex); }
-        return Err(e.into());
+        return Err(e);
     }
 
     crate::api::logging::blog_info("orders", format!(
@@ -1787,6 +1787,7 @@ static SUBSCRIPTION_ACTIVE: AtomicBool = AtomicBool::new(false);
 /// 3. Parses each Kind 38383 event via `parse_order_event` and upserts it
 ///    into the order book, which broadcasts the update to all `OrdersStream`
 ///    subscribers.
+///
 /// RAII guard that resets `SUBSCRIPTION_ACTIVE` to `false` when dropped,
 /// ensuring the flag is cleared even if the subscription task panics.
 struct ResetGuard;
@@ -2185,7 +2186,7 @@ async fn _run_order_subscription() {
         return;
     }
 
-    crate::api::logging::blog_info("orders", format!("subscriptions active — waiting for events"));
+    crate::api::logging::blog_info("orders", "subscriptions active — waiting for events".to_string());
 
     use nostr_sdk::RelayPoolNotification;
 
@@ -2262,6 +2263,9 @@ impl OrdersStream {
 
 /// Called internally to process a raw Nostr event into the order cache.
 /// Typically invoked from the relay pool's event processing loop.
+// Currently unused: the subscription loop inlines `parse_order_event` +
+// `upsert_order`. Kept as a reusable helper for future event-processing paths.
+#[allow(dead_code)]
 pub(crate) async fn process_order_event(
     event: &nostr_sdk::Event,
     my_pubkey: Option<&nostr_sdk::PublicKey>,


### PR DESCRIPTION
Prerequisite for #151 (CI with `cargo clippy -- -D warnings`).

Cleans up the 6 clippy warnings currently on `main` so the lint can become a required CI check without the first run rebounding.

- Declare `cfg(frb_expand)` in `[lints.rust]` (flutter_rust_bridge macro cfg)
- Drop useless `anyhow::Error` conversion in `create_order`
- Fix doc lazy-continuation on `ResetGuard`
- Replace argument-less `format!` with `.to_string()`
- Mark unused `process_order_event` with `#[allow(dead_code)]`

No behavior change — all fixes are semantic no-ops.

Verified: `cargo clippy -- -D warnings` clean, `cargo test` 82 passed / 0 failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved order creation error handling so failed publishes now return a cleaner error while preserving the same rollback behavior.
  * Reduced noise from an internal warning so valid configuration flags are no longer reported as unknown during linting.

* **Chores**
  * Updated subscription startup messaging and related documentation comments for clearer maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->