### PR TITLE
fix: resolve flutter analyze lints

### DIFF
--- a/lib/features/chat/screens/chat_rooms_screen.dart
+++ b/lib/features/chat/screens/chat_rooms_screen.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,7 +11,6 @@ import 'package:mostro/core/services/identity_service.dart';
 import 'package:mostro/features/settings/providers/settings_provider.dart';
 import 'package:mostro/features/settings/widgets/mostro_node_selector.dart';
 import 'package:mostro/features/walkthrough/providers/first_run_provider.dart';
-import 'package:mostro/features/account/providers/backup_reminder_provider.dart';
 import 'package:mostro/firebase_options.dart';
 import 'package:mostro/src/rust/frb_generated.dart';
 import 'package:mostro/src/rust/api.dart' as rust_api;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,6 +62,7 @@ dependencies:
   permission_handler: ^11.4.0
 
   # File-system paths (DB path on native)
+  path: ^1.9.1
   path_provider: ^2.1.5
 
   # Internationalization


### PR DESCRIPTION
Clears the 3 pre-existing `flutter analyze` infos so the Flutter CI job (added in #173) goes green.

- Remove redundant `package:flutter/foundation.dart` import in `chat_rooms_screen.dart` (`debugPrint` comes from `material.dart`).
- Remove redundant `backup_reminder_provider` import in `main.dart` (re-exported via `first_run_provider`).
- Declare `path` as a direct dependency (used by `p.join`), fixing `depend_on_referenced_packages`.

Verified: `flutter analyze` reports no issues; `flutter test` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for path-related file handling.
  * Removed unused imports to improve code cleanliness.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->