### PR TITLE
fix(web): route wall-clock time through rt so wasm does not panic

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,13 +310,14 @@ compiles the Rust core for you; on web it does **not** — you compile the Rust 
 WebAssembly yourself, and the page must be served with cross-origin isolation headers.
 Skip either step and the app builds but shows a **blank page**.
 
-**One-time prerequisites** — in addition to the table above. `build-web` compiles the
-Rust core with `-Z build-std`, which requires a nightly toolchain with `rust-src`:
+**One-time prerequisites** — in addition to the table above. The wasm build compiles
+the Rust core with `-Z build-std`, which requires a nightly toolchain with `rust-src`
+(and the wasm target on that same nightly toolchain):
 
 ```bash
 rustup toolchain install nightly
 rustup component add rust-src --toolchain nightly
-rustup target add wasm32-unknown-unknown
+rustup target add wasm32-unknown-unknown --toolchain nightly
 cargo install wasm-pack
 ```
 
@@ -324,11 +325,17 @@ cargo install wasm-pack
 `rust_bg.wasm`). Re-run it after any change under `rust/src/`:
 
 ```bash
-flutter_rust_bridge_codegen build-web
+./scripts/build-web.sh              # add --release for an optimized build
 ```
 
-If you skip this, the console shows `Refused to execute script from '.../pkg/rust.js'
-because its MIME type ('text/html') is not executable` — the WASM was never built.
+Do **not** run `flutter_rust_bridge_codegen build-web` directly: on current nightly it
+silently produces WASM without shared memory, which crashes at runtime with
+`DataCloneError: ... #<Memory> could not be cloned` when FRB spawns its worker pool.
+The script adds the required linker flags and verifies the output (see issue #212).
+
+If you skip this step entirely, the console shows `Refused to execute script from
+'.../pkg/rust.js' because its MIME type ('text/html') is not executable` — the WASM was
+never built.
 
 **2. Run in Chrome with cross-origin isolation headers.** The Rust core uses
 `SharedArrayBuffer`, which browsers enable only under COOP/COEP:

--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ Make sure the following tools are installed on your system:
 | Rust toolchain | 1.94+ stable | `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \| sh` |
 | WASM target | — | `rustup target add wasm32-unknown-unknown` |
 | wasm-pack | latest | `cargo install wasm-pack` |
+| Rust nightly + `rust-src` (web only) | — | `rustup toolchain install nightly && rustup component add rust-src --toolchain nightly` |
 | flutter_rust_bridge CLI | 2.11.1 | `cargo install flutter_rust_bridge_codegen --version 2.11.1 --locked` |
 | Xcode (macOS / iOS only) | 15+ | Mac App Store |
 | Android Studio / NDK (Android only) | latest | [developer.android.com](https://developer.android.com/studio) |
@@ -296,11 +297,58 @@ flutter run
 # Target a specific platform
 flutter run -d android
 flutter run -d ios
-flutter run -d chrome        # Web (WASM)
+flutter run -d chrome        # Web — needs extra steps, see "Running on Web" below
 flutter run -d macos
 flutter run -d windows
 flutter run -d linux
 ```
+
+### Running on Web
+
+Web needs two steps that the other platforms don't. On native, the Flutter build
+compiles the Rust core for you; on web it does **not** — you compile the Rust core to
+WebAssembly yourself, and the page must be served with cross-origin isolation headers.
+Skip either step and the app builds but shows a **blank page**.
+
+**One-time prerequisites** — in addition to the table above. `build-web` compiles the
+Rust core with `-Z build-std`, which requires a nightly toolchain with `rust-src`:
+
+```bash
+rustup toolchain install nightly
+rustup component add rust-src --toolchain nightly
+rustup target add wasm32-unknown-unknown
+cargo install wasm-pack
+```
+
+**1. Compile the Rust core to WASM.** This produces `web/pkg/` (`rust.js` +
+`rust_bg.wasm`). Re-run it after any change under `rust/src/`:
+
+```bash
+flutter_rust_bridge_codegen build-web
+```
+
+If you skip this, the console shows `Refused to execute script from '.../pkg/rust.js'
+because its MIME type ('text/html') is not executable` — the WASM was never built.
+
+**2. Run in Chrome with cross-origin isolation headers.** The Rust core uses
+`SharedArrayBuffer`, which browsers enable only under COOP/COEP:
+
+```bash
+flutter run -d chrome \
+  --web-header "Cross-Origin-Opener-Policy=same-origin" \
+  --web-header "Cross-Origin-Embedder-Policy=require-corp"
+```
+
+Without the headers the console shows `Buffers cannot be shared due to missing
+cross-origin headers` and the page stays blank.
+
+On first launch the app generates an identity and connects to relays; you should see the
+order book populate from the daemon's Kind 38383 events without running anything locally.
+
+**Deploying the production build.** `flutter build web` (see below) emits `build/web`, but
+the same two COOP/COEP headers must be set by whatever serves it — a reverse proxy, CDN
+config, or a [`coi-serviceworker`](https://github.com/gzuidhof/coi-serviceworker) shim —
+or the deployed site is blank for the same `SharedArrayBuffer` reason.
 
 ### Build for Production
 

--- a/rust/src/api/disputes.rs
+++ b/rust/src/api/disputes.rs
@@ -100,12 +100,7 @@ fn dispute_store() -> &'static DisputeStore {
 
 // ── Helper ────────────────────────────────────────────────────────────────────
 
-fn unix_now() -> i64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs() as i64
-}
+use crate::rt::unix_now;
 
 // ── Public API ────────────────────────────────────────────────────────────────
 

--- a/rust/src/api/identity.rs
+++ b/rust/src/api/identity.rs
@@ -365,13 +365,7 @@ fn reconcile_trade_key_index(
     }
 }
 
-fn unix_now() -> i64 {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs() as i64
-}
+use crate::rt::unix_now;
 
 /// Expose the in-memory `Keys` for other Rust modules (relay pool, gift wrap).
 /// Returns `Err("NoIdentity")` if no identity is loaded.

--- a/rust/src/api/logging.rs
+++ b/rust/src/api/logging.rs
@@ -110,10 +110,7 @@ pub(crate) fn forward_log(level: log::Level, target: &str, message: &str) {
             },
             tag: target.split("::").last().unwrap_or(target).to_string(),
             message: message.to_string(),
-            timestamp: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs() as i64,
+            timestamp: crate::rt::unix_now(),
         };
         if let Ok(g) = tx.lock() {
             let _ = g.send(entry);

--- a/rust/src/api/messages.rs
+++ b/rust/src/api/messages.rs
@@ -580,13 +580,7 @@ impl AttachmentProgressStream {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-fn unix_now() -> i64 {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs() as i64
-}
+use crate::rt::unix_now;
 
 /// Strip directory components from a caller-supplied file name to prevent
 /// path traversal (e.g. `../../../etc/passwd` → `passwd`).

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -664,10 +664,7 @@ pub async fn create_order(params: NewOrderParams) -> Result<OrderInfo> {
     // Build a local OrderInfo representing the newly created order.
     // In Phase 7, this will be replaced by the actual Mostro response
     // after the NIP-59 message is published and acknowledged.
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs() as i64;
+    let now = crate::rt::unix_now();
 
     // Clone params before the struct takes ownership of its fields.
     let params_for_dispatch = params.clone();
@@ -1046,10 +1043,7 @@ pub async fn take_order(
 
     // Accepted: build the trade from the daemon's actual reply instead of
     // optimistic assumptions, then persist and wire up the trade session.
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs() as i64;
+    let now = crate::rt::unix_now();
     let initial_step = match role {
         TradeRole::Buyer => TradeStep::Buyer(BuyerStep::OrderTaken),
         TradeRole::Seller => TradeStep::Seller(SellerStep::TakerFound),

--- a/rust/src/api/reputation.rs
+++ b/rust/src/api/reputation.rs
@@ -109,12 +109,7 @@ fn rating_store() -> &'static RatingStore {
 
 // ── Helper ────────────────────────────────────────────────────────────────────
 
-fn unix_now() -> i64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs() as i64
-}
+use crate::rt::unix_now;
 
 // ── Public API ────────────────────────────────────────────────────────────────
 

--- a/rust/src/mostro/session.rs
+++ b/rust/src/mostro/session.rs
@@ -77,10 +77,7 @@ impl SessionManager {
             ));
         }
 
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs() as i64;
+        let now = crate::rt::unix_now();
 
         let session = Session {
             order_id: order_id.clone(),
@@ -149,10 +146,7 @@ impl SessionManager {
     /// Remove sessions older than `timeout_secs` that have no shared key
     /// (i.e., the take action was never acknowledged by Mostro).
     pub async fn cleanup_stale_sessions(&self, timeout_secs: i64) {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs() as i64;
+        let now = crate::rt::unix_now();
 
         let mut sessions = self.sessions.write().await;
         sessions.retain(|_, s| {

--- a/rust/src/nostr/blossom.rs
+++ b/rust/src/nostr/blossom.rs
@@ -133,13 +133,8 @@ async fn try_upload(
     {
         use base64::{engine::general_purpose::STANDARD, Engine};
         use nostr_sdk::prelude::*;
-        use std::time::{SystemTime, UNIX_EPOCH};
 
-        let expiration = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs()
-            + 600; // 10 minutes
+        let expiration = crate::rt::unix_now() as u64 + 600; // 10 minutes
 
         // Build and sign the auth event.
         // Fallback: if no identity is loaded (e.g. first-run upload before

--- a/rust/src/nostr/relay_pool.rs
+++ b/rust/src/nostr/relay_pool.rs
@@ -13,7 +13,7 @@ use nostr_sdk::prelude::*;
 // conflicting with our internal `RelayStatus` from `crate::api::types`.
 use nostr_sdk::RelayStatus as SdkRelayStatus;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 use tokio::sync::{broadcast, RwLock};
 
 use crate::api::types::{ConnectionState, RelayInfo, RelaySource, RelayStatus};
@@ -231,9 +231,4 @@ fn map_sdk_status(s: SdkRelayStatus) -> RelayStatus {
     }
 }
 
-fn unix_now() -> i64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs() as i64
-}
+use crate::rt::unix_now;

--- a/rust/src/nwc/client.rs
+++ b/rust/src/nwc/client.rs
@@ -346,12 +346,7 @@ mod native {
         }
     }
 
-    fn unix_now() -> i64 {
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs() as i64
-    }
+    use crate::rt::unix_now;
 }
 
 // ── Public re-exports ────────────────────────────────────────────────────────

--- a/rust/src/queue/outbox.rs
+++ b/rust/src/queue/outbox.rs
@@ -1,5 +1,4 @@
 use std::sync::{Mutex, OnceLock};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
@@ -171,12 +170,7 @@ pub fn queue_message(event_json: String) {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-fn unix_now() -> i64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0)
-}
+use crate::rt::unix_now;
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 

--- a/rust/src/rt.rs
+++ b/rust/src/rt.rs
@@ -26,15 +26,33 @@ where
     wasm_bindgen_futures::spawn_local(future);
 }
 
-/// Timer primitives mirroring the subset of `tokio::time` used by the crate.
+/// Timer and clock primitives mirroring the subset of `std::time` / `tokio::time`
+/// used by the crate.
+///
+/// `SystemTime`/`UNIX_EPOCH` matter for the wall clock: `std::time::SystemTime::now()`
+/// is unimplemented on `wasm32-unknown-unknown` and panics at runtime ("time not
+/// implemented on this platform"). `wasmtimer` provides a browser-backed drop-in, so
+/// every wall-clock read must go through `crate::rt::time` (or `unix_now()` below).
 #[cfg(not(target_arch = "wasm32"))]
 pub mod time {
+    pub use std::time::{SystemTime, UNIX_EPOCH};
     pub use tokio::time::{sleep, timeout, Duration, Instant};
 }
 
 #[cfg(target_arch = "wasm32")]
 pub mod time {
     pub use std::time::Duration;
-    pub use wasmtimer::std::Instant;
+    pub use wasmtimer::std::{Instant, SystemTime, UNIX_EPOCH};
     pub use wasmtimer::tokio::{sleep, timeout};
+}
+
+/// Current Unix time in whole seconds, on both native and wasm.
+///
+/// Returns 0 if the clock is before the Unix epoch (never happens in practice),
+/// mirroring the `unwrap_or_default()` behaviour of the call sites this replaces.
+pub fn unix_now() -> i64 {
+    time::SystemTime::now()
+        .duration_since(time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
 }

--- a/scripts/build-web.sh
+++ b/scripts/build-web.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Compile the Rust core to WebAssembly with shared memory (threads) into web/pkg/.
+#
+# Do NOT use `flutter_rust_bridge_codegen build-web` directly: on current nightly,
+# rustc no longer auto-adds the shared-memory linker flags when `+atomics` is set,
+# so that build silently emits non-shared memory and FRB's worker pool dies at
+# runtime with:
+#   DataCloneError: Failed to execute 'postMessage' on 'Worker': #<Memory> could not be cloned.
+# Full story in issue #212 (and #210 for the wasm bring-up it was found during).
+#
+# Usage:
+#   ./scripts/build-web.sh              dev build (fast, unoptimized)
+#   ./scripts/build-web.sh --release    release build
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+profile_flag="--dev"
+if [[ "${1-}" == "--release" ]]; then
+  profile_flag=""
+elif [[ -n "${1-}" ]]; then
+  echo "usage: $0 [--release]" >&2
+  exit 2
+fi
+
+for tool in wasm-pack rustup python3; do
+  command -v "$tool" >/dev/null || { echo "✗ $tool is not installed." >&2; exit 1; }
+done
+
+export RUSTUP_TOOLCHAIN=nightly
+# +atomics/+bulk-memory/+mutable-globals enable wasm threads. The link-args are the
+# shared-memory set rustc historically added by itself when it saw +atomics — minus
+# __wasm_init_memory (no longer an exportable symbol in current lld) and plus
+# __heap_base (required by wasm-bindgen's thread transform).
+export RUSTFLAGS='-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--shared-memory -C link-arg=--max-memory=1073741824 -C link-arg=--import-memory -C link-arg=--export=__wasm_init_tls -C link-arg=--export=__tls_size -C link-arg=--export=__tls_align -C link-arg=--export=__tls_base -C link-arg=--export=__heap_base'
+
+# shellcheck disable=SC2086  # $profile_flag must word-split (it is empty on release)
+wasm-pack build -t no-modules -d "$repo_root/web/pkg" --no-typescript --out-name rust \
+  $profile_flag rust -- -Z build-std=std,panic_abort
+
+# Verify the emitted memory is actually shared. A toolchain regression here compiles
+# fine and only fails at runtime (the DataCloneError above), so fail the build loudly
+# instead of shipping a blank page.
+python3 - "$repo_root/web/pkg/rust_bg.wasm" <<'EOF'
+import sys
+
+data = open(sys.argv[1], 'rb').read()
+
+def leb(b, i):
+    r = s = 0
+    while True:
+        x = b[i]; i += 1; r |= (x & 0x7f) << s
+        if not x & 0x80:
+            return r, i
+        s += 7
+
+i = 8  # skip magic + version
+shared = None
+while i < len(data) and shared is None:
+    sid = data[i]; i += 1
+    size, i = leb(data, i)
+    if sid == 2:  # import section — threaded builds import their memory
+        j = i
+        n, j = leb(data, j)
+        for _ in range(n):
+            ml, j = leb(data, j); j += ml
+            nl, j = leb(data, j); j += nl
+            kind = data[j]; j += 1
+            if kind == 0:      # function
+                _, j = leb(data, j)
+            elif kind == 1:    # table: elemtype + limits
+                j += 1
+                f = data[j]; j += 1
+                _, j = leb(data, j)
+                if f & 1:
+                    _, j = leb(data, j)
+            elif kind == 2:    # memory — what we are after
+                shared = bool(data[j] & 0x2)
+                break
+            elif kind == 3:    # global: valtype + mutability
+                j += 2
+    elif sid == 5:  # local memory section — a non-threaded build defines its own
+        j = i
+        _, j = leb(data, j)
+        shared = bool(data[j] & 0x2)
+    i += size
+
+if not shared:
+    sys.exit(
+        "✗ web/pkg/rust_bg.wasm was built WITHOUT shared memory — the app will crash "
+        "at runtime spawning workers (DataCloneError). The RUSTFLAGS in this script "
+        "did not take effect; see issue #212."
+    )
+print("✓ web/pkg/rust_bg.wasm has shared memory (threads enabled).")
+EOF
+
+echo "✓ WASM build complete: web/pkg/"


### PR DESCRIPTION
Closes #210

## What

The web client rendered a blank page. The Rust core panicked at runtime the moment it
read wall-clock time, which happens on first launch during identity creation:

```
panicked at .../std/src/sys/time/unsupported.rs:35:9:
time not implemented on this platform
  <std::time::SystemTime>::now
  rust::api::identity::unix_now
  rust::api::identity::create_identity
```

## Why

`std::time::SystemTime::now()` is unimplemented on `wasm32-unknown-unknown` and aborts.
`rust/src/rt.rs` already abstracts the monotonic clock and timers per platform
(`Instant`, `sleep`, `timeout` via `wasmtimer` on wasm) — but the wall clock was never
abstracted, and 12 call sites read `SystemTime::now()` directly.

CI never caught it: `cargo check --target wasm32` type-checks the wasm build but never
runs it, and the panic is at runtime.

## How

- **`rt.rs`**: add `SystemTime`/`UNIX_EPOCH` to `crate::rt::time`, resolved per platform
  (native `std`, wasm `wasmtimer::std` — already a dependency, no new crate), plus a
  single `rt::unix_now() -> i64`.
- **12 call sites** routed through it:
  - seven private `unix_now()` copies (`identity`, `disputes`, `reputation`, `messages`,
    `nwc`, `outbox`, `relay_pool`) now `use crate::rt::unix_now`;
  - five inline reads (`orders` ×2, `logging`, `session` ×2, `blossom`) call
    `crate::rt::unix_now()` directly.
- Removes eight duplicated copies of the same `duration_since(UNIX_EPOCH)` logic.

No `std::time::SystemTime::now()` remains outside `rt.rs`.

## Docs

Adds a **Running on Web** section to the README — the flow was entirely undocumented and
is what made this hard to hit: nightly + `rust-src` prerequisites, `build-web` to compile
the Rust core to WASM, `flutter run -d chrome` with COOP/COEP headers, the exact console
error each missing step produces, and a note that production hosting needs the same
headers.

## Test plan

- [x] `cargo test` — 110 pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo check --target wasm32-unknown-unknown` — clean
- [x] `flutter_rust_bridge_codegen build-web` — rebuilds `web/pkg` successfully
- [x] Web reaches the UI: `build-web` + `flutter run -d chrome` (COOP/COEP) no longer
      aborts on identity creation — blank page resolved
- [ ] CI green

## Follow-up (out of scope, noted in the issue)

CI only type-checks wasm; a runtime panic like this slips through. A headless
`wasm-pack test` smoke test (or a grep guard against `SystemTime::now()` outside `rt.rs`)
would prevent regressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded web setup instructions with platform-specific run commands.
  * Added guidance for building Rust components to WebAssembly and configuring cross-origin isolation for development and production.

* **Improvements**
  * Improved timestamp consistency across messaging, orders, sessions, logging, identity, reputation, networking, and uploads.
  * Added more reliable time support for web builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->