### PR TITLE
test: Flutter test harness + critical notifier/filter unit tests

### DIFF
--- a/test/features/account/backup_reminder_provider_test.dart
+++ b/test/features/account/backup_reminder_provider_test.dart
@@ -1,0 +1,174 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro/features/account/providers/backup_reminder_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Future<SharedPreferences> _prefs() => SharedPreferences.getInstance();
+
+int _inFuture(Duration d) => DateTime.now().add(d).millisecondsSinceEpoch;
+int _inPast(Duration d) => DateTime.now().subtract(d).millisecondsSinceEpoch;
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('BackupReminderNotifier', () {
+    test('load(): active and not dismissed nor snoozed → badge on', () async {
+      SharedPreferences.setMockInitialValues({
+        kBackupReminderActiveKey: true,
+        kBackupReminderDismissedKey: false,
+      });
+
+      final notifier = BackupReminderNotifier();
+      await notifier.load();
+
+      expect(notifier.state, isTrue);
+    });
+
+    test('load(): dismissed suppresses the badge even when active', () async {
+      SharedPreferences.setMockInitialValues({
+        kBackupReminderActiveKey: true,
+        kBackupReminderDismissedKey: true,
+      });
+
+      final notifier = BackupReminderNotifier();
+      await notifier.load();
+
+      expect(notifier.state, isFalse);
+    });
+
+    test('load(): an unexpired snooze suppresses the badge', () async {
+      SharedPreferences.setMockInitialValues({
+        kBackupReminderActiveKey: true,
+        kBackupReminderDismissedKey: false,
+        kBackupSnoozedUntilKey: _inFuture(const Duration(hours: 12)),
+      });
+
+      final notifier = BackupReminderNotifier();
+      await notifier.load();
+
+      expect(notifier.state, isFalse);
+    });
+
+    test('load(): an expired snooze does not suppress the badge', () async {
+      SharedPreferences.setMockInitialValues({
+        kBackupReminderActiveKey: true,
+        kBackupReminderDismissedKey: false,
+        kBackupSnoozedUntilKey: _inPast(const Duration(hours: 1)),
+      });
+
+      final notifier = BackupReminderNotifier();
+      await notifier.load();
+
+      expect(notifier.state, isTrue);
+    });
+
+    test('showBackupReminder(): arms the badge and clears prior state',
+        () async {
+      SharedPreferences.setMockInitialValues({
+        kBackupReminderDismissedKey: true,
+        kBackupCompletedKey: true,
+        kBackupSnoozedUntilKey: _inFuture(const Duration(days: 1)),
+      });
+
+      final notifier = BackupReminderNotifier();
+      await notifier.showBackupReminder();
+
+      expect(notifier.state, isTrue);
+      final prefs = await _prefs();
+      expect(prefs.getBool(kBackupReminderActiveKey), isTrue);
+      expect(prefs.getBool(kBackupReminderDismissedKey), isFalse);
+      expect(prefs.getBool(kBackupCompletedKey), isFalse);
+      expect(prefs.getInt(kBackupSnoozedUntilKey), isNull);
+    });
+
+    test('snoozeUntilTomorrow(): hides badge and persists a future snooze',
+        () async {
+      SharedPreferences.setMockInitialValues({
+        kBackupReminderActiveKey: true,
+        kBackupReminderDismissedKey: false,
+      });
+
+      final notifier = BackupReminderNotifier();
+      await notifier.snoozeUntilTomorrow();
+
+      expect(notifier.state, isFalse);
+      final prefs = await _prefs();
+      final until = prefs.getInt(kBackupSnoozedUntilKey);
+      expect(until, isNotNull);
+      expect(until, greaterThan(DateTime.now().millisecondsSinceEpoch));
+    });
+
+    test('confirmBackupComplete(): permanently dismisses the reminder',
+        () async {
+      SharedPreferences.setMockInitialValues({
+        kBackupReminderActiveKey: true,
+        kBackupReminderDismissedKey: false,
+        kBackupSnoozedUntilKey: _inFuture(const Duration(days: 1)),
+      });
+
+      final notifier = BackupReminderNotifier();
+      await notifier.confirmBackupComplete();
+
+      expect(notifier.state, isFalse);
+      final prefs = await _prefs();
+      expect(prefs.getBool(kBackupReminderDismissedKey), isTrue);
+      expect(prefs.getBool(kBackupCompletedKey), isTrue);
+      expect(prefs.getInt(kBackupSnoozedUntilKey), isNull);
+    });
+
+    test('initialValue with a live snooze is reconciled to off', () async {
+      SharedPreferences.setMockInitialValues({
+        kBackupSnoozedUntilKey: _inFuture(const Duration(hours: 6)),
+      });
+
+      final notifier = BackupReminderNotifier(initialValue: true);
+      // Constructor kicks off an async snooze reconciliation.
+      await pumpEventQueue();
+
+      expect(notifier.state, isFalse);
+    });
+  });
+
+  group('BackupCompletedNotifier', () {
+    test('load(): reads the explicit completed flag', () async {
+      SharedPreferences.setMockInitialValues({kBackupCompletedKey: true});
+
+      final notifier = BackupCompletedNotifier();
+      await notifier.load();
+
+      expect(notifier.state, isTrue);
+    });
+
+    test('load(): legacy installs fall back to the dismissed flag', () async {
+      SharedPreferences.setMockInitialValues({
+        kBackupReminderDismissedKey: true,
+      });
+
+      final notifier = BackupCompletedNotifier();
+      await notifier.load();
+
+      expect(notifier.state, isTrue);
+    });
+
+    test('markCompleted() persists and flips state on', () async {
+      SharedPreferences.setMockInitialValues({});
+
+      final notifier = BackupCompletedNotifier();
+      await notifier.markCompleted();
+
+      expect(notifier.state, isTrue);
+      final prefs = await _prefs();
+      expect(prefs.getBool(kBackupCompletedKey), isTrue);
+    });
+
+    test('reset() clears the backed-up flag', () async {
+      SharedPreferences.setMockInitialValues({kBackupCompletedKey: true});
+
+      final notifier = BackupCompletedNotifier();
+      await notifier.reset();
+
+      expect(notifier.state, isFalse);
+      final prefs = await _prefs();
+      expect(prefs.getBool(kBackupCompletedKey), isFalse);
+    });
+  });
+}

