### PR TITLE
feat(#142): restore sessions & trades from mnemonic  handshake

### DIFF
--- a/rust/src/api/identity.rs
+++ b/rust/src/api/identity.rs
@@ -164,8 +164,17 @@ pub async fn load_identity_from_mnemonic(
 /// When `recover = true`, the daemon recovery flow is triggered (Phase 7).
 /// Currently this validates and loads the mnemonic; recovery contacts are
 /// initiated separately via the daemon API.
-pub async fn import_from_mnemonic(words: Vec<String>, _recover: bool) -> Result<IdentityInfo> {
-    load_identity_from_mnemonic(words, 0, false, None).await
+pub async fn import_from_mnemonic(words: Vec<String>, recover: bool) -> Result<IdentityInfo> {
+    let info = load_identity_from_mnemonic(words, 0, false, None).await?;
+    if recover {
+        // Recovery is only possible in Reputation mode; Full-Privacy trades
+        // are anonymous by design and cannot be replayed by the daemon.
+        if info.privacy_mode {
+            bail!("PrivacyModeRecoveryUnavailable");
+        }
+        crate::api::orders::restore_session().await?;
+    }
+    Ok(info)
 }
 
 /// Import identity from an nsec (bech32-encoded Nostr secret key).

--- a/rust/src/api/identity.rs
+++ b/rust/src/api/identity.rs
@@ -165,11 +165,17 @@ pub async fn load_identity_from_mnemonic(
 /// Currently this validates and loads the mnemonic; recovery contacts are
 /// initiated separately via the daemon API.
 pub async fn import_from_mnemonic(words: Vec<String>, recover: bool) -> Result<IdentityInfo> {
-    let info = load_identity_from_mnemonic(words, 0, false, None).await?;
+    // Source the authoritative privacy mode BEFORE loading, so the imported
+    // identity reflects the current session's mode and the recovery guard is
+    // enforced consistently (a hardcoded `false` here left info.privacy_mode
+    // always false, so the guard below could never fire — while
+    // restore_session() reads the real flag from reputation::get_privacy_mode()).
+    let privacy_mode = crate::api::reputation::get_privacy_mode();
+    let info = load_identity_from_mnemonic(words, 0, privacy_mode, None).await?;
     if recover {
         // Recovery is only possible in Reputation mode; Full-Privacy trades
         // are anonymous by design and cannot be replayed by the daemon.
-        if info.privacy_mode {
+        if privacy_mode {
             bail!("PrivacyModeRecoveryUnavailable");
         }
         crate::api::orders::restore_session().await?;

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -53,6 +53,10 @@ enum DaemonReply {
     Acknowledged,
     /// Daemon rejected the request with a CantDo reason.
     Rejected { reason: String, message: String },
+    /// Daemon replied to a RestoreSession with the user's active trades and
+    /// disputes. Correlated by identity pubkey (RestoreSession carries no
+    /// request_id) — see take_matching_restore.
+    Restored(mostro_core::message::RestoreSessionInfo),
 }
 
 /// What kind of outgoing request a pending record tracks.
@@ -72,6 +76,10 @@ enum PendingRequestKind {
     Take,
     /// A buyer's add-invoice awaiting the daemon's acknowledgement.
     AddInvoice,
+    /// A session-restore awaiting the daemon's RestoreData reply. Correlated
+    /// by identity pubkey, not request_id (the RestoreSession message carries
+    /// no request_id — see mostro-core Message::new_restore).
+    Restore,
 }
 
 /// Everything one outgoing daemon request needs tracked until its reply is
@@ -124,6 +132,18 @@ fn request_id_matches(expected: u64, got: Option<u64>) -> bool {
 /// in place: relays can replay historical events, and a stale reply must not
 /// confirm, reject, or reconcile a live request — the genuine reply (carrying
 /// the nonce) arrives later and finds the record.
+/// Remove and return the pending RESTORE request for `pubkey_hex`. Unlike
+/// `take_matching_request`, there is no request_id gate: the RestoreSession
+/// message carries no request_id, so the daemon's RestoreData reply is
+/// correlated purely by the identity pubkey it is addressed to.
+fn take_matching_restore(pubkey_hex: &str) -> Option<PendingRequest> {
+    let mut map = pending_requests().lock().ok()?;
+    match map.get(pubkey_hex) {
+        Some(p) if matches!(p.kind, PendingRequestKind::Restore) => map.remove(pubkey_hex),
+        _ => None,
+    }
+}
+
 fn take_matching_request(trade_pubkey_hex: &str, got: Option<u64>) -> Option<PendingRequest> {
     let mut map = pending_requests().lock().ok()?;
     match map.get(trade_pubkey_hex) {
@@ -3268,4 +3288,47 @@ mod tests {
         .await;
         // If we reach here without panicking the test passes.
     }
+}
+
+/// Send a `RestoreSession` request to the active Mostro daemon and rebuild the
+/// user's active trades/disputes from the reply.
+///
+/// Correlation differs from order actions: the daemon replies with
+/// `Payload::RestoreData(RestoreSessionInfo)` addressed to the IDENTITY pubkey
+/// (restore_session.rs:93, keyed by trade_pubkey — NOT a request_id). The
+/// RestoreSession message itself carries no request_id.
+///
+/// STATUS: send half implemented; await + reconstruction pending a design
+/// decision (reuse pending-request machinery adapted for pubkey correlation,
+/// vs. a separate restore-await path) — see issue #142.
+pub async fn restore_session() -> Result<()> {
+    // Identity keys — restore is looked up by master/identity key, not a
+    // per-trade key (matches the daemon's restore_session handler).
+    let identity_keys = crate::api::identity::get_active_keys().await?;
+    let mostro_pubkey = nostr_sdk::PublicKey::from_hex(&active_mostro_pubkey())?;
+    let transport_keys =
+        crate::api::identity::get_transport_identity_keys(&identity_keys).await?;
+
+    // Build the RestoreSession event (payload None, from identity key).
+    let event_json =
+        actions::restore_session(&transport_keys, &mostro_pubkey).await?;
+
+    // Subscribe on the identity pubkey so the daemon's RestoreData reply is
+    // received (mirrors create_order's subscribe-before-publish ordering).
+    subscribe_gift_wraps(identity_keys.public_key(), 0).await;
+
+    if let Err(e) = publish_event_json(&event_json).await {
+        return Err(e);
+    }
+    crate::api::logging::blog_info(
+        "restore",
+        "RestoreSession published — awaiting daemon RestoreData".to_string(),
+    );
+
+    // --- UNVERIFIED / UNDESIGNED: await the RestoreData reply -----------------
+    // The reply arrives asynchronously through dispatch_mostro_message, keyed
+    // by identity pubkey. This needs either (a) a pubkey-correlated pending
+    // entry + a new Payload::RestoreData dispatcher arm, or (b) a separate
+    // restore-await channel. Deferred pending grunch's architecture call (#142).
+    todo!("await Payload::RestoreData reply + reconstruct trades — see #142");
 }

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -3386,3 +3386,49 @@ pub async fn restore_session() -> Result<mostro_core::message::RestoreSessionInf
         _ => Err(anyhow::anyhow!("NoDaemonResponse")),
     }
 }
+
+#[cfg(test)]
+mod restore_e2e_tests {
+    //! E2E smoke test for the RestoreSession handshake (#142).
+    //! Requires a live regtest stack: mostrod + relay on ws://localhost:7000.
+    //! Run with:  cargo test --lib restore_session_roundtrip -- --ignored --nocapture
+    //! Ignored by default so it never runs in CI without the stack.
+    use super::*;
+
+    #[tokio::test]
+    #[ignore = "requires live regtest daemon + relay on ws://localhost:7000"]
+    async fn restore_session_roundtrip() {
+        // Point ONLY at the local regtest relay.
+        crate::api::nostr::initialize(Some(vec!["ws://localhost:7000".to_string()]))
+            .await
+            .expect("relay pool init");
+
+        // Regtest daemon pubkey (from mostrod startup logs).
+        crate::config::set_active_mostro_pubkey(Some(
+            "bae71ea2566771ed45b1d267dc0c0753028fe960a7bc4aeee08a44da0cb91520".to_string(),
+        ));
+
+        // Fresh in-memory identity (no keyring needed — Rust never persists it).
+        let id = crate::api::identity::create_identity().await.expect("create identity");
+        println!("[test] created identity pubkey={}", id.public_key);
+
+        // Let the relay connection settle.
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+
+        // Fire the handshake.
+        println!("[test] calling restore_session()...");
+        let result = restore_session().await;
+        println!("[test] restore_session result: {:?}", result.is_ok());
+
+        match result {
+            Ok(info) => {
+                println!(
+                    "[test] ✓ round-trip OK — {} orders, {} disputes",
+                    info.restore_orders.len(),
+                    info.restore_disputes.len()
+                );
+            }
+            Err(e) => panic!("[test] restore_session failed: {e}"),
+        }
+    }
+}

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -1770,6 +1770,36 @@ async fn dispatch_mostro_message(
                 log::warn!("[orders] gift-wrap NewOrder has no order id");
             }
         }
+        Action::RestoreSession => {
+            // Daemon's restore reply (mostro send_restore_session_response ->
+            // Message::new_restore(RestoreData), addressed to the sending trade
+            // key). Correlated by trade pubkey only — RestoreSession carries no
+            // request_id — so take_matching_restore skips the nonce gate.
+            match &kind.payload {
+                Some(mostro_core::message::Payload::RestoreData(info)) => {
+                    if let Some(pending) = take_matching_restore(trade_pubkey_hex) {
+                        if let Some(tx) = pending.tx {
+                            let _ = tx.send(DaemonReply::Restored(info.clone()));
+                            crate::api::logging::blog_info("gift-wrap", format!(
+                                "RestoreData: notified waiting restore_session ({} orders, {} disputes)",
+                                info.restore_orders.len(),
+                                info.restore_disputes.len()
+                            ));
+                        }
+                    } else {
+                        crate::api::logging::blog_info("gift-wrap", format!(
+                            "RestoreData with no waiting caller for trade={}",
+                            &trade_pubkey_hex[..8]
+                        ));
+                    }
+                }
+                _ => {
+                    log::warn!(
+                        "[orders] RestoreSession reply payload is not RestoreData for trade={trade_pubkey_hex}"
+                    );
+                }
+            }
+        }
         Action::Canceled => {
             log::info!("[orders] gift-wrap Canceled for trade={trade_pubkey_hex}");
             if let Some(order_id) = &kind.id {
@@ -3290,45 +3320,68 @@ mod tests {
     }
 }
 
-/// Send a `RestoreSession` request to the active Mostro daemon and rebuild the
-/// user's active trades/disputes from the reply.
+/// Send a `RestoreSession` to the active daemon and return the user's active
+/// trades/disputes. Mirrors create_order's send/await, minus the order payload.
 ///
-/// Correlation differs from order actions: the daemon replies with
-/// `Payload::RestoreData(RestoreSessionInfo)` addressed to the IDENTITY pubkey
-/// (restore_session.rs:93, keyed by trade_pubkey — NOT a request_id). The
-/// RestoreSession message itself carries no request_id.
-///
-/// STATUS: send half implemented; await + reconstruction pending a design
-/// decision (reuse pending-request machinery adapted for pubkey correlation,
-/// vs. a separate restore-await path) — see issue #142.
-pub async fn restore_session() -> Result<()> {
-    // Identity keys — restore is looked up by master/identity key, not a
-    // per-trade key (matches the daemon's restore_session handler).
-    let identity_keys = crate::api::identity::get_active_keys().await?;
+/// Correlation: the request is sent from a fresh TRADE key (event.sender) while
+/// the Seal carries the IDENTITY key (event.identity). The daemon looks up
+/// trades by identity/master key and replies to the trade key
+/// (mostro restore_session.rs: master_key = event.identity, reply -> event.sender),
+/// so we subscribe on the trade key and correlate the reply by that pubkey.
+pub async fn restore_session() -> Result<mostro_core::message::RestoreSessionInfo> {
+    // Fresh trade key -> event.sender (daemon replies here).
+    let trade_key_info = crate::api::identity::derive_trade_key().await?;
+    let trade_index = trade_key_info.index;
+    let sender_keys = crate::api::identity::get_active_trade_keys(trade_index).await?;
+    let trade_pk_hex = sender_keys.public_key().to_hex();
+
     let mostro_pubkey = nostr_sdk::PublicKey::from_hex(&active_mostro_pubkey())?;
-    let transport_keys =
-        crate::api::identity::get_transport_identity_keys(&identity_keys).await?;
+    // Identity/transport keys sign the Seal -> event.identity (master key).
+    let identity_keys =
+        crate::api::identity::get_transport_identity_keys(&sender_keys).await?;
 
-    // Build the RestoreSession event (payload None, from identity key).
     let event_json =
-        actions::restore_session(&transport_keys, &mostro_pubkey).await?;
+        actions::restore_session(&identity_keys, &sender_keys, &mostro_pubkey).await?;
 
-    // Subscribe on the identity pubkey so the daemon's RestoreData reply is
-    // received (mirrors create_order's subscribe-before-publish ordering).
-    subscribe_gift_wraps(identity_keys.public_key(), 0).await;
+    // Register the pending-restore record BEFORE publishing so the reply can't
+    // race the map. Correlated by trade pubkey only (RestoreSession carries no
+    // request_id) -> take_matching_restore.
+    let (conf_tx, conf_rx) = tokio::sync::oneshot::channel::<DaemonReply>();
+    if let Ok(mut map) = pending_requests().lock() {
+        map.insert(
+            trade_pk_hex.clone(),
+            PendingRequest {
+                request_id: 0,
+                trade_index,
+                kind: PendingRequestKind::Restore,
+                tx: Some(conf_tx),
+            },
+        );
+    }
+
+    subscribe_gift_wraps(sender_keys.public_key(), trade_index).await;
 
     if let Err(e) = publish_event_json(&event_json).await {
+        remove_pending_request(&trade_pk_hex, 0);
         return Err(e);
     }
     crate::api::logging::blog_info(
         "restore",
-        "RestoreSession published — awaiting daemon RestoreData".to_string(),
+        format!("RestoreSession published trade_index={trade_index} — waiting for daemon"),
     );
 
-    // --- UNVERIFIED / UNDESIGNED: await the RestoreData reply -----------------
-    // The reply arrives asynchronously through dispatch_mostro_message, keyed
-    // by identity pubkey. This needs either (a) a pubkey-correlated pending
-    // entry + a new Payload::RestoreData dispatcher arm, or (b) a separate
-    // restore-await channel. Deferred pending grunch's architecture call (#142).
-    todo!("await Payload::RestoreData reply + reconstruct trades — see #142");
+    let confirmation = crate::rt::time::timeout(
+        std::time::Duration::from_secs(10),
+        conf_rx,
+    ).await;
+
+    if !matches!(confirmation, Ok(Ok(_))) {
+        detach_request_waiter(&trade_pk_hex, 0);
+    }
+
+    match confirmation {
+        Ok(Ok(DaemonReply::Restored(info))) => Ok(info),
+        Ok(Ok(_other)) => Err(anyhow::anyhow!("unexpected restore reply")),
+        _ => Err(anyhow::anyhow!("NoDaemonResponse")),
+    }
 }

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -3431,4 +3431,39 @@ mod restore_e2e_tests {
             Err(e) => panic!("[test] restore_session failed: {e}"),
         }
     }
+
+    #[tokio::test]
+    #[ignore = "requires live regtest daemon + relay on ws://localhost:7000"]
+    async fn trade_then_restore_recovers_order() {
+        crate::api::nostr::initialize(Some(vec!["ws://localhost:7000".to_string()]))
+            .await
+            .expect("relay pool init");
+        crate::config::set_active_mostro_pubkey(Some(
+            "bae71ea2566771ed45b1d267dc0c0753028fe960a7bc4aeee08a44da0cb91520".to_string(),
+        ));
+        let id = crate::api::identity::create_identity().await.expect("create identity");
+        println!("[test] identity A pubkey={}", id.public_key);
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        let params = crate::api::types::NewOrderParams {
+            kind: crate::api::types::OrderKind::Sell,
+            fiat_amount: Some(100.0),
+            fiat_amount_min: None,
+            fiat_amount_max: None,
+            fiat_code: "USD".to_string(),
+            payment_method: "cash".to_string(),
+            premium: 0.0,
+            amount_sats: None,
+        };
+        println!("[test] creating order...");
+        let order = create_order(params).await.expect("create_order (may need bond flow)");
+        println!("[test] order created id={}", order.id);
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        println!("[test] calling restore_session()...");
+        let info = restore_session().await.expect("restore round-trip");
+        println!("[test] restored {} orders", info.restore_orders.len());
+        for o in &info.restore_orders {
+            println!("[test]   order_id={} status={}", o.order_id, o.status);
+        }
+        assert!(!info.restore_orders.is_empty(), "restore should recover the created order");
+    }
 }

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -2609,6 +2609,14 @@ async fn ingest_order_event(event: &nostr_sdk::Event) {
                 info.kind,
                 info.status
             );
+            // Restore is_mine=true for recovered orders (#142): if the
+            // order_id was planted by restore_session's reconstruction, this
+            // order belongs to the user even though we can't fingerprint it
+            // (the restore reply carries no order data to fingerprint).
+            if !info.is_mine && get_trade_key_index(&info.id).await.is_some() {
+                info.is_mine = true;
+                log::info!("[orders] order {} recognised as mine via restore mapping", info.id);
+            }
             // Restore is_mine=true for maker orders on cold start by
             // comparing against the content fingerprint stored at creation time.
             if !info.is_mine {
@@ -3381,7 +3389,20 @@ pub async fn restore_session() -> Result<mostro_core::message::RestoreSessionInf
     }
 
     match confirmation {
-        Ok(Ok(DaemonReply::Restored(info))) => Ok(info),
+        Ok(Ok(DaemonReply::Restored(info))) => {
+            for ro in &info.restore_orders {
+                if let Ok(idx) = u32::try_from(ro.trade_index) {
+                    store_trade_key_index(&ro.order_id.to_string(), idx).await;
+                    crate::api::logging::blog_info("restore", format!(
+                        "recovered order {} (trade_index {}, status {}) — mapped for hydration",
+                        ro.order_id, idx, ro.status
+                    ));
+                } else {
+                    log::warn!("[restore] order {} has invalid trade_index {}", ro.order_id, ro.trade_index);
+                }
+            }
+            Ok(info)
+        }
         Ok(Ok(_other)) => Err(anyhow::anyhow!("unexpected restore reply")),
         _ => Err(anyhow::anyhow!("NoDaemonResponse")),
     }

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -1785,6 +1785,14 @@ async fn dispatch_mostro_message(
                                 info.restore_orders.len(),
                                 info.restore_disputes.len()
                             ));
+                        } else {
+                            // Post-timeout late reply: the caller already
+                            // returned NoDaemonResponse and detached its waiter.
+                            // Logged for parity with the NewOrder/take/add-invoice arms.
+                            crate::api::logging::blog_info("gift-wrap", format!(
+                                "RestoreData: late reply for timed-out restore on trade={}",
+                                &trade_pubkey_hex[..8]
+                            ));
                         }
                     } else {
                         crate::api::logging::blog_info("gift-wrap", format!(

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -3328,6 +3328,7 @@ mod tests {
 /// trades by identity/master key and replies to the trade key
 /// (mostro restore_session.rs: master_key = event.identity, reply -> event.sender),
 /// so we subscribe on the trade key and correlate the reply by that pubkey.
+#[flutter_rust_bridge::frb(ignore)]
 pub async fn restore_session() -> Result<mostro_core::message::RestoreSessionInfo> {
     // Fresh trade key -> event.sender (daemon replies here).
     let trade_key_info = crate::api::identity::derive_trade_key().await?;

--- a/rust/src/mostro/actions.rs
+++ b/rust/src/mostro/actions.rs
@@ -463,9 +463,10 @@ mod tests {
 /// Build a `RestoreSession` request (mostro-core `Message::new_restore`).
 ///
 /// Payload MUST be `None` — the daemon rejects any other payload
-/// (`MessageKind::verify`). Sent from the IDENTITY key, not a derived trade
-/// key: the daemon's restore_session handler replies to the requesting
-/// (identity) pubkey. Returns the NIP-59 Gift Wrap event JSON.
+/// (`MessageKind::verify`). The Seal is signed by the identity key (used by
+/// the daemon to look up the user's trades); the rumor is signed by a fresh
+/// trade key, and the daemon's restore reply is addressed to that trade key.
+/// Returns the NIP-59 Gift Wrap event JSON.
 pub async fn restore_session(
     identity_keys: &Keys,
     trade_keys: &Keys,

--- a/rust/src/mostro/actions.rs
+++ b/rust/src/mostro/actions.rs
@@ -459,3 +459,17 @@ mod tests {
         assert!(matches!(kind.payload, Some(Payload::Amount(100))));
     }
 }
+
+/// Build a `RestoreSession` request (mostro-core `Message::new_restore`).
+///
+/// Payload MUST be `None` — the daemon rejects any other payload
+/// (`MessageKind::verify`). Sent from the IDENTITY key, not a derived trade
+/// key: the daemon's restore_session handler replies to the requesting
+/// (identity) pubkey. Returns the NIP-59 Gift Wrap event JSON.
+pub async fn restore_session(
+    identity_keys: &Keys,
+    mostro_pubkey: &PublicKey,
+) -> Result<String> {
+    let msg = Message::new_restore(None);
+    wrap_message(identity_keys, identity_keys, mostro_pubkey, &msg).await
+}

--- a/rust/src/mostro/actions.rs
+++ b/rust/src/mostro/actions.rs
@@ -468,8 +468,12 @@ mod tests {
 /// (identity) pubkey. Returns the NIP-59 Gift Wrap event JSON.
 pub async fn restore_session(
     identity_keys: &Keys,
+    trade_keys: &Keys,
     mostro_pubkey: &PublicKey,
 ) -> Result<String> {
+    // identity_keys sign the Seal (-> event.identity = master key, used by the
+    // daemon to look up the user's trades); trade_keys sign the rumor
+    // (-> event.sender, the key the daemon replies to). Mirrors new_order.
     let msg = Message::new_restore(None);
-    wrap_message(identity_keys, identity_keys, mostro_pubkey, &msg).await
+    wrap_message(identity_keys, trade_keys, mostro_pubkey, &msg).await
 }


### PR DESCRIPTION
## What this does

Implements the client side of **restore sessions & trades from mnemonic** (#142): after a reinstall, entering the 12-word phrase restores not just the identity but the user's active trades.

Before this work, importing a mnemonic restored only the identity keys the `recover` flag was silently ignored (`_recover`), so no `RestoreSession` was ever sent and trades were lost. This PR wires the full `RestoreSession` handshake, proves it end-to-end against a regtest daemon, and lays the reconstruction foundation.

> **Status: not merge-ready.** The handshake and trade recovery are complete and E2E-proven. The final hop surfacing recovered orders in **My Trades**  needs one architecture decision (see *Open design question* below). Marking as draft.

## How it works

Restore correlates differently from every other action, and this was the core of the work:

- The app sends `RestoreSession` **from a freshly-derived trade key**. The gift-wrap Seal is signed with the **identity key**, so on the daemon side `event.identity` = master key and `event.sender` = trade key.
- The daemon looks up the user's trades **by master key** (`restore_session.rs`: `master_key = event.identity`) and replies with `Payload::RestoreData` **addressed to the trade key** (`event.sender`).
- `RestoreSession` carries **no `request_id`**, so the reply is correlated **purely by pubkey** a dedicated `take_matching_restore(pubkey)` that skips the nonce gate the order path uses.
- The dispatcher gains an `Action::RestoreSession` arm that decodes `RestoreData`, resolves the waiting caller, and returns the `RestoreSessionInfo`.

This mirrors `create_order`'s send/await pattern wholesale, minus the order payload and request_id.

## Changes

- `identity.rs` `import_from_mnemonic` now honors `recover` (was a `_recover` stub) and calls `restore_session()`.
- `mostro/actions.rs` `restore_session` builder (`Message::new_restore(None)`), wraps with identity key in the Seal + derived trade key as sender.
- `api/orders.rs`
  - `PendingRequestKind::Restore` + `DaemonReply::Restored(RestoreSessionInfo)`
  - `take_matching_restore(pubkey)` pubkey-only correlation (no request_id)
  - `restore_session()` derive trade key, send, subscribe, register pending, await reply
  - `Action::RestoreSession` dispatcher arm
  - `#[flutter_rust_bridge::frb(ignore)]` on `restore_session()` (internal returns a mostro-core type FRB can't bridge; called by `import_from_mnemonic`, never from Dart)
  - **Reconstruction foundation:** `restore_session` plants `order_id -> trade_index` mappings for recovered orders; `ingest_order_event` marks `is_mine = true` when an `order_id` is known via restore.

## Testing E2E proven against a regtest daemon

Two integration tests (`#[ignore]`, require a live regtest stack on `ws://localhost:7000`), run individually:

```bash
cargo test --lib restore_session_roundtrip     -- --ignored --nocapture
cargo test --lib trade_then_restore_recovers_order -- --ignored --nocapture
```

1. **`restore_session_roundtrip`** bare handshake round-trips: app publishes `RestoreSession` (kind-14) -> daemon receives and replies `RestoreData` to the trade key -> dispatcher resolves the waiter. Returns `Ok` with an empty result for a fresh identity (0 trades).

2. **`trade_then_restore_recovers_order`** real recovery: create a Sell order under identity A (daemon-confirmed), then restore as A. The daemon looks up by master key and returns the order **created under a different trade index**, proving master-key correlation on the wire:

   ```
   RestoreData(RestoreSessionInfo { restore_orders: [
       RestoredOrdersInfo { order_id: <uuid>, trade_index: 1, status: "pending" }
   ], restore_disputes: [] })
   ```

Existing suite: `107 passed; 0 failed` (`cargo test --lib`). `cargo build` clean.

*Shaking this out end-to-end also surfaced two regtest-env issues unrelated to the code my daemon was on `transport = "gift-wrap"` (v1, kind-1059) instead of `nip44` (v2, kind-14), and the `transport` key was under `[nostr]` instead of `[mostro]` in `settings.toml`. Both fixed locally; noting in case it helps others' v2 setup.*

## Open design question (the one thing I need a call on)

Recovered orders don't yet appear in **My Trades**. `RestoredOrdersInfo` carries only `{order_id, trade_index, status}`, but `list_trades()` reads full `TradeInfo` records from the **DB** which need the full order data plus `role`/`current_step`/counterparty. The order-book `is_mine` flag (fed by Kind-38383) is a **separate store** from that DB.

So the final reconstruction step needs a direction:

- **(A)** Client hydrates the full order from its Kind-38383 event and **synthesizes a `TradeInfo`** (deriving `role`/`current_step` from `status`), then writes it to the trades DB.
- **(B)** `RestoreData` / `RestoredOrdersInfo` carries **richer order data** so the client can build a complete `TradeInfo` directly (cross-repo change to mostro-core + daemon).

I've committed the mapping + `is_mine`-by-order-id foundation; I'll build the `TradeInfo` synthesis once the approach is confirmed, to avoid guessing the intended data model.

## Notes for review

- The two E2E tests are `#[ignore]`d (won't run in CI) and one hardcodes my regtest daemon pubkey. **Happy to make them env-configurable or drop them from the PR whichever you prefer.**
- No Dart/UI changes here; the restore UI wiring (the 12-word screens) comes after reconstruction lands.

Refs #142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session recovery when importing an identity with recovery enabled.
  * Added support for restoring previously active orders and their trade associations.
  * Added restore-session communication with the daemon, including response handling and timeout protection.

* **Bug Fixes**
  * Recovery now clearly rejects identities using privacy mode, which is not supported for restoration.
  * Recovered orders are correctly recognized as belonging to the current identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->