### PR TITLE
fix: persist trade key index at derivation so the counter never regresses

### DIFF
--- a/lib/core/services/identity_service.dart
+++ b/lib/core/services/identity_service.dart
@@ -57,16 +57,6 @@ class IdentityService {
     }
   }
 
-  /// Persist an updated trade-key index after each new trade key is derived.
-  static Future<void> saveTradeKeyIndex(int index) async {
-    try {
-      await _storage.write(key: _kTradeKeyIndex, value: index.toString());
-    } catch (e) {
-      debugPrint('[identity] saveTradeKeyIndex($_kTradeKeyIndex) error: $e');
-      rethrow;
-    }
-  }
-
   /// Persist privacy mode setting.
   static Future<void> savePrivacyMode(bool enabled) async {
     try {

--- a/lib/features/order/screens/add_order_screen.dart
+++ b/lib/features/order/screens/add_order_screen.dart
@@ -10,10 +10,8 @@ import 'package:mostro/features/settings/providers/settings_provider.dart';
 import 'package:mostro/features/order/widgets/order_preset_selector.dart';
 import 'package:mostro/features/order/widgets/payment_method_section.dart';
 import 'package:mostro/features/order/widgets/price_section.dart';
-import 'package:mostro/core/services/identity_service.dart';
 import 'package:mostro/features/trades/providers/trades_providers.dart'
     show refreshTrades;
-import 'package:mostro/src/rust/api/identity.dart' as identity_api;
 import 'package:mostro/src/rust/api/orders.dart' as rust_orders;
 import 'package:mostro/src/rust/api/types.dart';
 
@@ -190,17 +188,6 @@ class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
       );
 
       final order = await rust_orders.createOrder(params: params);
-
-      // Persist the updated trade key index so it survives app restarts.
-      // Failures here are non-fatal — the order was already created.
-      try {
-        final identity = await identity_api.getIdentity();
-        if (identity != null) {
-          await IdentityService.saveTradeKeyIndex(identity.tradeKeyIndex);
-        }
-      } catch (e) {
-        debugPrint('[orders] save tradeKeyIndex failed: $e');
-      }
 
       refreshTrades(ref);
 

--- a/rust/src/api/identity.rs
+++ b/rust/src/api/identity.rs
@@ -18,6 +18,7 @@ use tokio::sync::RwLock;
 
 use crate::api::types::{IdentityInfo, NymIdentity};
 use crate::crypto::{keys as key_ops, nym};
+use crate::db::Storage;
 
 // ── Global in-memory identity state ──────────────────────────────────────────
 
@@ -112,6 +113,16 @@ pub async fn load_identity_from_mnemonic(
     let keys = key_ops::derive_master_key(&words)?;
     let public_key = keys.public_key().to_hex();
 
+    // Reconcile with the index Rust persisted at derivation time. The two
+    // stores can disagree (e.g. the Dart-side value is only written on
+    // create success), and the counter must never move backwards.
+    let stored = match crate::db::app_db::db() {
+        Some(db) => db.get_identity().await.unwrap_or(None),
+        None => None,
+    };
+    let trade_key_index =
+        reconcile_trade_key_index(trade_key_index, stored.as_ref(), &public_key);
+
     let created_at = match created_at {
         Some(ts) if ts > 0 => ts,
         _ => unix_now(),
@@ -194,9 +205,22 @@ pub async fn derive_trade_key() -> Result<TradeKeyInfo> {
 
     let candidate_index = state.identity_info.trade_key_index + 1;
 
-    // Derive first — only persist the incremented index on success.
     let trade_keys = key_ops::derive_trade_key(&state.mnemonic_words, candidate_index)?;
     state.identity_info.trade_key_index = candidate_index;
+
+    // Persist immediately: an index is consumed the moment it is derived.
+    // The daemon registers every index it sees — even on a rejected or
+    // timed-out operation — so the counter must survive restarts regardless
+    // of the operation's outcome, or the next session re-derives the same
+    // key and gets CantDo(InvalidTradeIndex). The write happens under the
+    // identity lock so concurrent derivations persist in increment order.
+    if let Some(db) = crate::db::app_db::db() {
+        if let Err(e) = db.save_identity(&state.identity_info).await {
+            log::warn!(
+                "[identity] failed to persist trade_key_index {candidate_index}: {e}"
+            );
+        }
+    }
 
     Ok(TradeKeyInfo {
         index: candidate_index,
@@ -290,6 +314,23 @@ pub async fn export_encrypted_backup(passphrase: String) -> Result<String> {
 
 // ── Internal helpers ──────────────────────────────────────────────────────────
 
+/// Pick the trade key index to restore on identity load: the highest of the
+/// value passed from Flutter's secure storage and the one Rust persisted at
+/// derivation time. The counter must never move backwards — a lower value
+/// means re-deriving already-consumed keys, which the daemon rejects with
+/// `InvalidTradeIndex`. A stored identity with a different public key is
+/// ignored: its counter belongs to another mnemonic.
+fn reconcile_trade_key_index(
+    passed: u32,
+    stored: Option<&IdentityInfo>,
+    public_key: &str,
+) -> u32 {
+    match stored {
+        Some(info) if info.public_key == public_key => passed.max(info.trade_key_index),
+        _ => passed,
+    }
+}
+
 fn unix_now() -> i64 {
     use std::time::{SystemTime, UNIX_EPOCH};
     SystemTime::now()
@@ -340,4 +381,64 @@ pub(crate) async fn get_transport_identity_keys(trade_keys: &Keys) -> Result<Key
         return Ok(trade_keys.clone());
     }
     get_active_keys().await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stored_identity(public_key: &str, trade_key_index: u32) -> IdentityInfo {
+        IdentityInfo {
+            public_key: public_key.to_string(),
+            display_name: None,
+            privacy_mode: false,
+            trade_key_index,
+            created_at: 1,
+        }
+    }
+
+    #[test]
+    fn reconcile_prefers_higher_stored_index() {
+        let stored = stored_identity("abc", 22);
+        assert_eq!(reconcile_trade_key_index(20, Some(&stored), "abc"), 22);
+    }
+
+    #[test]
+    fn reconcile_prefers_higher_passed_index() {
+        let stored = stored_identity("abc", 5);
+        assert_eq!(reconcile_trade_key_index(20, Some(&stored), "abc"), 20);
+    }
+
+    #[test]
+    fn reconcile_ignores_stored_index_of_other_identity() {
+        let stored = stored_identity("other-pubkey", 99);
+        assert_eq!(reconcile_trade_key_index(3, Some(&stored), "abc"), 3);
+    }
+
+    #[test]
+    fn reconcile_without_stored_identity_keeps_passed_index() {
+        assert_eq!(reconcile_trade_key_index(7, None, "abc"), 7);
+    }
+
+    /// Single test for the global identity state (kept as ONE test so
+    /// parallel test threads never race on the `identity_lock` singleton):
+    /// loading restores the counter and each derivation advances it.
+    #[tokio::test]
+    async fn load_then_derive_advances_trade_key_index() {
+        let words = key_ops::generate_mnemonic().unwrap();
+
+        let info = load_identity_from_mnemonic(words.clone(), 20, false, None)
+            .await
+            .unwrap();
+        assert_eq!(info.trade_key_index, 20);
+
+        let first = derive_trade_key().await.unwrap();
+        let second = derive_trade_key().await.unwrap();
+        assert_eq!(first.index, 21);
+        assert_eq!(second.index, 22);
+        assert_ne!(first.public_key, second.public_key);
+
+        let current = get_identity().await.unwrap().unwrap();
+        assert_eq!(current.trade_key_index, 22);
+    }
 }

--- a/rust/src/api/identity.rs
+++ b/rust/src/api/identity.rs
@@ -194,6 +194,21 @@ pub async fn delete_identity() -> Result<()> {
         bail!("NoIdentity");
     }
     *guard = None;
+    drop(guard);
+
+    // Clear the persisted trade key counter and per-order key mappings: both
+    // belong to the deleted identity's derivation tree, and a new mnemonic
+    // must start counting from zero instead of inheriting them. (If this
+    // cleanup fails, the pubkey guard in `reconcile_trade_key_index` still
+    // prevents the stale row from leaking into a different identity.)
+    if let Some(db) = crate::db::app_db::db() {
+        if let Err(e) = db.delete_identity().await {
+            log::warn!("[identity] failed to clear persisted identity: {e}");
+        }
+        if let Err(e) = db.clear_trade_keys().await {
+            log::warn!("[identity] failed to clear trade key mappings: {e}");
+        }
+    }
     Ok(())
 }
 
@@ -422,9 +437,10 @@ mod tests {
 
     /// Single test for the global identity state (kept as ONE test so
     /// parallel test threads never race on the `identity_lock` singleton):
-    /// loading restores the counter and each derivation advances it.
+    /// loading restores the counter, each derivation advances it, and
+    /// deletion clears the in-memory state.
     #[tokio::test]
-    async fn load_then_derive_advances_trade_key_index() {
+    async fn load_derive_then_delete_identity_lifecycle() {
         let words = key_ops::generate_mnemonic().unwrap();
 
         let info = load_identity_from_mnemonic(words.clone(), 20, false, None)
@@ -440,5 +456,11 @@ mod tests {
 
         let current = get_identity().await.unwrap().unwrap();
         assert_eq!(current.trade_key_index, 22);
+
+        delete_identity().await.unwrap();
+        assert!(get_identity().await.unwrap().is_none());
+
+        // Deleting again fails: there is no identity left.
+        assert!(delete_identity().await.is_err());
     }
 }

--- a/rust/src/api/identity.rs
+++ b/rust/src/api/identity.rs
@@ -116,8 +116,22 @@ pub async fn load_identity_from_mnemonic(
     // Reconcile with the index Rust persisted at derivation time. The two
     // stores can disagree (e.g. the Dart-side value is only written on
     // create success), and the counter must never move backwards.
+    //
+    // A read failure falls back to the passed index rather than failing the
+    // load: identity loading must survive a corrupt store, and the fallback
+    // is safe — any subsequent derivation either persists (repairing the
+    // store) or fails before handing out a key.
     let stored = match crate::db::app_db::db() {
-        Some(db) => db.get_identity().await.unwrap_or(None),
+        Some(db) => match db.get_identity().await {
+            Ok(v) => v,
+            Err(e) => {
+                log::warn!(
+                    "[identity] could not read persisted identity — \
+                     falling back to secure-storage index: {e}"
+                );
+                None
+            }
+        },
         None => None,
     };
     let trade_key_index =
@@ -229,12 +243,17 @@ pub async fn derive_trade_key() -> Result<TradeKeyInfo> {
     // of the operation's outcome, or the next session re-derives the same
     // key and gets CantDo(InvalidTradeIndex). The write happens under the
     // identity lock so concurrent derivations persist in increment order.
+    //
+    // A persistence failure fails the derivation: handing out a key whose
+    // consumption is not durably recorded reopens the counter-regression
+    // window this exists to close. The in-memory increment is kept, so a
+    // retry moves on to the next index — never back.
     if let Some(db) = crate::db::app_db::db() {
-        if let Err(e) = db.save_identity(&state.identity_info).await {
-            log::warn!(
-                "[identity] failed to persist trade_key_index {candidate_index}: {e}"
-            );
-        }
+        db.save_identity(&state.identity_info).await.map_err(|e| {
+            anyhow!(
+                "StorageError: failed to persist trade_key_index {candidate_index}: {e}"
+            )
+        })?;
     }
 
     Ok(TradeKeyInfo {

--- a/rust/src/db/indexeddb.rs
+++ b/rust/src/db/indexeddb.rs
@@ -64,6 +64,9 @@ impl Storage for IndexedDbStorage {
     async fn get_identity(&self) -> Result<Option<IdentityInfo>> {
         Err(anyhow!("IndexedDB not yet implemented"))
     }
+    async fn delete_identity(&self) -> Result<()> {
+        Err(anyhow!("IndexedDB not yet implemented"))
+    }
     async fn save_queued_message(&self, _msg: &QueuedMessage) -> Result<()> {
         Err(anyhow!("IndexedDB not yet implemented"))
     }
@@ -94,6 +97,10 @@ impl Storage for IndexedDbStorage {
     }
 
     async fn delete_trade_key(&self, _order_id: &str) -> Result<()> {
+        Ok(()) // IndexedDB not yet implemented
+    }
+
+    async fn clear_trade_keys(&self) -> Result<()> {
         Ok(()) // IndexedDB not yet implemented
     }
 

--- a/rust/src/db/mod.rs
+++ b/rust/src/db/mod.rs
@@ -40,6 +40,10 @@ pub trait Storage: Send + Sync {
     async fn save_identity(&self, identity: &crate::api::types::IdentityInfo) -> Result<()>;
     async fn get_identity(&self) -> Result<Option<crate::api::types::IdentityInfo>>;
 
+    /// Delete the persisted identity row, so a subsequently created or
+    /// imported identity starts with a fresh trade key counter.
+    async fn delete_identity(&self) -> Result<()>;
+
     async fn save_queued_message(
         &self,
         msg: &crate::queue::outbox::QueuedMessage,
@@ -67,6 +71,10 @@ pub trait Storage: Send + Sync {
 
     /// Delete the trade key entry for `order_id`.
     async fn delete_trade_key(&self, order_id: &str) -> Result<()>;
+
+    /// Delete ALL trade key entries. Used on identity deletion — the
+    /// order→index mappings belong to the removed identity's derivation tree.
+    async fn clear_trade_keys(&self) -> Result<()>;
 
     // ── Settings / Mostro node ────────────────────────────────────────────────
 

--- a/rust/src/db/sqlite.rs
+++ b/rust/src/db/sqlite.rs
@@ -263,6 +263,13 @@ impl Storage for SqliteStorage {
         Ok(row.map(|(data,)| serde_json::from_str(&data)).transpose()?)
     }
 
+    async fn delete_identity(&self) -> Result<()> {
+        sqlx::query("DELETE FROM identity")
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
     async fn save_queued_message(&self, msg: &QueuedMessage) -> Result<()> {
         let data = serde_json::to_string(msg)?;
         let status = format!("{:?}", msg.status);
@@ -369,6 +376,13 @@ impl Storage for SqliteStorage {
     async fn delete_trade_key(&self, order_id: &str) -> Result<()> {
         sqlx::query("DELETE FROM trade_keys WHERE order_id = ?")
             .bind(order_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    async fn clear_trade_keys(&self) -> Result<()> {
+        sqlx::query("DELETE FROM trade_keys")
             .execute(&self.pool)
             .await?;
         Ok(())
@@ -551,6 +565,38 @@ mod tests {
         storage.save_identity(&identity).await.unwrap();
         let loaded = storage.get_identity().await.unwrap().unwrap();
         assert_eq!(loaded.trade_key_index, 22);
+
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn delete_identity_clears_row_and_trade_keys() {
+        let path = temp_db_path();
+        let path_str = path.to_str().unwrap().to_string();
+        let storage = SqliteStorage::open(&path_str).await.unwrap();
+
+        let identity = IdentityInfo {
+            public_key: "abc123".to_string(),
+            display_name: None,
+            privacy_mode: false,
+            trade_key_index: 7,
+            created_at: 1_700_000_000,
+        };
+        storage.save_identity(&identity).await.unwrap();
+        storage.save_trade_key("order-1", 5).await.unwrap();
+        storage.save_trade_key("order-2", 6).await.unwrap();
+
+        storage.delete_identity().await.unwrap();
+        storage.clear_trade_keys().await.unwrap();
+
+        assert!(storage.get_identity().await.unwrap().is_none());
+        assert_eq!(storage.get_trade_key("order-1").await.unwrap(), None);
+        assert_eq!(storage.get_trade_key("order-2").await.unwrap(), None);
+
+        // Deleting again on empty tables is a no-op, not an error.
+        storage.delete_identity().await.unwrap();
+        storage.clear_trade_keys().await.unwrap();
 
         drop(storage);
         let _ = std::fs::remove_file(&path);

--- a/rust/src/db/sqlite.rs
+++ b/rust/src/db/sqlite.rs
@@ -524,4 +524,35 @@ mod tests {
         drop(storage);
         let _ = std::fs::remove_file(&path);
     }
+
+    #[tokio::test]
+    async fn identity_round_trip_preserves_trade_key_index() {
+        let path = temp_db_path();
+        let path_str = path.to_str().unwrap().to_string();
+        let storage = SqliteStorage::open(&path_str).await.unwrap();
+
+        // Absent until the first save.
+        assert!(storage.get_identity().await.unwrap().is_none());
+
+        let mut identity = IdentityInfo {
+            public_key: "abc123".to_string(),
+            display_name: None,
+            privacy_mode: false,
+            trade_key_index: 21,
+            created_at: 1_700_000_000,
+        };
+        storage.save_identity(&identity).await.unwrap();
+        let loaded = storage.get_identity().await.unwrap().unwrap();
+        assert_eq!(loaded.public_key, "abc123");
+        assert_eq!(loaded.trade_key_index, 21);
+
+        // INSERT OR REPLACE keeps a single row with the latest counter.
+        identity.trade_key_index = 22;
+        storage.save_identity(&identity).await.unwrap();
+        let loaded = storage.get_identity().await.unwrap().unwrap();
+        assert_eq!(loaded.trade_key_index, 22);
+
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
 }


### PR DESCRIPTION
Closes #169 

## Problem

The trade key index was only persisted after a *successful* order
creation (Dart-side, in `add_order_screen`). Any other path lost the
in-memory increment on restart:

- rejected or timed-out creates (the index is registered by the daemon
  even when it rejects)
- **taking an order never persisted the index at all**, not even on
  success

On the next launch the app re-derived an already-consumed index, so the
daemon rejected valid operations with `CantDo(InvalidTradeIndex)`, and —
since the same index means the same derived pubkey — the per-trade
subscription inherited the old key's relay history, fueling the stale
replay scenarios of #169 .

## Fix (mirrors v1's `KeyManager` semantics: an index is consumed the
moment it is derived, and the counter never moves backwards)

- **`fix(identity): persist trade key index at derivation and reconcile
  on load`** — `derive_trade_key()` saves `IdentityInfo` to the app DB
  (the existing, previously unused `identity` table) the moment the
  index is incremented, under the identity lock so concurrent
  derivations persist in order. `load_identity_from_mnemonic()` restores
  `max(secure-storage value, DB value)`; a stored identity with a
  different pubkey is ignored.
- **`fix(identity): reset persisted trade key index on identity
  deletion`** — `delete_identity()` clears the persisted identity row
  and the `trade_keys` table so a new mnemonic starts from zero. Adds
  `Storage::delete_identity` / `Storage::clear_trade_keys` (SQLite impl
  + IndexedDB stubs).
- **`refactor(identity): drop UI-side trade key index persistence`** —
  removes the post-success `saveTradeKeyIndex` block and the now-unused
  service method. Rust owns the counter; the secure-storage value
  remains only as legacy migration input for the `max()` reconciliation.

## Testing

- `cargo test` (94 passed) — new coverage: reconciliation helper (4
  cases), identity lifecycle (load → derive ×2 → delete), SQLite
  round-trip and deletion tests. `cargo clippy` clean on touched files;
  `flutter analyze` / `flutter test` green.
- Manually verified on a live mostrod: a rejected create's index now
  survives restart (`22 keys derived` after a rejected index-22
  attempt), the next create derives 23 and is accepted — no more
  `InvalidTradeIndex` loop; fresh identity after deletion starts at
  index 1 with the `identity`/`trade_keys` tables cleared; counter
  advances monotonically (1→7) across sessions with no Dart-side
  writes.

No FRB regeneration needed: no `rust/src/api/` signatures changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Identity loading now restores and reconciles the persisted trade-key counter, preventing it from moving backward after app restarts.
  * Deleting an identity also clears all related stored trade-key mappings, reducing stale state.
  * Order submission no longer attempts to save a potentially outdated trade-key index after creating an order.
* **Tests**
  * Added coverage for trade-key index reconciliation, persistence across load/derivation, and identity/trade-key cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->