--- a/test/features/home/filtered_orders_provider_test.dart
+++ b/test/features/home/filtered_orders_provider_test.dart
@@ -1,23 +1,13 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mostro/features/home/providers/home_order_providers.dart';
 
 import '../../support/fake_orders.dart';
-import '../../support/provider_harness.dart';
-
-/// Awaits the book so [filteredOrdersProvider] can be read synchronously after.
-Future<ProviderContainerHelper> _bookWith(List<OrderItem> orders) async {
-  final container = createContainer(overrides: [
-    orderBookProvider.overrideWith((ref) => Stream.value(orders)),
-  ]);
-  await container.read(orderBookProvider.future);
-  return ProviderContainerHelper(container);
-}
+import '../../support/order_book_harness.dart';
 
 void main() {
   group('filteredOrdersProvider', () {
     test('BUY tab shows only pending sell orders', () async {
-      final helper = await _bookWith([
+      final helper = await bookWith([
         fakeOrder(id: 'sell', kind: 'sell'),
         fakeOrder(id: 'buy', kind: 'buy'),
       ]);
@@ -27,7 +17,7 @@ void main() {
     });
 
     test('SELL tab shows only pending buy orders', () async {
-      final helper = await _bookWith([
+      final helper = await bookWith([
         fakeOrder(id: 'sell', kind: 'sell'),
         fakeOrder(id: 'buy', kind: 'buy'),
       ]);
@@ -37,7 +27,7 @@ void main() {
     });
 
     test('own orders show regardless of the active tab', () async {
-      final helper = await _bookWith([
+      final helper = await bookWith([
         fakeOrder(id: 'mine-buy', kind: 'buy', isMine: true),
         fakeOrder(id: 'other-buy', kind: 'buy'),
       ]);
@@ -47,7 +37,7 @@ void main() {
     });
 
     test('non-pending orders are excluded', () async {
-      final helper = await _bookWith([
+      final helper = await bookWith([
         fakeOrder(id: 'pending', kind: 'sell'),
         fakeOrder(id: 'active', kind: 'sell', status: OrderStatus.active),
       ]);
@@ -57,7 +47,7 @@ void main() {
     });
 
     test('currency filter keeps only selected fiat codes', () async {
-      final helper = await _bookWith([
+      final helper = await bookWith([
         fakeOrder(id: 'usd', kind: 'sell', fiatCode: 'USD'),
         fakeOrder(id: 'eur', kind: 'sell', fiatCode: 'EUR'),
       ]);
@@ -68,7 +58,7 @@ void main() {
     });
 
     test('payment method filter matches any comma-separated token', () async {
-      final helper = await _bookWith([
+      final helper = await bookWith([
         fakeOrder(id: 'multi', kind: 'sell', paymentMethod: 'Wire, Revolut'),
         fakeOrder(id: 'cash', kind: 'sell', paymentMethod: 'Cash'),
       ]);
@@ -80,7 +70,7 @@ void main() {
     });
 
     test('rating range excludes orders outside the bounds', () async {
-      final helper = await _bookWith([
+      final helper = await bookWith([
         fakeOrder(id: 'low', kind: 'sell', rating: 2.0),
         fakeOrder(id: 'high', kind: 'sell', rating: 4.5),
       ]);
@@ -92,7 +82,7 @@ void main() {
     });
 
     test('premium range excludes orders outside the bounds', () async {
-      final helper = await _bookWith([
+      final helper = await bookWith([
         fakeOrder(id: 'cheap', kind: 'sell', premium: -5.0),
         fakeOrder(id: 'pricey', kind: 'sell', premium: 8.0),
       ]);
@@ -104,7 +94,7 @@ void main() {
     });
 
     test('results are sorted newest-first by createdAt', () async {
-      final helper = await _bookWith([
+      final helper = await bookWith([
         fakeOrder(id: 'older', kind: 'sell', minutesAgo: 30),
         fakeOrder(id: 'newer', kind: 'sell', minutesAgo: 5),
       ]);
@@ -112,17 +102,29 @@ void main() {
 
       expect(helper.ids(), ['newer', 'older']);
     });
+
+    test('default rating range does not filter out unrated orders', () async {
+      final helper = await bookWith([
+        fakeOrder(id: 'unrated', kind: 'sell', rating: 0.0),
+      ]);
+      helper.setTab(OrderType.buy);
+
+      expect(helper.ids(), ['unrated']);
+    });
+
+    test('range orders pass through the filters', () async {
+      final helper = await bookWith([
+        fakeOrder(
+          id: 'range',
+          kind: 'sell',
+          fiatAmount: null,
+          fiatAmountMin: 50,
+          fiatAmountMax: 150,
+        ),
+      ]);
+      helper.setTab(OrderType.buy);
+
+      expect(helper.ids(), ['range']);
+    });
   });
-}
-
-class ProviderContainerHelper {
-  ProviderContainerHelper(this.container);
-
-  final ProviderContainer container;
-
-  void setTab(OrderType type) =>
-      container.read(homeOrderTypeProvider.notifier).state = type;
-
-  List<String> ids() =>
-      container.read(filteredOrdersProvider).map((o) => o.id).toList();
 }

--- a/test/features/home/filtered_orders_provider_test.dart
+++ b/test/features/home/filtered_orders_provider_test.dart
@@ -1,0 +1,128 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro/features/home/providers/home_order_providers.dart';
+
+import '../../support/fake_orders.dart';
+import '../../support/provider_harness.dart';
+
+/// Awaits the book so [filteredOrdersProvider] can be read synchronously after.
+Future<ProviderContainerHelper> _bookWith(List<OrderItem> orders) async {
+  final container = createContainer(overrides: [
+    orderBookProvider.overrideWith((ref) => Stream.value(orders)),
+  ]);
+  await container.read(orderBookProvider.future);
+  return ProviderContainerHelper(container);
+}
+
+void main() {
+  group('filteredOrdersProvider', () {
+    test('BUY tab shows only pending sell orders', () async {
+      final helper = await _bookWith([
+        fakeOrder(id: 'sell', kind: 'sell'),
+        fakeOrder(id: 'buy', kind: 'buy'),
+      ]);
+      helper.setTab(OrderType.buy);
+
+      expect(helper.ids(), ['sell']);
+    });
+
+    test('SELL tab shows only pending buy orders', () async {
+      final helper = await _bookWith([
+        fakeOrder(id: 'sell', kind: 'sell'),
+        fakeOrder(id: 'buy', kind: 'buy'),
+      ]);
+      helper.setTab(OrderType.sell);
+
+      expect(helper.ids(), ['buy']);
+    });
+
+    test('own orders show regardless of the active tab', () async {
+      final helper = await _bookWith([
+        fakeOrder(id: 'mine-buy', kind: 'buy', isMine: true),
+        fakeOrder(id: 'other-buy', kind: 'buy'),
+      ]);
+      helper.setTab(OrderType.buy); // buy tab targets sell orders
+
+      expect(helper.ids(), ['mine-buy']);
+    });
+
+    test('non-pending orders are excluded', () async {
+      final helper = await _bookWith([
+        fakeOrder(id: 'pending', kind: 'sell'),
+        fakeOrder(id: 'active', kind: 'sell', status: OrderStatus.active),
+      ]);
+      helper.setTab(OrderType.buy);
+
+      expect(helper.ids(), ['pending']);
+    });
+
+    test('currency filter keeps only selected fiat codes', () async {
+      final helper = await _bookWith([
+        fakeOrder(id: 'usd', kind: 'sell', fiatCode: 'USD'),
+        fakeOrder(id: 'eur', kind: 'sell', fiatCode: 'EUR'),
+      ]);
+      helper.setTab(OrderType.buy);
+      helper.container.read(currencyFilterProvider.notifier).state = ['EUR'];
+
+      expect(helper.ids(), ['eur']);
+    });
+
+    test('payment method filter matches any comma-separated token', () async {
+      final helper = await _bookWith([
+        fakeOrder(id: 'multi', kind: 'sell', paymentMethod: 'Wire, Revolut'),
+        fakeOrder(id: 'cash', kind: 'sell', paymentMethod: 'Cash'),
+      ]);
+      helper.setTab(OrderType.buy);
+      helper.container.read(paymentMethodFilterProvider.notifier).state =
+          ['revolut'];
+
+      expect(helper.ids(), ['multi']);
+    });
+
+    test('rating range excludes orders outside the bounds', () async {
+      final helper = await _bookWith([
+        fakeOrder(id: 'low', kind: 'sell', rating: 2.0),
+        fakeOrder(id: 'high', kind: 'sell', rating: 4.5),
+      ]);
+      helper.setTab(OrderType.buy);
+      helper.container.read(ratingFilterProvider.notifier).state =
+          (min: 4.0, max: 5.0);
+
+      expect(helper.ids(), ['high']);
+    });
+
+    test('premium range excludes orders outside the bounds', () async {
+      final helper = await _bookWith([
+        fakeOrder(id: 'cheap', kind: 'sell', premium: -5.0),
+        fakeOrder(id: 'pricey', kind: 'sell', premium: 8.0),
+      ]);
+      helper.setTab(OrderType.buy);
+      helper.container.read(premiumRangeFilterProvider.notifier).state =
+          (min: 5.0, max: 10.0);
+
+      expect(helper.ids(), ['pricey']);
+    });
+
+    test('results are sorted newest-first by createdAt', () async {
+      final helper = await _bookWith([
+        fakeOrder(id: 'older', kind: 'sell', minutesAgo: 30),
+        fakeOrder(id: 'newer', kind: 'sell', minutesAgo: 5),
+      ]);
+      helper.setTab(OrderType.buy);
+
+      expect(helper.ids(), ['newer', 'older']);
+    });
+  });
+}
+
+class ProviderContainerHelper {
+  ProviderContainerHelper(this.container);
+
+  final ProviderContainer container;
+
+  void setTab(OrderType type) =>
+      container.read(homeOrderTypeProvider.notifier).state = type;
+
+  List<String> ids() =>
+      container.read(filteredOrdersProvider).map((o) => o.id).toList();
+}

--- a/test/features/trades/filtered_trades_provider_test.dart
+++ b/test/features/trades/filtered_trades_provider_test.dart
@@ -29,7 +29,7 @@ void main() {
         fakeTrade(id: 'b', status: OrderStatus.pending),
       ]);
 
-      expect(await _orderIds(container), containsAll(['order-a', 'order-b']));
+      expect(await _orderIds(container), unorderedEquals(['order-a', 'order-b']));
     });
 
     test('status filter keeps only matching trades', () async {
@@ -54,7 +54,7 @@ void main() {
 
       expect(
         await _orderIds(container, filter: TradeStatusFilter.success),
-        containsAll(['order-success', 'order-settled']),
+        unorderedEquals(['order-success', 'order-settled']),
       );
     });
 
@@ -65,6 +65,34 @@ void main() {
       ]);
 
       expect(await _orderIds(container), ['order-newer', 'order-older']);
+    });
+  });
+
+  group('orderStatusToFilter', () {
+    test('maps every protocol status to its bucket', () {
+      const expected = {
+        OrderStatus.pending: TradeStatusFilter.pending,
+        OrderStatus.waitingBuyerInvoice: TradeStatusFilter.waitingInvoice,
+        OrderStatus.waitingPayment: TradeStatusFilter.waitingPayment,
+        OrderStatus.active: TradeStatusFilter.active,
+        OrderStatus.inProgress: TradeStatusFilter.active,
+        OrderStatus.fiatSent: TradeStatusFilter.fiatSent,
+        OrderStatus.settledHoldInvoice: TradeStatusFilter.success,
+        OrderStatus.success: TradeStatusFilter.success,
+        OrderStatus.settledByAdmin: TradeStatusFilter.success,
+        OrderStatus.completedByAdmin: TradeStatusFilter.success,
+        OrderStatus.canceled: TradeStatusFilter.canceled,
+        OrderStatus.expired: TradeStatusFilter.canceled,
+        OrderStatus.cooperativelyCanceled: TradeStatusFilter.canceled,
+        OrderStatus.canceledByAdmin: TradeStatusFilter.canceled,
+        OrderStatus.dispute: TradeStatusFilter.dispute,
+      };
+
+      // Guards against an unmapped status silently slipping through.
+      expect(expected.length, OrderStatus.values.length);
+      expected.forEach((status, bucket) {
+        expect(orderStatusToFilter(status), bucket, reason: '$status');
+      });
     });
   });
 }

--- a/test/features/trades/filtered_trades_provider_test.dart
+++ b/test/features/trades/filtered_trades_provider_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro/features/trades/providers/trades_providers.dart';
+import 'package:mostro/src/rust/api/types.dart' show TradeInfo, OrderStatus;
+
+import '../../support/fake_trades.dart';
+import '../../support/provider_harness.dart';
+
+ProviderContainer _tradesWith(List<TradeInfo> trades) {
+  return createContainer(overrides: [
+    rawTradesProvider.overrideWith((ref) async => trades),
+  ]);
+}
+
+Future<List<String>> _orderIds(
+  ProviderContainer container, {
+  TradeStatusFilter filter = TradeStatusFilter.all,
+}) async {
+  container.read(selectedStatusFilterProvider.notifier).state = filter;
+  final items = await container.read(filteredTradesWithOrderStateProvider.future);
+  return items.map((t) => t.orderId).toList();
+}
+
+void main() {
+  group('filteredTradesWithOrderStateProvider', () {
+    test('"All" returns every trade', () async {
+      final container = _tradesWith([
+        fakeTrade(id: 'a', status: OrderStatus.active),
+        fakeTrade(id: 'b', status: OrderStatus.pending),
+      ]);
+
+      expect(await _orderIds(container), containsAll(['order-a', 'order-b']));
+    });
+
+    test('status filter keeps only matching trades', () async {
+      final container = _tradesWith([
+        fakeTrade(id: 'active', status: OrderStatus.active),
+        fakeTrade(id: 'pending', status: OrderStatus.pending),
+      ]);
+
+      expect(
+        await _orderIds(container, filter: TradeStatusFilter.pending),
+        ['order-pending'],
+      );
+    });
+
+    test('terminal protocol statuses collapse into the success filter',
+        () async {
+      final container = _tradesWith([
+        fakeTrade(id: 'success', status: OrderStatus.success),
+        fakeTrade(id: 'settled', status: OrderStatus.settledByAdmin),
+        fakeTrade(id: 'canceled', status: OrderStatus.canceled),
+      ]);
+
+      expect(
+        await _orderIds(container, filter: TradeStatusFilter.success),
+        containsAll(['order-success', 'order-settled']),
+      );
+    });
+
+    test('results are sorted newest-first by startedAt', () async {
+      final container = _tradesWith([
+        fakeTrade(id: 'older', startedAt: 1000),
+        fakeTrade(id: 'newer', startedAt: 5000),
+      ]);
+
+      expect(await _orderIds(container), ['order-newer', 'order-older']);
+    });
+  });
+}

--- a/test/features/walkthrough/first_run_provider_test.dart
+++ b/test/features/walkthrough/first_run_provider_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro/features/walkthrough/providers/first_run_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('FirstRunNotifier', () {
+    test('starts loading then resolves to the stored flag', () async {
+      SharedPreferences.setMockInitialValues({kFirstRunCompleteKey: true});
+
+      final notifier = FirstRunNotifier();
+      expect(notifier.state, isA<AsyncLoading<bool>>());
+
+      await pumpEventQueue();
+      expect(notifier.state, const AsyncData<bool>(true));
+    });
+
+    test('defaults to false (first launch) when the key is absent', () async {
+      SharedPreferences.setMockInitialValues({});
+
+      final notifier = FirstRunNotifier();
+      await pumpEventQueue();
+
+      expect(notifier.state, const AsyncData<bool>(false));
+    });
+
+    test('initialValue skips the loading state', () {
+      final notifier = FirstRunNotifier(initialValue: true);
+      expect(notifier.state, const AsyncData<bool>(true));
+    });
+
+    test('markFirstRunComplete() persists and exposes data(true)', () async {
+      SharedPreferences.setMockInitialValues({});
+
+      final notifier = FirstRunNotifier(initialValue: false);
+      await notifier.markFirstRunComplete();
+
+      expect(notifier.state, const AsyncData<bool>(true));
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getBool(kFirstRunCompleteKey), isTrue);
+    });
+  });
+}

--- a/test/support/fake_orders.dart
+++ b/test/support/fake_orders.dart
@@ -1,0 +1,34 @@
+import 'package:mostro/features/home/providers/home_order_providers.dart';
+
+/// Anchor so timestamp-based sort assertions don't depend on the wall clock.
+final DateTime kFakeNow = DateTime.utc(2026, 1, 1, 12);
+
+/// Builds a fixed-amount [OrderItem], exposing only the fields filter logic
+/// reads. [minutesAgo] controls recency for sort assertions.
+OrderItem fakeOrder({
+  String id = 'order-1',
+  String kind = 'sell',
+  double fiatAmount = 100,
+  String fiatCode = 'USD',
+  String paymentMethod = 'Wire',
+  double premium = 0,
+  String creatorPubkey = 'pubkey-1',
+  double rating = 5.0,
+  OrderStatus status = OrderStatus.pending,
+  bool isMine = false,
+  int minutesAgo = 0,
+}) {
+  return OrderItem(
+    id: id,
+    kind: kind,
+    fiatAmount: fiatAmount,
+    fiatCode: fiatCode,
+    paymentMethod: paymentMethod,
+    premium: premium,
+    creatorPubkey: creatorPubkey,
+    createdAt: kFakeNow.subtract(Duration(minutes: minutesAgo)),
+    rating: rating,
+    status: status,
+    isMine: isMine,
+  );
+}

--- a/test/support/fake_orders.dart
+++ b/test/support/fake_orders.dart
@@ -3,12 +3,16 @@ import 'package:mostro/features/home/providers/home_order_providers.dart';
 /// Anchor so timestamp-based sort assertions don't depend on the wall clock.
 final DateTime kFakeNow = DateTime.utc(2026, 1, 1, 12);
 
-/// Builds a fixed-amount [OrderItem], exposing only the fields filter logic
-/// reads. [minutesAgo] controls recency for sort assertions.
+/// Builds an [OrderItem], exposing only the fields filter logic reads.
+/// [minutesAgo] controls recency for sort assertions. Pass
+/// [fiatAmountMin]/[fiatAmountMax] to build a range order (which drops
+/// [fiatAmount], as the [OrderItem] shape validation requires).
 OrderItem fakeOrder({
   String id = 'order-1',
   String kind = 'sell',
-  double fiatAmount = 100,
+  double? fiatAmount = 100,
+  double? fiatAmountMin,
+  double? fiatAmountMax,
   String fiatCode = 'USD',
   String paymentMethod = 'Wire',
   double premium = 0,
@@ -18,10 +22,13 @@ OrderItem fakeOrder({
   bool isMine = false,
   int minutesAgo = 0,
 }) {
+  final isRange = fiatAmountMin != null && fiatAmountMax != null;
   return OrderItem(
     id: id,
     kind: kind,
-    fiatAmount: fiatAmount,
+    fiatAmount: isRange ? null : fiatAmount,
+    fiatAmountMin: fiatAmountMin,
+    fiatAmountMax: fiatAmountMax,
     fiatCode: fiatCode,
     paymentMethod: paymentMethod,
     premium: premium,

--- a/test/support/fake_trades.dart
+++ b/test/support/fake_trades.dart
@@ -1,0 +1,37 @@
+import 'package:mostro/src/rust/api/types.dart';
+
+/// Builds a [TradeInfo] exposing only the fields the trades-list mapping reads.
+/// [startedAt] is the newest-first sort key. `currentStep` is unread by the
+/// mapping, so it takes an arbitrary value.
+TradeInfo fakeTrade({
+  String id = 'trade-1',
+  OrderStatus status = OrderStatus.active,
+  TradeRole role = TradeRole.buyer,
+  String fiatCode = 'USD',
+  String paymentMethod = 'Wire',
+  bool isMine = false,
+  int startedAt = 1000,
+}) {
+  final order = OrderInfo(
+    id: 'order-$id',
+    kind: OrderKind.sell,
+    status: status,
+    fiatAmount: 100,
+    fiatCode: fiatCode,
+    paymentMethod: paymentMethod,
+    premium: 0,
+    creatorPubkey: 'pubkey-$id',
+    createdAt: startedAt,
+    isMine: isMine,
+  );
+
+  return TradeInfo(
+    id: id,
+    order: order,
+    role: role,
+    counterpartyPubkey: 'counterparty-$id',
+    currentStep: const TradeStep.disputed(),
+    tradeKeyIndex: 0,
+    startedAt: startedAt,
+  );
+}

--- a/test/support/order_book_harness.dart
+++ b/test/support/order_book_harness.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mostro/features/home/providers/home_order_providers.dart';
+
+import 'provider_harness.dart';
+
+/// Overrides the order book to yield [orders], resolved so
+/// [filteredOrdersProvider] can be read synchronously afterwards.
+Future<OrderBookHarness> bookWith(List<OrderItem> orders) async {
+  final container = createContainer(overrides: [
+    orderBookProvider.overrideWith((ref) => Stream.value(orders)),
+  ]);
+  // Keep the autoDispose stream alive so it survives any later awaits.
+  container.listen(orderBookProvider, (_, __) {});
+  await container.read(orderBookProvider.future);
+  return OrderBookHarness(container);
+}
+
+class OrderBookHarness {
+  OrderBookHarness(this.container);
+
+  final ProviderContainer container;
+
+  void setTab(OrderType type) =>
+      container.read(homeOrderTypeProvider.notifier).state = type;
+
+  List<String> ids() =>
+      container.read(filteredOrdersProvider).map((o) => o.id).toList();
+}

--- a/test/support/provider_harness.dart
+++ b/test/support/provider_harness.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Creates a [ProviderContainer] and disposes it at test tear-down, so state
+/// never leaks between tests. Call from inside a `test(...)` body.
+ProviderContainer createContainer({
+  List<Override> overrides = const [],
+  ProviderContainer? parent,
+}) {
+  final container = ProviderContainer(
+    parent: parent,
+    overrides: overrides,
+  );
+  addTearDown(container.dispose);
+  return container;
+}


### PR DESCRIPTION
Refs #152 (PR1 of 2 — phased).

First slice of the Flutter test base:

- `ProviderContainer` harness with auto-dispose + fake data builders (`test/support/`).
- Notifier tests: `BackupReminderNotifier`/`BackupCompletedNotifier` (snooze, dismiss, legacy migration) and `FirstRunNotifier` (loading→data, first-launch default).
- Filter/derivation tests: `filteredOrdersProvider` (tabs, ownership, currency/payment/rating/premium, sort) and `filteredTradesWithOrderStateProvider` (status filter, terminal-status collapse, sort) — Rust-backed providers are overridden with fakes.

29 tests passing; `flutter analyze` clean. Suite runs in the existing CI `flutter test` step (no workflow change needed).

Deferred to PR2: DESIGN_SYSTEM golden tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added coverage for backup reminders and completion, including load/reconcile behavior, snoozing, dismissal, persistence, and legacy fallback.
  - Added first-run completion notifier tests covering loading, defaults, and persistence.
  - Added Riverpod provider tests for orders and trades filtering, status mapping, sorting, and edge cases (unrated/range orders, terminal status bucketing).
- **Test Support**
  - Added deterministic order/trade fixtures, including “fake now” timestamping and range order support.
  - Introduced Riverpod test utilities (container creation and order book harness) to streamline provider-based assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->