### PR TITLE
feat: make Rust crate wasm32-compatible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   rust:
-    name: Rust (build / test / clippy)
+    name: Rust (build / test / clippy / wasm)
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -37,6 +37,7 @@ jobs:
         uses: dtolnay/rust-toolchain@1.97.0
         with:
           components: clippy
+          targets: wasm32-unknown-unknown
 
       - name: Cache cargo registry and target
         uses: Swatinem/rust-cache@v2
@@ -51,6 +52,9 @@ jobs:
 
       - name: Clippy (deny warnings)
         run: cargo clippy --locked -- -D warnings
+
+      - name: Check wasm32 target
+        run: cargo check --locked --target wasm32-unknown-unknown
 
   flutter:
     name: Flutter (analyze / test)

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2282,6 +2282,7 @@ dependencies = [
  "tokio",
  "uuid",
  "wasm-bindgen-futures",
+ "wasmtimer",
 ]
 
 [[package]]
@@ -3290,6 +3291,20 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "wasmtimer"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -65,3 +65,7 @@ android_logger = "0.14"
 wasm-bindgen-futures = "0.4"
 indexed_db_futures = "0.4"
 reqwest = { version = "0.12", default-features = false, features = ["json"] }
+# tokio's sync primitives are runtime-agnostic and compile to wasm (no rt/net/fs/time).
+tokio = { version = "1", default-features = false, features = ["sync"] }
+# tokio::time replacement for wasm (sleep/timeout/Instant backed by the browser).
+wasmtimer = "0.4"

