### PR TITLE
feat: parse anti-abuse bond policy from kind-38385 info event

### DIFF
--- a/lib/features/about/models/mostro_instance.dart
+++ b/lib/features/about/models/mostro_instance.dart
@@ -1,5 +1,19 @@
 import 'package:flutter/foundation.dart';
 
+/// Anti-abuse bond policy advertised by a Mostro daemon via its kind-38385
+/// info event.
+///
+/// Three states must be distinguished:
+/// - [unsupported]: the `bond_enabled` tag is absent (legacy daemon that
+///   predates the anti-abuse bond feature) or carries a malformed value.
+/// - [disabled]: `bond_enabled="false"` — the operator left the feature off.
+/// - [enabled]: `bond_enabled="true"` — the bond is active and the remaining
+///   bond tags are meaningful.
+enum BondPolicy { unsupported, disabled, enabled }
+
+/// Which side of a trade a bond applies to (`bond_apply_to` tag).
+enum BondApplyTo { take, make, both }
+
 /// Dart model parsed from a Nostr Kind 38385 (Mostro instance status) event.
 ///
 /// All fields are derived from individual tags — the event `content` is empty
@@ -29,6 +43,13 @@ class MostroInstance {
     this.lndNetworks,
     this.lndUris,
     this.maxOrdersPerResponse,
+    this.bondPolicy = BondPolicy.unsupported,
+    this.bondApplyTo,
+    this.bondSlashOnWaitingTimeout,
+    this.bondAmountPct,
+    this.bondBaseAmountSats,
+    this.bondSlashNodeSharePct,
+    this.bondPayoutClaimWindowDays,
   });
 
   /// Mostro daemon pubkey (from `d` tag).
@@ -66,6 +87,26 @@ class MostroInstance {
   final String? lndNetworks;
   final String? lndUris;
 
+  // ── Anti-abuse bond ─────────────────────────────────────────────────────────
+
+  /// Bond policy state; defaults to [BondPolicy.unsupported]. See [BondPolicy].
+  final BondPolicy bondPolicy;
+
+  // The following six fields carry the bond parameters and are only meaningful
+  // when [bondPolicy] is [BondPolicy.enabled]. Each is `null` when the tag is
+  // absent or when its value fails validation.
+
+  final BondApplyTo? bondApplyTo;
+  final bool? bondSlashOnWaitingTimeout;
+  /// Bond fraction of the order amount, constrained to `[0.0, 1.0]`.
+  final double? bondAmountPct;
+  /// Minimum bond floor in sats, `>= 0`.
+  final int? bondBaseAmountSats;
+  /// Node's share of a slashed bond, constrained to `[0.0, 1.0]`.
+  final double? bondSlashNodeSharePct;
+  /// Days to claim a payout before forfeit, `> 0`.
+  final int? bondPayoutClaimWindowDays;
+
   // ── Factory ─────────────────────────────────────────────────────────────────
 
   /// Parse a Kind 38385 event's tag list into a [MostroInstance].
@@ -80,6 +121,73 @@ class MostroInstance {
         }
       }
       return null;
+    }
+
+    // Like [get] but trims the value and treats empty/whitespace-only as
+    // missing, so an empty tag (e.g. `bond_enabled=""`) is not misparsed as a
+    // legitimate value — preserving the three-state [BondPolicy] semantics.
+    String? getOptional(String name) {
+      final raw = get(name);
+      if (raw == null) return null;
+      final value = raw.trim();
+      return value.isEmpty ? null : value;
+    }
+
+    BondPolicy parseBondPolicy() {
+      switch (getOptional('bond_enabled')?.toLowerCase()) {
+        case 'true':
+          return BondPolicy.enabled;
+        case 'false':
+          return BondPolicy.disabled;
+        default:
+          return BondPolicy.unsupported;
+      }
+    }
+
+    BondApplyTo? parseBondApplyTo() {
+      switch (getOptional('bond_apply_to')?.toLowerCase()) {
+        case 'take':
+          return BondApplyTo.take;
+        case 'make':
+          return BondApplyTo.make;
+        case 'both':
+          return BondApplyTo.both;
+        default:
+          return null;
+      }
+    }
+
+    // Parses a boolean tag, yielding `null` for anything other than
+    // `"true"`/`"false"` so malformed data is not collapsed into a valid state.
+    bool? parseBool(String name) {
+      switch (getOptional(name)?.toLowerCase()) {
+        case 'true':
+          return true;
+        case 'false':
+          return false;
+        default:
+          return null;
+      }
+    }
+
+    // Parses a fraction constrained to `[0.0, 1.0]`; out-of-range or
+    // unparseable values yield `null`.
+    double? parseFraction(String name) {
+      final value = double.tryParse(getOptional(name) ?? '');
+      if (value == null) return null;
+      return (value >= 0.0 && value <= 1.0) ? value : null;
+    }
+
+    int? parseNonNegativeInt(String name) {
+      final value = int.tryParse(getOptional(name) ?? '');
+      if (value == null) return null;
+      return value >= 0 ? value : null;
+    }
+
+    int? parsePositiveInt(String name) {
+      final value = int.tryParse(getOptional(name) ?? '');
+      if (value == null) return null;
+      return value > 0 ? value : null;
     }
 
     return MostroInstance(
@@ -108,6 +216,14 @@ class MostroInstance {
       lndUris: get('lnd_uris'),
       maxOrdersPerResponse:
           int.tryParse(get('max_orders_per_response') ?? ''),
+      bondPolicy: parseBondPolicy(),
+      bondApplyTo: parseBondApplyTo(),
+      bondSlashOnWaitingTimeout: parseBool('bond_slash_on_waiting_timeout'),
+      bondAmountPct: parseFraction('bond_amount_pct'),
+      bondBaseAmountSats: parseNonNegativeInt('bond_base_amount_sats'),
+      bondSlashNodeSharePct: parseFraction('bond_slash_node_share_pct'),
+      bondPayoutClaimWindowDays:
+          parsePositiveInt('bond_payout_claim_window_days'),
     );
   }
 

