### PR TITLE
fix(web): convert PlatformInt64 fields before using them as int

### DIFF
--- a/lib/core/services/identity_service.dart
+++ b/lib/core/services/identity_service.dart
@@ -1,13 +1,8 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
+import 'package:mostro/shared/utils/platform_int64.dart';
 import 'package:mostro/src/rust/api/identity.dart' as identity_api;
-
-/// Returns [v] as the correct `PlatformInt64` type for the current platform:
-/// `int` on native, `BigInt` on web (dart2js). Returning `dynamic` lets
-/// callers pass it directly to bridge parameters typed as `PlatformInt64?`
-/// without a static-type error on either platform.
-dynamic _toInt64(int v) => kIsWeb ? BigInt.from(v) : v;
 
 /// Secure-storage keys.
 const _kMnemonic = 'mostro_identity_mnemonic';
@@ -185,7 +180,7 @@ class IdentityService {
       words: words,
       tradeKeyIndex: tradeKeyIndex,
       privacyMode: privacyMode,
-      createdAt: createdAt > 0 ? _toInt64(createdAt ~/ 1000) : null,
+      createdAt: createdAt > 0 ? intToPlatformInt64(createdAt ~/ 1000) : null,
     );
 
     debugPrint('[identity] identity loaded — pubkey=${info.publicKey}');

--- a/lib/features/home/providers/home_order_providers.dart
+++ b/lib/features/home/providers/home_order_providers.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mostro/shared/utils/platform_int64.dart';
 import 'package:mostro/src/rust/api/orders.dart' as orders_api;
 import 'package:mostro/src/rust/api/types.dart';
 
@@ -35,11 +36,6 @@ final ratingFilterProvider =
 /// Premium range filter. Default = full range.
 final premiumRangeFilterProvider =
     StateProvider<({double min, double max})>((_) => defaultPremiumRange);
-
-/// Converts a `PlatformInt64` value (int on native, BigInt on web/dart2js)
-/// to a plain Dart `int`.
-// ignore: unnecessary_cast
-int _platformInt64ToInt(dynamic v) => v is BigInt ? v.toInt() : v as int;
 
 // ── Order model ───────────────────────────────────────────────────────────────
 
@@ -124,10 +120,10 @@ class OrderItem {
         premium: info.premium,
         creatorPubkey: info.creatorPubkey,
         createdAt: DateTime.fromMillisecondsSinceEpoch(
-            _platformInt64ToInt(info.createdAt) * 1000),
+            platformInt64ToInt(info.createdAt) * 1000),
         expiresAt: info.expiresAt != null
             ? DateTime.fromMillisecondsSinceEpoch(
-                _platformInt64ToInt(info.expiresAt!) * 1000)
+                platformInt64ToInt(info.expiresAt!) * 1000)
             : null,
         status: info.status,
         amountSats: info.amountSats,

--- a/lib/features/home/providers/home_order_providers.dart
+++ b/lib/features/home/providers/home_order_providers.dart
@@ -120,10 +120,12 @@ class OrderItem {
         premium: info.premium,
         creatorPubkey: info.creatorPubkey,
         createdAt: DateTime.fromMillisecondsSinceEpoch(
-            platformInt64ToInt(info.createdAt) * 1000),
+          platformInt64ToInt(info.createdAt) * 1000,
+        ),
         expiresAt: info.expiresAt != null
             ? DateTime.fromMillisecondsSinceEpoch(
-                platformInt64ToInt(info.expiresAt!) * 1000)
+                platformInt64ToInt(info.expiresAt!) * 1000,
+              )
             : null,
         status: info.status,
         amountSats: info.amountSats,

--- a/lib/features/settings/screens/log_report_screen.dart
+++ b/lib/features/settings/screens/log_report_screen.dart
@@ -6,6 +6,7 @@ import 'package:mostro/core/app_theme.dart';
 import 'package:mostro/features/settings/providers/log_provider.dart';
 import 'package:mostro/features/settings/providers/settings_provider.dart';
 import 'package:mostro/l10n/app_localizations.dart';
+import 'package:mostro/shared/utils/platform_int64.dart';
 import 'package:mostro/src/rust/api/types.dart';
 
 // ── Screen ────────────────────────────────────────────────────────────────────