--- a/rust/src/api/logging.rs
+++ b/rust/src/api/logging.rs
@@ -186,7 +186,7 @@ mod tests {
 
         forward_log(log::Level::Warn, "nwc::client", "test warning");
 
-        let entry = tokio::time::timeout(
+        let entry = crate::rt::time::timeout(
             std::time::Duration::from_secs(2),
             stream.next(),
         )

--- a/rust/src/api/messages.rs
+++ b/rust/src/api/messages.rs
@@ -591,8 +591,8 @@ fn unix_now() -> i64 {
 /// Strip directory components from a caller-supplied file name to prevent
 /// path traversal (e.g. `../../../etc/passwd` → `passwd`).
 /// Returns `"attachment"` for empty or path-only inputs.
-// Only used by the native attachment writer; web returns early before naming.
-#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+// Native-only: the wasm attachment writer errors out before it needs a name.
+#[cfg(not(target_arch = "wasm32"))]
 fn safe_filename(name: &str) -> String {
     std::path::Path::new(name)
         .file_name()

--- a/rust/src/api/messages.rs
+++ b/rust/src/api/messages.rs
@@ -458,17 +458,10 @@ pub async fn download_attachment(message_id: String) -> Result<FileDownloadResul
     let plaintext = crate::crypto::file_enc::decrypt_file(&encrypted_bytes, &shared_key)
         .map_err(|e| anyhow!("DecryptionFailed: {e}"))?;
 
-    // 5. Write to temp dir with unique filename to avoid collisions.
-    let safe_name = safe_filename(&attachment.file_name);
-    let unique_name = format!("{message_id}_{safe_name}");
-    let local_path = std::env::temp_dir()
-        .join(&unique_name)
-        .to_string_lossy()
-        .into_owned();
-
-    tokio::fs::write(&local_path, &plaintext)
-        .await
-        .map_err(|e| anyhow!("WriteFailed: {e}"))?;
+    // 5. Persist the decrypted blob to a local path. Native writes to a temp
+    //    file; web has no filesystem, so that path is not supported there yet.
+    let local_path =
+        persist_decrypted_attachment(&message_id, &attachment.file_name, &plaintext).await?;
 
     let _ = message_store()
         .attachment_tx
@@ -598,6 +591,8 @@ fn unix_now() -> i64 {
 /// Strip directory components from a caller-supplied file name to prevent
 /// path traversal (e.g. `../../../etc/passwd` → `passwd`).
 /// Returns `"attachment"` for empty or path-only inputs.
+// Only used by the native attachment writer; web returns early before naming.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 fn safe_filename(name: &str) -> String {
     std::path::Path::new(name)
         .file_name()
@@ -605,6 +600,36 @@ fn safe_filename(name: &str) -> String {
         .filter(|s| !s.is_empty())
         .unwrap_or("attachment")
         .to_string()
+}
+
+/// Persist a decrypted attachment to a local path the UI can open.
+///
+/// Native writes to the OS temp dir. `wasm32` has no filesystem, so this is not
+/// supported on web yet and returns an error.
+#[cfg(not(target_arch = "wasm32"))]
+async fn persist_decrypted_attachment(
+    message_id: &str,
+    file_name: &str,
+    data: &[u8],
+) -> Result<String> {
+    let unique_name = format!("{message_id}_{}", safe_filename(file_name));
+    let local_path = std::env::temp_dir()
+        .join(&unique_name)
+        .to_string_lossy()
+        .into_owned();
+    tokio::fs::write(&local_path, data)
+        .await
+        .map_err(|e| anyhow!("WriteFailed: {e}"))?;
+    Ok(local_path)
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn persist_decrypted_attachment(
+    _message_id: &str,
+    _file_name: &str,
+    _data: &[u8],
+) -> Result<String> {
+    Err(anyhow!("attachment download to disk is not supported on web"))
 }
 
 fn is_supported_mime_type(mime: &str) -> bool {
@@ -640,7 +665,7 @@ pub(crate) async fn subscribe_incoming_chat(
 ) {
     use nostr_sdk::RelayPoolNotification;
     use tokio::sync::broadcast;
-    use tokio::time::{timeout, Duration};
+    use crate::rt::time::{timeout, Duration};
 
     const IDLE_TIMEOUT_SECS: u64 = 30 * 60;
 
@@ -669,7 +694,7 @@ pub(crate) async fn subscribe_incoming_chat(
         "[messages] incoming-chat subscription active order={order_id} shared_pubkey={shared_pubkey_hex}"
     );
 
-    let mut last_activity = tokio::time::Instant::now();
+    let mut last_activity = crate::rt::time::Instant::now();
 
     loop {
         let remaining =
@@ -693,7 +718,7 @@ pub(crate) async fn subscribe_incoming_chat(
                 if !is_for_us {
                     continue;
                 }
-                last_activity = tokio::time::Instant::now();
+                last_activity = crate::rt::time::Instant::now();
 
                 // Decrypt gift wrap.
                 let event_json = match serde_json::to_string(&*event) {

--- a/rust/src/api/nostr.rs
+++ b/rust/src/api/nostr.rs
@@ -43,7 +43,7 @@ pub async fn initialize(relays: Option<Vec<String>>) -> Result<()> {
     // Spawn a background task that flushes the outbox whenever the relay pool
     // transitions to Online.  The task exits when the broadcast channel closes.
     let pool_ref = POOL.get().unwrap().clone();
-    tokio::spawn(async move {
+    crate::rt::spawn(async move {
         let mut rx = pool_ref.subscribe_connection_state();
         log::info!("[nostr] connection state watcher started");
         loop {

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -781,7 +781,7 @@ pub async fn create_order(params: NewOrderParams) -> Result<OrderInfo> {
     // Wait for daemon confirmation. The daemon typically responds within 1s.
     // The 10s timeout is a safety net for network issues; on timeout the order
     // is treated as not created (see below) rather than shown optimistically.
-    let confirmation = tokio::time::timeout(
+    let confirmation = crate::rt::time::timeout(
         std::time::Duration::from_secs(10),
         conf_rx,
     ).await;
@@ -1002,7 +1002,7 @@ pub async fn take_order(
     // acknowledges the take. On timeout, detach only the waiter and leave the
     // record: a genuine late reply is logged, a stale replay still can't
     // consume it, and the record dies with the per-trade subscription.
-    let reply = tokio::time::timeout(
+    let reply = crate::rt::time::timeout(
         std::time::Duration::from_secs(10),
         conf_rx,
     ).await;
@@ -1200,7 +1200,7 @@ pub async fn send_invoice(
     // must surface instead of letting the UI advance on a publish that the
     // daemon errored on. Timeout keeps the record for a late reply, which the
     // dispatcher processes as a normal status update.
-    let reply = tokio::time::timeout(
+    let reply = crate::rt::time::timeout(
         std::time::Duration::from_secs(10),
         conf_rx,
     ).await;
@@ -1402,12 +1402,12 @@ pub(crate) async fn subscribe_gift_wraps(trade_pubkey: nostr_sdk::PublicKey, tra
     ));
 
     // ── Event loop: spawned as a background task ──
-    tokio::spawn(async move {
+    crate::rt::spawn(async move {
         use nostr_sdk::RelayPoolNotification;
-        use tokio::time::{timeout, Duration};
+        use crate::rt::time::{timeout, Duration};
 
         const IDLE_TIMEOUT_SECS: u64 = 30 * 60;
-        let mut last_activity = tokio::time::Instant::now();
+        let mut last_activity = crate::rt::time::Instant::now();
 
         loop {
             let remaining =
@@ -1448,7 +1448,7 @@ pub(crate) async fn subscribe_gift_wraps(trade_pubkey: nostr_sdk::PublicKey, tra
                     match crate::nostr::gift_wrap::unwrap_mostro_message(&recipient_keys, &event).await {
                         Ok(Some(unwrapped)) => {
                             dispatch_mostro_message(unwrapped, &trade_pubkey_hex, trade_index).await;
-                            last_activity = tokio::time::Instant::now();
+                            last_activity = crate::rt::time::Instant::now();
                         }
                         Ok(None) => {
                             // The per-trade filter already narrowed by p-tag, so this
@@ -2143,7 +2143,7 @@ async fn on_peer_pubkey_received(order_id: &str, trade_pubkey_hex: &str, peer_pu
     // Spawn incoming-chat subscription on shared-key pubkey.
     let order_id_owned = order_id.to_string();
     let trade_pubkey_hex_owned = trade_pubkey_hex.to_string();
-    tokio::spawn(async move {
+    crate::rt::spawn(async move {
         crate::api::messages::subscribe_incoming_chat(
             order_id_owned,
             trade_pubkey_hex_owned,
@@ -2164,7 +2164,7 @@ async fn on_peer_pubkey_received(order_id: &str, trade_pubkey_hex: &str, peer_pu
 /// down or after a generous idle timeout (no updates for 30 minutes).
 async fn subscribe_single_order(order_id: &str) {
     let order_id = order_id.to_string();
-    tokio::spawn(async move {
+    crate::rt::spawn(async move {
         let Ok(pool) = crate::api::nostr::get_pool() else {
             log::warn!("[orders] subscribe_single_order: relay pool not initialized");
             return;
@@ -2188,12 +2188,12 @@ async fn subscribe_single_order(order_id: &str) {
         log::info!("[orders] subscribed to d-tag updates for order={order_id}");
 
         use nostr_sdk::RelayPoolNotification;
-        use tokio::time::{timeout, Duration};
+        use crate::rt::time::{timeout, Duration};
 
         // Exit after 30 minutes of inactivity (no order updates received).
         // The timer resets on each relevant event so active trades stay subscribed.
         const IDLE_TIMEOUT_SECS: u64 = 30 * 60;
-        let mut last_activity = tokio::time::Instant::now();
+        let mut last_activity = crate::rt::time::Instant::now();
 
         loop {
             let remaining =
@@ -2213,7 +2213,7 @@ async fn subscribe_single_order(order_id: &str) {
                                 order_id,
                                 order.status
                             );
-                            last_activity = tokio::time::Instant::now();
+                            last_activity = crate::rt::time::Instant::now();
                             // Sync trade status in DB so My Trades reflects it.
                             if let Some(db) = crate::db::app_db::db() {
                                 if let Err(e) = db
@@ -2301,7 +2301,7 @@ pub async fn subscribe_orders() {
     }
     log::info!("[orders] subscribe_orders: spawning subscription loop");
 
-    tokio::spawn(async {
+    crate::rt::spawn(async {
         let _guard = ResetGuard;
         _run_order_subscription().await;
     });

--- a/rust/src/api/reputation.rs
+++ b/rust/src/api/reputation.rs
@@ -217,7 +217,7 @@ pub fn get_privacy_mode() -> bool {
 pub fn set_privacy_mode(enabled: bool) {
     // Best-effort identity check: log a warning if no identity is configured but
     // proceed anyway so the UI setting is never silently stuck.
-    tokio::spawn(async move {
+    crate::rt::spawn(async move {
         if crate::api::identity::get_active_keys().await.is_err() {
             log::warn!("[reputation] set_privacy_mode({enabled}): no identity configured");
         }

--- a/rust/src/api/settings.rs
+++ b/rust/src/api/settings.rs
@@ -229,6 +229,7 @@ pub async fn rehydrate_active_mostro_node() -> Result<()> {
 /// and the broadcast notification is sent.  When there is no runtime (e.g.
 /// during synchronous tests) we fall back to a blocking write; the broadcast
 /// notification is skipped in that path but the flag is always set.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn set_logging_enabled(enabled: bool) {
     // Note: the async path is fire-and-forget (spawn); callers that call
     // get_settings() immediately after may not yet see the updated flag
@@ -246,6 +247,16 @@ pub fn set_logging_enabled(enabled: bool) {
             store().settings.blocking_write().logging_enabled = enabled;
         }
     }
+}
+
+// wasm has no Tokio runtime handle; the single-threaded executor is always
+// present, so dispatch onto it directly.
+#[cfg(target_arch = "wasm32")]
+pub fn set_logging_enabled(enabled: bool) {
+    crate::rt::spawn(async move {
+        let snapshot = store().write_with(|s| s.logging_enabled = enabled).await;
+        store().notify(snapshot);
+    });
 }
 
 // ── Stream ────────────────────────────────────────────────────────────────────

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -12,6 +12,7 @@ pub mod mostro;
 pub mod nostr;
 pub mod nwc;
 pub mod queue;
+mod rt;
 
 /// Called once by Flutter during `RustLib.init()` — sets up logging so Rust
 /// messages appear in `adb logcat` / stderr and are forwarded to the Flutter

--- a/rust/src/nostr/gift_wrap.rs
+++ b/rust/src/nostr/gift_wrap.rs
@@ -263,7 +263,7 @@ mod tests {
 
         // Mining is probabilistic — cap wall time so a regression that
         // stalls or loops does not hang CI indefinitely.
-        let event = tokio::time::timeout(
+        let event = crate::rt::time::timeout(
             Duration::from_secs(30),
             wrap_mostro_message(
                 &identity_keys,

--- a/rust/src/nostr/relay_pool.rs
+++ b/rust/src/nostr/relay_pool.rs
@@ -54,7 +54,7 @@ impl RelayPool {
         // Give the SDK a moment to initiate WebSocket handshakes before the
         // first status poll.  Without this the initial broadcast is always
         // Reconnecting (every relay is still in Pending/Connecting state).
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        crate::rt::time::sleep(Duration::from_millis(500)).await;
 
         // Broadcast initial connection state after all relays are wired up.
         pool.broadcast_connection_state().await;
@@ -161,9 +161,9 @@ impl RelayPool {
         let conn_tx = self.conn_tx.clone();
         let relay_tx = self.relay_tx.clone();
 
-        tokio::spawn(async move {
+        crate::rt::spawn(async move {
             loop {
-                tokio::time::sleep(Duration::from_secs(STATUS_POLL_INTERVAL_SECS)).await;
+                crate::rt::time::sleep(Duration::from_secs(STATUS_POLL_INTERVAL_SECS)).await;
 
                 let relay_urls: Vec<String> =
                     relays.read().await.iter().map(|r| r.url.clone()).collect();

--- a/rust/src/nwc/client.rs
+++ b/rust/src/nwc/client.rs
@@ -163,14 +163,14 @@ mod native {
                     .map_err(|e| anyhow!("Failed to send NIP-47 request: {e}"))?;
 
                 // 3. Wait for the matching response on the notification channel.
-                let deadline = tokio::time::Instant::now() + NWC_TIMEOUT;
+                let deadline = crate::rt::time::Instant::now() + NWC_TIMEOUT;
                 loop {
-                    let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+                    let remaining = deadline.saturating_duration_since(crate::rt::time::Instant::now());
                     if remaining.is_zero() {
                         bail!("NWC timeout: no response received from wallet within {NWC_TIMEOUT:?}");
                     }
 
-                    match tokio::time::timeout(remaining, notifications.recv()).await {
+                    match crate::rt::time::timeout(remaining, notifications.recv()).await {
                         Ok(Ok(RelayPoolNotification::Event {
                             event: resp_event, ..
                         })) => {

--- a/rust/src/rt.rs
+++ b/rust/src/rt.rs
@@ -1,0 +1,40 @@
+//! Platform runtime shims.
+//!
+//! Native builds run on the Tokio runtime; `wasm32` has none, so task spawning
+//! and timers are backed by `wasm-bindgen-futures` and `wasmtimer`. Call sites
+//! use `crate::rt::{spawn, time}` instead of the `tokio` equivalents so both
+//! targets compile from a single source.
+
+/// Spawn a detached background task.
+///
+/// All current callers are fire-and-forget, so the join handle is intentionally
+/// dropped. On `wasm32` this delegates to `spawn_local` (no `Send` bound, since
+/// the single-threaded executor never moves the future across threads).
+#[cfg(not(target_arch = "wasm32"))]
+pub fn spawn<F>(future: F)
+where
+    F: std::future::Future<Output = ()> + Send + 'static,
+{
+    tokio::spawn(future);
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn spawn<F>(future: F)
+where
+    F: std::future::Future<Output = ()> + 'static,
+{
+    wasm_bindgen_futures::spawn_local(future);
+}
+
+/// Timer primitives mirroring the subset of `tokio::time` used by the crate.
+#[cfg(not(target_arch = "wasm32"))]
+pub mod time {
+    pub use tokio::time::{sleep, timeout, Duration, Instant};
+}
+
+#[cfg(target_arch = "wasm32")]
+pub mod time {
+    pub use std::time::Duration;
+    pub use wasmtimer::std::Instant;
+    pub use wasmtimer::tokio::{sleep, timeout};
+}


### PR DESCRIPTION
Finish the partial wasm port so `cargo check --target wasm32-unknown-unknown`
compiles again, and re-add it as a CI gate.

- Add tokio `sync` feature + `wasmtimer` for wasm targets.
- New `crate::rt` shim: `spawn` (`spawn_local`) and `time` (`wasmtimer`) on wasm.
- Route `tokio::spawn` / `tokio::time` through `crate::rt`.
- cfg-gate `tokio::fs` (attachment write) and `tokio::runtime::Handle` usage.
- Re-add the wasm32 check to the Rust CI job.

Closes #174.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WebAssembly-compatible support for background tasks and timer/timeout handling.
  * Improved WASM-specific behavior for logging updates and attachment handling (disk persistence is disabled in-browser).

* **Bug Fixes**
  * Enhanced cross-platform reliability by routing waits, timeouts, and “last activity” tracking through the same runtime across targets.

* **Tests**
  * Updated CI to explicitly build and run checks for the `wasm32-unknown-unknown` target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->