### PR TITLE
feat: add Zapstore manifest for v2 (#156)

### DIFF
--- a/zapstore.yaml
+++ b/zapstore.yaml
@@ -1,0 +1,44 @@
+repository: https://github.com/MostroP2P/app
+description: |
+  The official non-custodial, cross-platform client for the Mostro peer-to-peer exchange network.
+
+  Mostro App lets anyone buy or sell Bitcoin for local fiat currency over the Lightning Network — without accounts, without KYC, and without trusting a third party. Built with Flutter and a Rust core, it runs on Android, iOS, Web, macOS, Windows, and Linux from a single codebase.
+
+  Key Features:
+
+    - Non-custodial: Your keys stay on your device — no exchange ever holds your funds
+    - Privacy-first: End-to-end encrypted over Nostr — NIP-44 direct messages with the Mostro daemon and NIP-59 Gift Wrap for peer-to-peer chat
+    - Lightning-native: All Bitcoin settlements happen via Lightning invoices, with Nostr Wallet Connect (NWC) support for automated invoicing
+    - Hierarchical Key Management: BIP-32 / BIP-39 key derivation with a unique key per trade
+    - Censorship-resistant: Built on Nostr — no central server or domain to block
+    - Multi-Language: English, Spanish, Italian, French, and German
+    - Open source: MIT licensed and fully auditable
+summary: Non-custodial, peer-to-peer Bitcoin exchange on Lightning, powered by Nostr.
+tags:
+    - peer-to-peer
+    - p2p
+    - security
+    - privacy
+    - android
+    - bitcoin
+    - lightning
+    - nostr
+    - cryptography
+    - freedom-tech
+license: MIT
+website: https://mostro.network
+# TODO: assets/images/wt-*.png are 817-byte placeholder PNGs, not real
+# screenshots. Populate with real store screenshots before publishing.
+# images:
+#     - assets/images/screenshot-1.png
+supported_nips:
+    - "01"
+    - "06"
+    - "13"
+    - "17"
+    - "44"
+    - "47"
+    - "59"
+    - "69"
+metadata_sources:
+    - github


### PR DESCRIPTION
Adds zapstore.yaml for v2, per #156, manifest file only the release pipeline (#118) and signing are deliberately out of scope for now.
Every field is verified against v2's code and README:
•	supported_nips verified against v2 source: added 13 (PoW) and 17 (peer chat), dropped 65 (relay-list discovery not implemented yet tracked in #146). Final list: 01, 06, 13, 17, 44, 47, 59, 69.
•	description / summary written from v2's README, not v1's, v1's copy described NIP-59 for all comms, which is inaccurate for v2 (NIP-44 with the daemon, NIP-59 for peer chat). Leads with non-custodial and the six supported platforms.
•	Languages: en, es, it, fr, de (5 locales, from the .arb files).
•	images left as a documented TODO, assets/images/wt-*.png are 817-byte placeholder PNGs, not real screenshots. Manifest is publish-ready once real ones are added.
•	Mirrors v1's proven field structure; if Zapstore needs an explicit foundation.mostro.app identifier, happy to add it.
Marked Refs #156 (not Closes) since the screenshots portion is still open



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a ZapStore listing for the Mostro App, including its description, key features, categories, licensing, website, and supported Nostr standards.
  * Added metadata identifying GitHub as a source for listing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->