@@ -124,7 +125,7 @@ class _LogReportScreenState extends ConsumerState<LogReportScreen> {
 
   Future<void> _shareLogs(List<LogEntry> entries) async {
     final lines = entries.map((e) {
-      final time = _formatTimestamp(e.timestamp);
+      final time = _formatTimestamp(platformInt64ToInt(e.timestamp));
       final level = e.level.name.toUpperCase().padRight(7);
       final tag = _sanitizeForShare(e.tag);
       final message = _sanitizeForShare(e.message);
@@ -206,7 +207,7 @@ class _LogEntryTile extends StatelessWidget {
               const Spacer(),
               // Timestamp
               Text(
-                _formatTimestamp(entry.timestamp),
+                _formatTimestamp(platformInt64ToInt(entry.timestamp)),
                 style: Theme.of(context).textTheme.bodySmall,
               ),
             ],

--- a/lib/features/trades/providers/trades_providers.dart
+++ b/lib/features/trades/providers/trades_providers.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mostro/features/order/providers/trade_state_provider.dart';
 import 'package:mostro/l10n/app_localizations.dart';
 import 'package:mostro/shared/providers/nav_providers.dart';
+import 'package:mostro/shared/utils/platform_int64.dart';
 import 'package:mostro/src/rust/api/orders.dart' as orders_api;
 import 'package:mostro/src/rust/api/types.dart' as rust_types;
 
@@ -120,11 +121,7 @@ TradeListItem _tradeInfoToItem(rust_types.TradeInfo trade) {
     trade.order.fiatAmountMax,
   );
 
-  // PlatformInt64 = `int` on native, `BigInt` on web. Web persistence is not
-  // yet implemented; the BigInt branch guards future correctness.
-  final createdAt = trade.startedAt is BigInt
-      ? (trade.startedAt as BigInt).toInt()
-      : trade.startedAt as int; // ignore: unnecessary_cast
+  final createdAt = platformInt64ToInt(trade.startedAt);
 
   return TradeListItem(
     orderId: trade.order.id,

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -17,6 +17,7 @@ import 'package:mostro/features/home/providers/home_order_providers.dart';
 import 'package:mostro/features/order/providers/trade_state_provider.dart';
 import 'package:mostro/features/trades/providers/trades_providers.dart';
 import 'package:mostro/features/trades/widgets/release_confirmation_dialog.dart';
+import 'package:mostro/shared/utils/platform_int64.dart';
 import 'package:mostro/shared/widgets/mostro_reactive_button.dart';
 import 'package:mostro/shared/widgets/nym_avatar.dart';
 
@@ -112,8 +113,7 @@ class _TradeDetailScreenState extends ConsumerState<TradeDetailScreen> {
       final info = await orders_api.getOrder(orderId: widget.orderId);
       final raw = info?.expiresAt;
       if (raw == null || !mounted) return;
-      // PlatformInt64 = int on native, BigInt on web.
-      final expiresAtSeconds = raw is BigInt ? raw.toInt() : raw;
+      final expiresAtSeconds = platformInt64ToInt(raw);
       final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
       final diff = expiresAtSeconds - now;
       if (!mounted) return;
@@ -223,9 +223,7 @@ class _TradeDetailScreenState extends ConsumerState<TradeDetailScreen> {
     try {
       final dispute = await disputes_api.openDispute(tradeId: widget.orderId);
       if (!mounted) return;
-      final raw = dispute.openedAt;
-      // PlatformInt64 = int on native, BigInt on web.
-      final openedAt = raw is BigInt ? raw.toInt() : raw;
+      final openedAt = platformInt64ToInt(dispute.openedAt);
       ref.read(disputeNotifierProvider.notifier).upsert(
             DisputeItem(
               id: dispute.id,

--- a/lib/shared/utils/platform_int64.dart
+++ b/lib/shared/utils/platform_int64.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/foundation.dart';
+
+/// Helpers for flutter_rust_bridge's `PlatformInt64`.
+///
+/// Rust `u64`/`i64` fields cross the bridge as `PlatformInt64`, which is a
+/// plain `int` on native but a `BigInt` on web (dart2js cannot represent a
+/// 64-bit integer as `int`). Dart code that assumes `int` compiles on native
+/// and fails to compile — or misbehaves — on web, so route every conversion
+/// through these two functions instead of hand-rolling the check.
+
+/// Converts a `PlatformInt64` value to a plain Dart `int`.
+///
+/// The `else` branch must cast to `int`: without it the expression's static
+/// type is the `int`/`BigInt` least upper bound (`Object`), which does not
+/// compile where an `int` is expected.
+int platformInt64ToInt(dynamic value) =>
+    value is BigInt ? value.toInt() : value as int;
+
+/// Converts a Dart `int` to the `PlatformInt64` representation for the current
+/// platform: `int` on native, `BigInt` on web. Returns `dynamic` so the result
+/// can be passed straight to a bridge parameter typed `PlatformInt64` on either
+/// platform without a static-type error.
+dynamic intToPlatformInt64(int value) => kIsWeb ? BigInt.from(value) : value;

--- a/test/shared/utils/platform_int64_test.dart
+++ b/test/shared/utils/platform_int64_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro/shared/utils/platform_int64.dart';
+
+void main() {
+  group('platformInt64ToInt', () {
+    test('returns the value unchanged when it is already an int (native)', () {
+      // Arrange
+      const dynamic value = 1721764800;
+
+      // Act
+      final result = platformInt64ToInt(value);
+
+      // Assert
+      expect(result, 1721764800);
+      expect(result, isA<int>());
+    });
+
+    test('converts a BigInt to int (web/dart2js representation)', () {
+      // Arrange
+      final dynamic value = BigInt.from(1721764800);
+
+      // Act
+      final result = platformInt64ToInt(value);
+
+      // Assert
+      expect(result, 1721764800);
+      expect(result, isA<int>());
+    });
+
+    test('result is usable in int arithmetic (guards the LUB regression)', () {
+      // A ternary that does not cast the else branch yields `Object`, which
+      // fails to compile in arithmetic. This asserts the helper returns a
+      // usable int for both input representations.
+      final fromInt = platformInt64ToInt(100);
+      final fromBigInt = platformInt64ToInt(BigInt.from(40));
+
+      expect(fromInt - fromBigInt, 60);
+    });
+  });
+
+  group('intToPlatformInt64', () {
+    test('returns an int on native (kIsWeb is false under the VM test runner)',
+        () {
+      // Act
+      final result = intToPlatformInt64(1721764800);
+
+      // Assert
+      expect(result, 1721764800);
+      expect(result, isA<int>());
+    });
+  });
+}


### PR DESCRIPTION
## What

`flutter build web` failed to compile. This fixes the four failing sites and removes the
scattered duplication that caused the bug.

## Why

Rust `u64`/`i64` fields cross the flutter_rust_bridge boundary as `PlatformInt64`: a plain
`int` on native, but a `BigInt` on web (dart2js cannot hold a 64-bit integer in `int`). Four
sites used these values where an `int` is expected, so the code compiled on native and broke
on web:

```
log_report_screen.dart:127  The argument type 'BigInt' can't be assigned to the parameter type 'int'.
log_report_screen.dart:209  The argument type 'BigInt' can't be assigned to the parameter type 'int'.
trade_detail_screen.dart:118 The operator '-' isn't defined for the type 'Object'.
trade_detail_screen.dart:235 The argument type 'Object' can't be assigned to the parameter type 'int'.
```

Two of them already tried to guard for web with `raw is BigInt ? raw.toInt() : raw`, but the
`else` branch is not cast. The ternary's static type is then the `int`/`BigInt` least upper
bound — `Object` — which is precisely the `Object` in the errors above.

## How

- New `lib/shared/utils/platform_int64.dart` with `platformInt64ToInt(dynamic)` and
  `intToPlatformInt64(int)`, each documenting the native-vs-web split. `platformInt64ToInt`
  casts the `else` branch so the result is always `int`.
- Route the four failing sites through `platformInt64ToInt`.
- Replace three pre-existing private copies of the same conversion
  (`home_order_providers`, `trades_providers`, `identity_service`) with the shared helpers, so
  the logic lives in one place and the bug cannot recur in an un-fixed copy.

## Not in scope

The `flutter build web` output also lists "Wasm dry run findings" (`dart:html` in
`flutter_secure_storage_web`, `flutter_keyboard_visibility_web`, and an FRB web util). Those are
informational warnings for a `--wasm` build, not part of this failure — the standard dart2js/JS
build is what was broken, and it now compiles. Left for a separate discussion if wasm output is
wanted.

## Test plan

- [x] `flutter build web` → `✓ Built build/web`
- [x] `flutter analyze` → No issues found
- [x] `flutter test` → 121 pass (120 existing + new helper unit test covering int and BigInt inputs)
- [ ] CI green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when handling timestamps across web and native platforms.
  * Ensured timestamps display and share correctly in logs, orders, trades, identity details, and disputes.

* **Tests**
  * Added coverage for platform-specific timestamp conversion, including integer and large-integer values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->