--- a/lib/features/about/models/mostro_instance.dart
+++ b/lib/features/about/models/mostro_instance.dart
@@ -100,7 +100,8 @@ class MostroInstance {
   final BondApplyTo? bondApplyTo;
   final bool? bondSlashOnWaitingTimeout;
 
-  /// Bond fraction of the order amount, constrained to `[0.0, 1.0]`.
+  /// Bond fraction of the order amount (0.01 = 1%). Non-negative and finite;
+  /// not capped at 1.0 (the daemon does not constrain its upper bound).
   final double? bondAmountPct;
 
   /// Minimum bond floor in sats, `>= 0`.
@@ -172,10 +173,14 @@ class MostroInstance {
       }
     }
 
-    double? parseFraction(String name) {
+    // Rejects NaN/Infinity and negatives. [max] caps the upper bound only when
+    // the protocol constrains it: the daemon validates `slash_node_share_pct`
+    // to `<= 1.0`, but `amount_pct` is an unbounded fraction (0.01 = 1%).
+    double? parseFraction(String name, {double? max}) {
       final value = double.tryParse(getOptional(name) ?? '');
-      if (value == null) return null;
-      return (value >= 0.0 && value <= 1.0) ? value : null;
+      if (value == null || !value.isFinite || value < 0.0) return null;
+      if (max != null && value > max) return null;
+      return value;
     }
 
     int? parseNonNegativeInt(String name) {
@@ -229,7 +234,9 @@ class MostroInstance {
       bondBaseAmountSats:
           isEnabled ? parseNonNegativeInt('bond_base_amount_sats') : null,
       bondSlashNodeSharePct:
-          isEnabled ? parseFraction('bond_slash_node_share_pct') : null,
+          isEnabled
+              ? parseFraction('bond_slash_node_share_pct', max: 1.0)
+              : null,
       bondPayoutClaimWindowDays:
           isEnabled ? parsePositiveInt('bond_payout_claim_window_days') : null,
     );

--- a/lib/features/about/models/mostro_instance.dart
+++ b/lib/features/about/models/mostro_instance.dart
@@ -61,8 +61,10 @@ class MostroInstance {
   final String? commitHash;
   final int? maxOrderAmount;
   final int? minOrderAmount;
+
   /// Pending order lifetime in hours.
   final int? expirationHours;
+
   /// Fee as a fraction, e.g. 0.006 = 0.6 %.
   final double? fee;
   final String? fiatCurrenciesAccepted;
@@ -92,18 +94,21 @@ class MostroInstance {
   /// Bond policy state; defaults to [BondPolicy.unsupported]. See [BondPolicy].
   final BondPolicy bondPolicy;
 
-  // The following six fields carry the bond parameters and are only meaningful
-  // when [bondPolicy] is [BondPolicy.enabled]. Each is `null` when the tag is
-  // absent or when its value fails validation.
+  // The six bond parameters are non-null only when [bondPolicy] is
+  // [BondPolicy.enabled]; otherwise, or on an absent/invalid tag, they are null.
 
   final BondApplyTo? bondApplyTo;
   final bool? bondSlashOnWaitingTimeout;
+
   /// Bond fraction of the order amount, constrained to `[0.0, 1.0]`.
   final double? bondAmountPct;
+
   /// Minimum bond floor in sats, `>= 0`.
   final int? bondBaseAmountSats;
+
   /// Node's share of a slashed bond, constrained to `[0.0, 1.0]`.
   final double? bondSlashNodeSharePct;
+
   /// Days to claim a payout before forfeit, `> 0`.
   final int? bondPayoutClaimWindowDays;
 
@@ -123,9 +128,8 @@ class MostroInstance {
       return null;
     }
 
-    // Like [get] but trims the value and treats empty/whitespace-only as
-    // missing, so an empty tag (e.g. `bond_enabled=""`) is not misparsed as a
-    // legitimate value — preserving the three-state [BondPolicy] semantics.
+    // Treats empty/whitespace-only as missing, so an empty `bond_enabled=""`
+    // stays `unsupported` rather than being read as `disabled`.
     String? getOptional(String name) {
       final raw = get(name);
       if (raw == null) return null;
@@ -157,8 +161,6 @@ class MostroInstance {
       }
     }
 
-    // Parses a boolean tag, yielding `null` for anything other than
-    // `"true"`/`"false"` so malformed data is not collapsed into a valid state.
     bool? parseBool(String name) {
       switch (getOptional(name)?.toLowerCase()) {
         case 'true':
@@ -170,8 +172,6 @@ class MostroInstance {
       }
     }
 
-    // Parses a fraction constrained to `[0.0, 1.0]`; out-of-range or
-    // unparseable values yield `null`.
     double? parseFraction(String name) {
       final value = double.tryParse(getOptional(name) ?? '');
       if (value == null) return null;
@@ -190,6 +190,11 @@ class MostroInstance {
       return value > 0 ? value : null;
     }
 
+    // Parameters are gated on an enabled policy so a disabled or malformed
+    // event never exposes live bond values (consumers key off nullability).
+    final bondPolicy = parseBondPolicy();
+    final isEnabled = bondPolicy == BondPolicy.enabled;
+
     return MostroInstance(
       pubKey: get('d') ?? '',
       mostroVersion: get('mostro_version'),
@@ -201,12 +206,13 @@ class MostroInstance {
       fiatCurrenciesAccepted: get('fiat_currencies_accepted'),
       fee: double.tryParse(get('fee') ?? ''),
       pow: int.tryParse(get('pow') ?? ''),
-      holdInvoiceExpirationWindow:
-          int.tryParse(get('hold_invoice_expiration_window') ?? ''),
-      holdInvoiceCltvDelta:
-          int.tryParse(get('hold_invoice_cltv_delta') ?? ''),
-      invoiceExpirationWindow:
-          int.tryParse(get('invoice_expiration_window') ?? ''),
+      holdInvoiceExpirationWindow: int.tryParse(
+        get('hold_invoice_expiration_window') ?? '',
+      ),
+      holdInvoiceCltvDelta: int.tryParse(get('hold_invoice_cltv_delta') ?? ''),
+      invoiceExpirationWindow: int.tryParse(
+        get('invoice_expiration_window') ?? '',
+      ),
       lndVersion: get('lnd_version'),
       lndNodePublicKey: get('lnd_node_pubkey'),
       lndCommitHash: get('lnd_commit_hash'),
@@ -214,16 +220,18 @@ class MostroInstance {
       lndChains: get('lnd_chains'),
       lndNetworks: get('lnd_networks'),
       lndUris: get('lnd_uris'),
-      maxOrdersPerResponse:
-          int.tryParse(get('max_orders_per_response') ?? ''),
-      bondPolicy: parseBondPolicy(),
-      bondApplyTo: parseBondApplyTo(),
-      bondSlashOnWaitingTimeout: parseBool('bond_slash_on_waiting_timeout'),
-      bondAmountPct: parseFraction('bond_amount_pct'),
-      bondBaseAmountSats: parseNonNegativeInt('bond_base_amount_sats'),
-      bondSlashNodeSharePct: parseFraction('bond_slash_node_share_pct'),
+      maxOrdersPerResponse: int.tryParse(get('max_orders_per_response') ?? ''),
+      bondPolicy: bondPolicy,
+      bondApplyTo: isEnabled ? parseBondApplyTo() : null,
+      bondSlashOnWaitingTimeout:
+          isEnabled ? parseBool('bond_slash_on_waiting_timeout') : null,
+      bondAmountPct: isEnabled ? parseFraction('bond_amount_pct') : null,
+      bondBaseAmountSats:
+          isEnabled ? parseNonNegativeInt('bond_base_amount_sats') : null,
+      bondSlashNodeSharePct:
+          isEnabled ? parseFraction('bond_slash_node_share_pct') : null,
       bondPayoutClaimWindowDays:
-          parsePositiveInt('bond_payout_claim_window_days'),
+          isEnabled ? parsePositiveInt('bond_payout_claim_window_days') : null,
     );
   }
 

--- a/test/features/about/models/mostro_instance_test.dart
+++ b/test/features/about/models/mostro_instance_test.dart
@@ -148,41 +148,32 @@ void main() {
   });
 
   group('MostroInstance.fromTags — bond parameter validation', () {
-    test('bond_amount_pct out of [0.0, 1.0] yields null', () {
-      expect(
-        MostroInstance.fromTags(
-          enabledTagsWith({'bond_amount_pct': '1.5'}),
-        ).bondAmountPct,
-        isNull,
-      );
-      expect(
-        MostroInstance.fromTags(
-          enabledTagsWith({'bond_amount_pct': '-0.1'}),
-        ).bondAmountPct,
-        isNull,
-      );
-      expect(
-        MostroInstance.fromTags(
-          enabledTagsWith({'bond_amount_pct': 'abc'}),
-        ).bondAmountPct,
-        isNull,
-      );
+    test('bond_amount_pct rejects negative, NaN, Infinity, and garbage', () {
+      for (final bogus in ['-0.1', 'NaN', 'Infinity', '-Infinity', 'abc']) {
+        expect(
+          MostroInstance.fromTags(
+            enabledTagsWith({'bond_amount_pct': bogus}),
+          ).bondAmountPct,
+          isNull,
+          reason: 'rejects "$bogus"',
+        );
+      }
     });
 
-    test('bond_amount_pct accepts the [0.0, 1.0] boundaries', () {
-      expect(
-        MostroInstance.fromTags(
-          enabledTagsWith({'bond_amount_pct': '0.0'}),
-        ).bondAmountPct,
-        0.0,
-      );
-      expect(
-        MostroInstance.fromTags(
-          enabledTagsWith({'bond_amount_pct': '1.0'}),
-        ).bondAmountPct,
-        1.0,
-      );
-    });
+    test(
+      'bond_amount_pct accepts any non-negative fraction, including > 1.0',
+      () {
+        // The daemon does not cap amount_pct at 1.0, so neither do we.
+        for (final entry in {'0.0': 0.0, '1.0': 1.0, '1.5': 1.5}.entries) {
+          expect(
+            MostroInstance.fromTags(
+              enabledTagsWith({'bond_amount_pct': entry.key}),
+            ).bondAmountPct,
+            entry.value,
+          );
+        }
+      },
+    );
 
     test('negative bond_base_amount_sats yields null', () {
       expect(
@@ -199,13 +190,16 @@ void main() {
       );
     });
 
-    test('bond_slash_node_share_pct out of [0.0, 1.0] yields null', () {
-      expect(
-        MostroInstance.fromTags(
-          enabledTagsWith({'bond_slash_node_share_pct': '2.0'}),
-        ).bondSlashNodeSharePct,
-        isNull,
-      );
+    test('bond_slash_node_share_pct rejects values outside [0.0, 1.0]', () {
+      for (final bogus in ['2.0', '-0.5', 'NaN', 'Infinity']) {
+        expect(
+          MostroInstance.fromTags(
+            enabledTagsWith({'bond_slash_node_share_pct': bogus}),
+          ).bondSlashNodeSharePct,
+          isNull,
+          reason: 'rejects "$bogus"',
+        );
+      }
     });
 
     test('non-positive bond_payout_claim_window_days yields null', () {

--- a/test/features/about/models/mostro_instance_test.dart
+++ b/test/features/about/models/mostro_instance_test.dart
@@ -10,6 +10,13 @@ List<List<String>> tagsWith(Map<String, String> extra) {
   ];
 }
 
+/// Like [tagsWith] but always advertises an enabled bond policy, so bond
+/// parameter parsing/validation can be exercised — the six parameters are gated
+/// on `bondPolicy == enabled`.
+List<List<String>> enabledTagsWith(Map<String, String> extra) {
+  return tagsWith({'bond_enabled': 'true', ...extra});
+}
+
 /// The full set of valid bond tags for an enabled node.
 const _enabledBondTags = {
   'bond_enabled': 'true',
@@ -29,14 +36,16 @@ void main() {
     });
 
     test('disabled when bond_enabled="false"', () {
-      final instance =
-          MostroInstance.fromTags(tagsWith({'bond_enabled': 'false'}));
+      final instance = MostroInstance.fromTags(
+        tagsWith({'bond_enabled': 'false'}),
+      );
       expect(instance.bondPolicy, BondPolicy.disabled);
     });
 
     test('enabled when bond_enabled="true"', () {
-      final instance =
-          MostroInstance.fromTags(tagsWith({'bond_enabled': 'true'}));
+      final instance = MostroInstance.fromTags(
+        tagsWith({'bond_enabled': 'true'}),
+      );
       expect(instance.bondPolicy, BondPolicy.enabled);
     });
 
@@ -52,26 +61,28 @@ void main() {
     });
 
     test('empty bond_enabled="" is treated as missing (unsupported)', () {
-      final instance =
-          MostroInstance.fromTags(tagsWith({'bond_enabled': ''}));
+      final instance = MostroInstance.fromTags(tagsWith({'bond_enabled': ''}));
       expect(instance.bondPolicy, BondPolicy.unsupported);
     });
 
-    test('whitespace-only bond_enabled is treated as missing (unsupported)',
-        () {
-      final instance =
-          MostroInstance.fromTags(tagsWith({'bond_enabled': '   '}));
-      expect(instance.bondPolicy, BondPolicy.unsupported);
-    });
+    test(
+      'whitespace-only bond_enabled is treated as missing (unsupported)',
+      () {
+        final instance = MostroInstance.fromTags(
+          tagsWith({'bond_enabled': '   '}),
+        );
+        expect(instance.bondPolicy, BondPolicy.unsupported);
+      },
+    );
 
     test('malformed bond_enabled falls back to unsupported', () {
-      final instance =
-          MostroInstance.fromTags(tagsWith({'bond_enabled': 'yes'}));
+      final instance = MostroInstance.fromTags(
+        tagsWith({'bond_enabled': 'yes'}),
+      );
       expect(instance.bondPolicy, BondPolicy.unsupported);
     });
 
     test('a value-less bond_enabled tag is treated as missing', () {
-      // Tag array with only the name and no value.
       final instance = MostroInstance.fromTags(const [
         ['d', 'npub_test'],
         ['bond_enabled'],
@@ -94,40 +105,43 @@ void main() {
     });
 
     test('bond_apply_to parses take / make / both', () {
-      for (final entry in {
-        'take': BondApplyTo.take,
-        'make': BondApplyTo.make,
-        'both': BondApplyTo.both,
-      }.entries) {
-        final instance =
-            MostroInstance.fromTags(tagsWith({'bond_apply_to': entry.key}));
+      for (final entry
+          in {
+            'take': BondApplyTo.take,
+            'make': BondApplyTo.make,
+            'both': BondApplyTo.both,
+          }.entries) {
+        final instance = MostroInstance.fromTags(
+          enabledTagsWith({'bond_apply_to': entry.key}),
+        );
         expect(instance.bondApplyTo, entry.value);
       }
     });
 
     test('invalid bond_apply_to yields null', () {
-      final instance =
-          MostroInstance.fromTags(tagsWith({'bond_apply_to': 'sometimes'}));
+      final instance = MostroInstance.fromTags(
+        enabledTagsWith({'bond_apply_to': 'sometimes'}),
+      );
       expect(instance.bondApplyTo, isNull);
     });
 
     test('bond_slash_on_waiting_timeout parses true/false, else null', () {
       expect(
         MostroInstance.fromTags(
-                tagsWith({'bond_slash_on_waiting_timeout': 'true'}))
-            .bondSlashOnWaitingTimeout,
+          enabledTagsWith({'bond_slash_on_waiting_timeout': 'true'}),
+        ).bondSlashOnWaitingTimeout,
         isTrue,
       );
       expect(
         MostroInstance.fromTags(
-                tagsWith({'bond_slash_on_waiting_timeout': 'false'}))
-            .bondSlashOnWaitingTimeout,
+          enabledTagsWith({'bond_slash_on_waiting_timeout': 'false'}),
+        ).bondSlashOnWaitingTimeout,
         isFalse,
       );
       expect(
         MostroInstance.fromTags(
-                tagsWith({'bond_slash_on_waiting_timeout': 'maybe'}))
-            .bondSlashOnWaitingTimeout,
+          enabledTagsWith({'bond_slash_on_waiting_timeout': 'maybe'}),
+        ).bondSlashOnWaitingTimeout,
         isNull,
       );
     });
@@ -136,52 +150,60 @@ void main() {
   group('MostroInstance.fromTags — bond parameter validation', () {
     test('bond_amount_pct out of [0.0, 1.0] yields null', () {
       expect(
-        MostroInstance.fromTags(tagsWith({'bond_amount_pct': '1.5'}))
-            .bondAmountPct,
+        MostroInstance.fromTags(
+          enabledTagsWith({'bond_amount_pct': '1.5'}),
+        ).bondAmountPct,
         isNull,
       );
       expect(
-        MostroInstance.fromTags(tagsWith({'bond_amount_pct': '-0.1'}))
-            .bondAmountPct,
+        MostroInstance.fromTags(
+          enabledTagsWith({'bond_amount_pct': '-0.1'}),
+        ).bondAmountPct,
         isNull,
       );
       expect(
-        MostroInstance.fromTags(tagsWith({'bond_amount_pct': 'abc'}))
-            .bondAmountPct,
+        MostroInstance.fromTags(
+          enabledTagsWith({'bond_amount_pct': 'abc'}),
+        ).bondAmountPct,
         isNull,
       );
     });
 
     test('bond_amount_pct accepts the [0.0, 1.0] boundaries', () {
       expect(
-        MostroInstance.fromTags(tagsWith({'bond_amount_pct': '0.0'}))
-            .bondAmountPct,
+        MostroInstance.fromTags(
+          enabledTagsWith({'bond_amount_pct': '0.0'}),
+        ).bondAmountPct,
         0.0,
       );
       expect(
-        MostroInstance.fromTags(tagsWith({'bond_amount_pct': '1.0'}))
-            .bondAmountPct,
+        MostroInstance.fromTags(
+          enabledTagsWith({'bond_amount_pct': '1.0'}),
+        ).bondAmountPct,
         1.0,
       );
     });
 
     test('negative bond_base_amount_sats yields null', () {
       expect(
-        MostroInstance.fromTags(tagsWith({'bond_base_amount_sats': '-1'}))
-            .bondBaseAmountSats,
+        MostroInstance.fromTags(
+          enabledTagsWith({'bond_base_amount_sats': '-1'}),
+        ).bondBaseAmountSats,
         isNull,
       );
       expect(
-        MostroInstance.fromTags(tagsWith({'bond_base_amount_sats': '0'}))
-            .bondBaseAmountSats,
+        MostroInstance.fromTags(
+          enabledTagsWith({'bond_base_amount_sats': '0'}),
+        ).bondBaseAmountSats,
         0,
       );
     });
 
     test('bond_slash_node_share_pct out of [0.0, 1.0] yields null', () {
       expect(
-        MostroInstance.fromTags(tagsWith({'bond_slash_node_share_pct': '2.0'}))
-            .bondSlashNodeSharePct,
+        MostroInstance.fromTags(
+          enabledTagsWith({'bond_slash_node_share_pct': '2.0'}),
+        ).bondSlashNodeSharePct,
         isNull,
       );
     });
@@ -189,17 +211,57 @@ void main() {
     test('non-positive bond_payout_claim_window_days yields null', () {
       expect(
         MostroInstance.fromTags(
-                tagsWith({'bond_payout_claim_window_days': '0'}))
-            .bondPayoutClaimWindowDays,
+          enabledTagsWith({'bond_payout_claim_window_days': '0'}),
+        ).bondPayoutClaimWindowDays,
         isNull,
       );
       expect(
         MostroInstance.fromTags(
-                tagsWith({'bond_payout_claim_window_days': '-5'}))
-            .bondPayoutClaimWindowDays,
+          enabledTagsWith({'bond_payout_claim_window_days': '-5'}),
+        ).bondPayoutClaimWindowDays,
         isNull,
       );
     });
+  });
+
+  group('MostroInstance.fromTags — parameters gated on enabled policy', () {
+    void expectNoBondParameters(MostroInstance instance) {
+      expect(instance.bondApplyTo, isNull);
+      expect(instance.bondSlashOnWaitingTimeout, isNull);
+      expect(instance.bondAmountPct, isNull);
+      expect(instance.bondBaseAmountSats, isNull);
+      expect(instance.bondSlashNodeSharePct, isNull);
+      expect(instance.bondPayoutClaimWindowDays, isNull);
+    }
+
+    test(
+      'disabled node exposes no bond parameters even when tags are present',
+      () {
+        final instance = MostroInstance.fromTags(
+          tagsWith({..._enabledBondTags, 'bond_enabled': 'false'}),
+        );
+
+        expect(instance.bondPolicy, BondPolicy.disabled);
+        expectNoBondParameters(instance);
+      },
+    );
+
+    test(
+      'unsupported node exposes no bond parameters even when tags are present',
+      () {
+        // No `bond_enabled` tag, but stray bond parameter tags are present.
+        final instance = MostroInstance.fromTags(
+          tagsWith({
+            'bond_apply_to': 'both',
+            'bond_amount_pct': '0.05',
+            'bond_payout_claim_window_days': '15',
+          }),
+        );
+
+        expect(instance.bondPolicy, BondPolicy.unsupported);
+        expectNoBondParameters(instance);
+      },
+    );
   });
 
   group('MostroInstance.fromTags — non-bond parsing is unaffected', () {

--- a/test/features/about/models/mostro_instance_test.dart
+++ b/test/features/about/models/mostro_instance_test.dart
@@ -89,6 +89,15 @@ void main() {
       ]);
       expect(instance.bondPolicy, BondPolicy.unsupported);
     });
+
+    test('duplicate bond_enabled tags resolve first-wins', () {
+      final instance = MostroInstance.fromTags(const [
+        ['d', 'npub_test'],
+        ['bond_enabled', 'false'],
+        ['bond_enabled', 'true'],
+      ]);
+      expect(instance.bondPolicy, BondPolicy.disabled);
+    });
   });
 
   group('MostroInstance.fromTags — bond parameters (enabled node)', () {
@@ -124,6 +133,20 @@ void main() {
       );
       expect(instance.bondApplyTo, isNull);
     });
+
+    test(
+      'bond_apply_to and bond_slash_on_waiting_timeout are case-insensitive',
+      () {
+        final instance = MostroInstance.fromTags(
+          enabledTagsWith({
+            'bond_apply_to': 'BOTH',
+            'bond_slash_on_waiting_timeout': 'TRUE',
+          }),
+        );
+        expect(instance.bondApplyTo, BondApplyTo.both);
+        expect(instance.bondSlashOnWaitingTimeout, isTrue);
+      },
+    );
 
     test('bond_slash_on_waiting_timeout parses true/false, else null', () {
       expect(
@@ -256,6 +279,17 @@ void main() {
         expectNoBondParameters(instance);
       },
     );
+
+    test('enabled node with no parameter tags exposes null parameters', () {
+      // An enabled policy may legitimately omit every parameter; consumers
+      // fall back to their own defaults.
+      final instance = MostroInstance.fromTags(
+        tagsWith({'bond_enabled': 'true'}),
+      );
+
+      expect(instance.bondPolicy, BondPolicy.enabled);
+      expectNoBondParameters(instance);
+    });
   });
 
   group('MostroInstance.fromTags — non-bond parsing is unaffected', () {

--- a/test/features/about/models/mostro_instance_test.dart
+++ b/test/features/about/models/mostro_instance_test.dart
@@ -1,0 +1,228 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro/features/about/models/mostro_instance.dart';
+
+/// Builds the tag list for a kind-38385 event, always including the `d`
+/// (pubkey) tag and merging any extra tags passed in.
+List<List<String>> tagsWith(Map<String, String> extra) {
+  return [
+    ['d', 'npub_test'],
+    for (final entry in extra.entries) [entry.key, entry.value],
+  ];
+}
+
+/// The full set of valid bond tags for an enabled node.
+const _enabledBondTags = {
+  'bond_enabled': 'true',
+  'bond_apply_to': 'both',
+  'bond_slash_on_waiting_timeout': 'true',
+  'bond_amount_pct': '0.05',
+  'bond_base_amount_sats': '1000',
+  'bond_slash_node_share_pct': '0.5',
+  'bond_payout_claim_window_days': '15',
+};
+
+void main() {
+  group('MostroInstance.fromTags — bond policy state', () {
+    test('unsupported when bond_enabled tag is absent', () {
+      final instance = MostroInstance.fromTags(tagsWith({}));
+      expect(instance.bondPolicy, BondPolicy.unsupported);
+    });
+
+    test('disabled when bond_enabled="false"', () {
+      final instance =
+          MostroInstance.fromTags(tagsWith({'bond_enabled': 'false'}));
+      expect(instance.bondPolicy, BondPolicy.disabled);
+    });
+
+    test('enabled when bond_enabled="true"', () {
+      final instance =
+          MostroInstance.fromTags(tagsWith({'bond_enabled': 'true'}));
+      expect(instance.bondPolicy, BondPolicy.enabled);
+    });
+
+    test('bond_enabled is case-insensitive', () {
+      expect(
+        MostroInstance.fromTags(tagsWith({'bond_enabled': 'TRUE'})).bondPolicy,
+        BondPolicy.enabled,
+      );
+      expect(
+        MostroInstance.fromTags(tagsWith({'bond_enabled': 'False'})).bondPolicy,
+        BondPolicy.disabled,
+      );
+    });
+
+    test('empty bond_enabled="" is treated as missing (unsupported)', () {
+      final instance =
+          MostroInstance.fromTags(tagsWith({'bond_enabled': ''}));
+      expect(instance.bondPolicy, BondPolicy.unsupported);
+    });
+
+    test('whitespace-only bond_enabled is treated as missing (unsupported)',
+        () {
+      final instance =
+          MostroInstance.fromTags(tagsWith({'bond_enabled': '   '}));
+      expect(instance.bondPolicy, BondPolicy.unsupported);
+    });
+
+    test('malformed bond_enabled falls back to unsupported', () {
+      final instance =
+          MostroInstance.fromTags(tagsWith({'bond_enabled': 'yes'}));
+      expect(instance.bondPolicy, BondPolicy.unsupported);
+    });
+
+    test('a value-less bond_enabled tag is treated as missing', () {
+      // Tag array with only the name and no value.
+      final instance = MostroInstance.fromTags(const [
+        ['d', 'npub_test'],
+        ['bond_enabled'],
+      ]);
+      expect(instance.bondPolicy, BondPolicy.unsupported);
+    });
+  });
+
+  group('MostroInstance.fromTags — bond parameters (enabled node)', () {
+    test('parses every bond parameter', () {
+      final instance = MostroInstance.fromTags(tagsWith(_enabledBondTags));
+
+      expect(instance.bondPolicy, BondPolicy.enabled);
+      expect(instance.bondApplyTo, BondApplyTo.both);
+      expect(instance.bondSlashOnWaitingTimeout, isTrue);
+      expect(instance.bondAmountPct, 0.05);
+      expect(instance.bondBaseAmountSats, 1000);
+      expect(instance.bondSlashNodeSharePct, 0.5);
+      expect(instance.bondPayoutClaimWindowDays, 15);
+    });
+
+    test('bond_apply_to parses take / make / both', () {
+      for (final entry in {
+        'take': BondApplyTo.take,
+        'make': BondApplyTo.make,
+        'both': BondApplyTo.both,
+      }.entries) {
+        final instance =
+            MostroInstance.fromTags(tagsWith({'bond_apply_to': entry.key}));
+        expect(instance.bondApplyTo, entry.value);
+      }
+    });
+
+    test('invalid bond_apply_to yields null', () {
+      final instance =
+          MostroInstance.fromTags(tagsWith({'bond_apply_to': 'sometimes'}));
+      expect(instance.bondApplyTo, isNull);
+    });
+
+    test('bond_slash_on_waiting_timeout parses true/false, else null', () {
+      expect(
+        MostroInstance.fromTags(
+                tagsWith({'bond_slash_on_waiting_timeout': 'true'}))
+            .bondSlashOnWaitingTimeout,
+        isTrue,
+      );
+      expect(
+        MostroInstance.fromTags(
+                tagsWith({'bond_slash_on_waiting_timeout': 'false'}))
+            .bondSlashOnWaitingTimeout,
+        isFalse,
+      );
+      expect(
+        MostroInstance.fromTags(
+                tagsWith({'bond_slash_on_waiting_timeout': 'maybe'}))
+            .bondSlashOnWaitingTimeout,
+        isNull,
+      );
+    });
+  });
+
+  group('MostroInstance.fromTags — bond parameter validation', () {
+    test('bond_amount_pct out of [0.0, 1.0] yields null', () {
+      expect(
+        MostroInstance.fromTags(tagsWith({'bond_amount_pct': '1.5'}))
+            .bondAmountPct,
+        isNull,
+      );
+      expect(
+        MostroInstance.fromTags(tagsWith({'bond_amount_pct': '-0.1'}))
+            .bondAmountPct,
+        isNull,
+      );
+      expect(
+        MostroInstance.fromTags(tagsWith({'bond_amount_pct': 'abc'}))
+            .bondAmountPct,
+        isNull,
+      );
+    });
+
+    test('bond_amount_pct accepts the [0.0, 1.0] boundaries', () {
+      expect(
+        MostroInstance.fromTags(tagsWith({'bond_amount_pct': '0.0'}))
+            .bondAmountPct,
+        0.0,
+      );
+      expect(
+        MostroInstance.fromTags(tagsWith({'bond_amount_pct': '1.0'}))
+            .bondAmountPct,
+        1.0,
+      );
+    });
+
+    test('negative bond_base_amount_sats yields null', () {
+      expect(
+        MostroInstance.fromTags(tagsWith({'bond_base_amount_sats': '-1'}))
+            .bondBaseAmountSats,
+        isNull,
+      );
+      expect(
+        MostroInstance.fromTags(tagsWith({'bond_base_amount_sats': '0'}))
+            .bondBaseAmountSats,
+        0,
+      );
+    });
+
+    test('bond_slash_node_share_pct out of [0.0, 1.0] yields null', () {
+      expect(
+        MostroInstance.fromTags(tagsWith({'bond_slash_node_share_pct': '2.0'}))
+            .bondSlashNodeSharePct,
+        isNull,
+      );
+    });
+
+    test('non-positive bond_payout_claim_window_days yields null', () {
+      expect(
+        MostroInstance.fromTags(
+                tagsWith({'bond_payout_claim_window_days': '0'}))
+            .bondPayoutClaimWindowDays,
+        isNull,
+      );
+      expect(
+        MostroInstance.fromTags(
+                tagsWith({'bond_payout_claim_window_days': '-5'}))
+            .bondPayoutClaimWindowDays,
+        isNull,
+      );
+    });
+  });
+
+  group('MostroInstance.fromTags — non-bond parsing is unaffected', () {
+    test('existing tags still parse and bond fields default to null', () {
+      final instance = MostroInstance.fromTags(const [
+        ['d', 'npub_test'],
+        ['mostro_version', '0.13.1'],
+        ['max_order_amount', '1000000'],
+        ['fee', '0.006'],
+      ]);
+
+      expect(instance.pubKey, 'npub_test');
+      expect(instance.mostroVersion, '0.13.1');
+      expect(instance.maxOrderAmount, 1000000);
+      expect(instance.fee, 0.006);
+
+      expect(instance.bondPolicy, BondPolicy.unsupported);
+      expect(instance.bondApplyTo, isNull);
+      expect(instance.bondSlashOnWaitingTimeout, isNull);
+      expect(instance.bondAmountPct, isNull);
+      expect(instance.bondBaseAmountSats, isNull);
+      expect(instance.bondSlashNodeSharePct, isNull);
+      expect(instance.bondPayoutClaimWindowDays, isNull);
+    });
+  });
+}

--- a/test/features/about/models/mostro_instance_test.dart
+++ b/test/features/about/models/mostro_instance_test.dart
@@ -3,18 +3,18 @@ import 'package:mostro/features/about/models/mostro_instance.dart';
 
 /// Builds the tag list for a kind-38385 event, always including the `d`
 /// (pubkey) tag and merging any extra tags passed in.
-List<List<String>> tagsWith(Map<String, String> extra) {
+List<List<String>> _tagsWith(Map<String, String> extra) {
   return [
     ['d', 'npub_test'],
     for (final entry in extra.entries) [entry.key, entry.value],
   ];
 }
 
-/// Like [tagsWith] but always advertises an enabled bond policy, so bond
+/// Like [_tagsWith] but always advertises an enabled bond policy, so bond
 /// parameter parsing/validation can be exercised — the six parameters are gated
 /// on `bondPolicy == enabled`.
-List<List<String>> enabledTagsWith(Map<String, String> extra) {
-  return tagsWith({'bond_enabled': 'true', ...extra});
+List<List<String>> _enabledTagsWith(Map<String, String> extra) {
+  return _tagsWith({'bond_enabled': 'true', ...extra});
 }
 
 /// The full set of valid bond tags for an enabled node.
@@ -31,37 +31,39 @@ const _enabledBondTags = {
 void main() {
   group('MostroInstance.fromTags — bond policy state', () {
     test('unsupported when bond_enabled tag is absent', () {
-      final instance = MostroInstance.fromTags(tagsWith({}));
+      final instance = MostroInstance.fromTags(_tagsWith({}));
       expect(instance.bondPolicy, BondPolicy.unsupported);
     });
 
     test('disabled when bond_enabled="false"', () {
       final instance = MostroInstance.fromTags(
-        tagsWith({'bond_enabled': 'false'}),
+        _tagsWith({'bond_enabled': 'false'}),
       );
       expect(instance.bondPolicy, BondPolicy.disabled);
     });
 
     test('enabled when bond_enabled="true"', () {
       final instance = MostroInstance.fromTags(
-        tagsWith({'bond_enabled': 'true'}),
+        _tagsWith({'bond_enabled': 'true'}),
       );
       expect(instance.bondPolicy, BondPolicy.enabled);
     });
 
     test('bond_enabled is case-insensitive', () {
       expect(
-        MostroInstance.fromTags(tagsWith({'bond_enabled': 'TRUE'})).bondPolicy,
+        MostroInstance.fromTags(_tagsWith({'bond_enabled': 'TRUE'})).bondPolicy,
         BondPolicy.enabled,
       );
       expect(
-        MostroInstance.fromTags(tagsWith({'bond_enabled': 'False'})).bondPolicy,
+        MostroInstance.fromTags(
+          _tagsWith({'bond_enabled': 'False'}),
+        ).bondPolicy,
         BondPolicy.disabled,
       );
     });
 
     test('empty bond_enabled="" is treated as missing (unsupported)', () {
-      final instance = MostroInstance.fromTags(tagsWith({'bond_enabled': ''}));
+      final instance = MostroInstance.fromTags(_tagsWith({'bond_enabled': ''}));
       expect(instance.bondPolicy, BondPolicy.unsupported);
     });
 
@@ -69,7 +71,7 @@ void main() {
       'whitespace-only bond_enabled is treated as missing (unsupported)',
       () {
         final instance = MostroInstance.fromTags(
-          tagsWith({'bond_enabled': '   '}),
+          _tagsWith({'bond_enabled': '   '}),
         );
         expect(instance.bondPolicy, BondPolicy.unsupported);
       },
@@ -77,7 +79,7 @@ void main() {
 
     test('malformed bond_enabled falls back to unsupported', () {
       final instance = MostroInstance.fromTags(
-        tagsWith({'bond_enabled': 'yes'}),
+        _tagsWith({'bond_enabled': 'yes'}),
       );
       expect(instance.bondPolicy, BondPolicy.unsupported);
     });
@@ -102,7 +104,7 @@ void main() {
 
   group('MostroInstance.fromTags — bond parameters (enabled node)', () {
     test('parses every bond parameter', () {
-      final instance = MostroInstance.fromTags(tagsWith(_enabledBondTags));
+      final instance = MostroInstance.fromTags(_tagsWith(_enabledBondTags));
 
       expect(instance.bondPolicy, BondPolicy.enabled);
       expect(instance.bondApplyTo, BondApplyTo.both);
@@ -121,7 +123,7 @@ void main() {
             'both': BondApplyTo.both,
           }.entries) {
         final instance = MostroInstance.fromTags(
-          enabledTagsWith({'bond_apply_to': entry.key}),
+          _enabledTagsWith({'bond_apply_to': entry.key}),
         );
         expect(instance.bondApplyTo, entry.value);
       }
@@ -129,7 +131,7 @@ void main() {
 
     test('invalid bond_apply_to yields null', () {
       final instance = MostroInstance.fromTags(
-        enabledTagsWith({'bond_apply_to': 'sometimes'}),
+        _enabledTagsWith({'bond_apply_to': 'sometimes'}),
       );
       expect(instance.bondApplyTo, isNull);
     });
@@ -138,7 +140,7 @@ void main() {
       'bond_apply_to and bond_slash_on_waiting_timeout are case-insensitive',
       () {
         final instance = MostroInstance.fromTags(
-          enabledTagsWith({
+          _enabledTagsWith({
             'bond_apply_to': 'BOTH',
             'bond_slash_on_waiting_timeout': 'TRUE',
           }),
@@ -151,19 +153,19 @@ void main() {
     test('bond_slash_on_waiting_timeout parses true/false, else null', () {
       expect(
         MostroInstance.fromTags(
-          enabledTagsWith({'bond_slash_on_waiting_timeout': 'true'}),
+          _enabledTagsWith({'bond_slash_on_waiting_timeout': 'true'}),
         ).bondSlashOnWaitingTimeout,
         isTrue,
       );
       expect(
         MostroInstance.fromTags(
-          enabledTagsWith({'bond_slash_on_waiting_timeout': 'false'}),
+          _enabledTagsWith({'bond_slash_on_waiting_timeout': 'false'}),
         ).bondSlashOnWaitingTimeout,
         isFalse,
       );
       expect(
         MostroInstance.fromTags(
-          enabledTagsWith({'bond_slash_on_waiting_timeout': 'maybe'}),
+          _enabledTagsWith({'bond_slash_on_waiting_timeout': 'maybe'}),
         ).bondSlashOnWaitingTimeout,
         isNull,
       );
@@ -175,7 +177,7 @@ void main() {
       for (final bogus in ['-0.1', 'NaN', 'Infinity', '-Infinity', 'abc']) {
         expect(
           MostroInstance.fromTags(
-            enabledTagsWith({'bond_amount_pct': bogus}),
+            _enabledTagsWith({'bond_amount_pct': bogus}),
           ).bondAmountPct,
           isNull,
           reason: 'rejects "$bogus"',
@@ -190,7 +192,7 @@ void main() {
         for (final entry in {'0.0': 0.0, '1.0': 1.0, '1.5': 1.5}.entries) {
           expect(
             MostroInstance.fromTags(
-              enabledTagsWith({'bond_amount_pct': entry.key}),
+              _enabledTagsWith({'bond_amount_pct': entry.key}),
             ).bondAmountPct,
             entry.value,
           );
@@ -201,13 +203,13 @@ void main() {
     test('negative bond_base_amount_sats yields null', () {
       expect(
         MostroInstance.fromTags(
-          enabledTagsWith({'bond_base_amount_sats': '-1'}),
+          _enabledTagsWith({'bond_base_amount_sats': '-1'}),
         ).bondBaseAmountSats,
         isNull,
       );
       expect(
         MostroInstance.fromTags(
-          enabledTagsWith({'bond_base_amount_sats': '0'}),
+          _enabledTagsWith({'bond_base_amount_sats': '0'}),
         ).bondBaseAmountSats,
         0,
       );
@@ -217,7 +219,7 @@ void main() {
       for (final bogus in ['2.0', '-0.5', 'NaN', 'Infinity']) {
         expect(
           MostroInstance.fromTags(
-            enabledTagsWith({'bond_slash_node_share_pct': bogus}),
+            _enabledTagsWith({'bond_slash_node_share_pct': bogus}),
           ).bondSlashNodeSharePct,
           isNull,
           reason: 'rejects "$bogus"',
@@ -228,13 +230,13 @@ void main() {
     test('non-positive bond_payout_claim_window_days yields null', () {
       expect(
         MostroInstance.fromTags(
-          enabledTagsWith({'bond_payout_claim_window_days': '0'}),
+          _enabledTagsWith({'bond_payout_claim_window_days': '0'}),
         ).bondPayoutClaimWindowDays,
         isNull,
       );
       expect(
         MostroInstance.fromTags(
-          enabledTagsWith({'bond_payout_claim_window_days': '-5'}),
+          _enabledTagsWith({'bond_payout_claim_window_days': '-5'}),
         ).bondPayoutClaimWindowDays,
         isNull,
       );
@@ -255,7 +257,7 @@ void main() {
       'disabled node exposes no bond parameters even when tags are present',
       () {
         final instance = MostroInstance.fromTags(
-          tagsWith({..._enabledBondTags, 'bond_enabled': 'false'}),
+          _tagsWith({..._enabledBondTags, 'bond_enabled': 'false'}),
         );
 
         expect(instance.bondPolicy, BondPolicy.disabled);
@@ -268,7 +270,7 @@ void main() {
       () {
         // No `bond_enabled` tag, but stray bond parameter tags are present.
         final instance = MostroInstance.fromTags(
-          tagsWith({
+          _tagsWith({
             'bond_apply_to': 'both',
             'bond_amount_pct': '0.05',
             'bond_payout_claim_window_days': '15',
@@ -284,7 +286,7 @@ void main() {
       // An enabled policy may legitimately omit every parameter; consumers
       // fall back to their own defaults.
       final instance = MostroInstance.fromTags(
-        tagsWith({'bond_enabled': 'true'}),
+        _tagsWith({'bond_enabled': 'true'}),
       );
 
       expect(instance.bondPolicy, BondPolicy.enabled);


### PR DESCRIPTION
Closes #190. Part of the anti-abuse bond epic #145.

## What

Parses and validates the anti-abuse bond policy advertised by a Mostro node in its kind-38385 info event, exposing it on `MostroInstance` for the rest of the app to consume. Parsing only — no UI (the About-screen display is tracked in #196).

## Changes

- Add a three-state `BondPolicy` enum (`unsupported` / `disabled` / `enabled`) so the app can tell "feature off" apart from a legacy daemon, plus a `BondApplyTo` enum (`take` / `make` / `both`).
- Add seven bond fields to `MostroInstance` (`bondPolicy` defaults to `unsupported`; the six parameters are nullable and meaningful only when the policy is `enabled`).
- Parse the bond tags in `MostroInstance.fromTags` with defensive sanitization:
  - Empty or whitespace-only `bond_enabled=""` is treated as missing (`unsupported`), not `disabled`, preserving the three-state semantics.
  - Malformed `bond_enabled` values fall back to `unsupported`.
  - Range validation: `bond_amount_pct` and `bond_slash_node_share_pct` in `[0.0, 1.0]`, `bond_base_amount_sats` >= 0, `bond_payout_claim_window_days` > 0; out-of-range or unparseable values yield `null`.
- The bond amount is never computed client-side for charging — the daemon always sends the exact bolt11; the pct/base fields exist only for up-front UI warnings.

## Tests

- 18 unit tests covering the three policy states, case-insensitive parsing, empty / whitespace / malformed / value-less tags, per-tag parsing, and range validation.
- `flutter analyze` clean; existing non-bond parsing is unaffected.

## Parity reference

Client-side behavior mirrors v1 (`MostroP2P/mobile` `docs/architecture/ANTI_ABUSE_BOND.md` section 2).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Mostro instance “bond” configuration.
  * Bonds now support three states: enabled, disabled, or unsupported, with an application scope (take/make/both) and configurable parameters.
* **Bug Fixes**
  * Improved tag parsing robustness: whitespace and casing are handled, malformed values are ignored, and numeric inputs are validated (including range limits where applicable).
  * Bond parameters are only populated when the bond policy is enabled.
* **Tests**
  * Added coverage for bond policy resolution, parameter parsing/validation, and ensuring existing non-bond tag behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->