### PR TITLE
fix(#223): backup verify, redirect to 12 words after second wrong pick

### DIFF
--- a/lib/features/account/screens/backup_ritual_screen.dart
+++ b/lib/features/account/screens/backup_ritual_screen.dart
@@ -172,10 +172,9 @@ class _BackupRitualScreenState extends ConsumerState<BackupRitualScreen> {
         // up, then restart verification from scratch (#204 review).
         _backToWords();
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
+          SnackBar(
             content: Text(
-              'That was incorrect again. Please review and back up your 12 '
-              'words, then verify from the start.',
+              AppLocalizations.of(context).backupRitualSecondFailureMessage,
             ),
           ),
         );

--- a/lib/features/account/screens/backup_ritual_screen.dart
+++ b/lib/features/account/screens/backup_ritual_screen.dart
@@ -59,6 +59,11 @@ class _BackupRitualScreenState extends ConsumerState<BackupRitualScreen> {
   /// Option the user last tapped incorrectly (cleared on next tap).
   String? _wrongPick;
 
+  /// Wrong-pick counter for the current verification round. On the 2nd wrong
+  /// pick the user is sent back to the words screen and verification restarts,
+  /// so the confirmation can't be brute-forced by elimination (#204 review).
+  int _failCount = 0;
+
   bool _confirming = false;
 
   @override
@@ -119,6 +124,7 @@ class _BackupRitualScreenState extends ConsumerState<BackupRitualScreen> {
       _filled = [null, null, null];
       _activeSlot = 0;
       _wrongPick = null;
+      _failCount = 0;
       _options = _buildOptions(_challenge[0]);
       _step = 1;
     });
@@ -159,7 +165,23 @@ class _BackupRitualScreenState extends ConsumerState<BackupRitualScreen> {
         }
       });
     } else {
-      setState(() => _wrongPick = word);
+      _failCount++;
+      if (_failCount >= 2) {
+        // Second wrong pick this round: don't let the user keep guessing by
+        // elimination. Send them back to the 12 words to actually back them
+        // up, then restart verification from scratch (#204 review).
+        _backToWords();
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text(
+              'That was incorrect again. Please review and back up your 12 '
+              'words, then verify from the start.',
+            ),
+          ),
+        );
+      } else {
+        setState(() => _wrongPick = word);
+      }
     }
   }
 

--- a/lib/features/account/screens/backup_ritual_screen.dart
+++ b/lib/features/account/screens/backup_ritual_screen.dart
@@ -31,7 +31,12 @@ const _fallbackDecoys = [
 /// The words live only in this screen's state and are discarded when the
 /// screen is left, restoring the masked behavior of the Account screen.
 class BackupRitualScreen extends ConsumerStatefulWidget {
-  const BackupRitualScreen({super.key});
+  const BackupRitualScreen({super.key, @visibleForTesting this.debugWords});
+
+  /// Test-only word source. When non-null, [_loadWords] uses these instead of
+  /// calling the Rust bridge, so widget tests can drive verification with a
+  /// known mnemonic. Never set in production.
+  final List<String>? debugWords;
 
   @override
   ConsumerState<BackupRitualScreen> createState() => _BackupRitualScreenState();
@@ -59,10 +64,25 @@ class _BackupRitualScreenState extends ConsumerState<BackupRitualScreen> {
   /// Option the user last tapped incorrectly (cleared on next tap).
   String? _wrongPick;
 
-  /// Wrong-pick counter for the current verification round. On the 2nd wrong
-  /// pick the user is sent back to the words screen and verification restarts,
-  /// so the confirmation can't be brute-forced by elimination (#204 review).
+  /// Wrong-pick counter for the word currently being verified. Reset to 0 on
+  /// each correct pick, so it counts misses on the word in front of the user.
+  /// A second wrong pick on the same word sends them back to the 12 words and
+  /// restarts verification, so a single slot can't be solved by tapping every
+  /// option in turn (#223).
   int _failCount = 0;
+
+  /// Test-only: the correct word for the slot currently being verified, or null
+  /// if verification isn't active. Lets widget tests tap the right/wrong option
+  /// deterministically despite the randomised challenge. Never used in prod UI.
+  @visibleForTesting
+  String? get debugCorrectWordForActiveSlot {
+    if (_words == null ||
+        _challenge.isEmpty ||
+        _activeSlot >= _challenge.length) {
+      return null;
+    }
+    return _words![_challenge[_activeSlot]];
+  }
 
   bool _confirming = false;
 
@@ -81,7 +101,8 @@ class _BackupRitualScreenState extends ConsumerState<BackupRitualScreen> {
 
   Future<void> _loadWords() async {
     try {
-      final words = await IdentityService.getMnemonicWords();
+      final words =
+          widget.debugWords ?? await IdentityService.getMnemonicWords();
       if (!mounted) return;
       if (words.isEmpty) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -155,6 +176,7 @@ class _BackupRitualScreenState extends ConsumerState<BackupRitualScreen> {
       setState(() {
         _filled[_activeSlot] = word;
         _wrongPick = null;
+        _failCount = 0; // correct pick — reset the per-word miss budget
         final next = _filled.indexWhere((w) => w == null);
         if (next != -1) {
           _activeSlot = next;
@@ -165,11 +187,11 @@ class _BackupRitualScreenState extends ConsumerState<BackupRitualScreen> {
         }
       });
     } else {
-      _failCount++;
+      setState(() => _failCount++);
       if (_failCount >= 2) {
-        // Second wrong pick this round: don't let the user keep guessing by
-        // elimination. Send them back to the 12 words to actually back them
-        // up, then restart verification from scratch (#204 review).
+        // Second wrong pick on this word: don't let the user grind through the
+        // options by elimination. Send them back to the 12 words to review,
+        // then restart verification from scratch (#223).
         _backToWords();
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
@@ -218,6 +240,7 @@ class _BackupRitualScreenState extends ConsumerState<BackupRitualScreen> {
       _activeSlot = 0;
       _options = const [];
       _wrongPick = null;
+      _failCount = 0; // round is over — the next one starts clean
     });
   }
 

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -203,6 +203,7 @@
   "relayAddFailed": "Relay konnte nicht hinzugefügt werden",
   "relayRemoveFailed": "Relay konnte nicht entfernt werden",
   "backupConfirmCheckbox": "Ich habe meine Wörter aufgeschrieben und sicher gespeichert",
+  "backupRitualSecondFailureMessage": "Das war erneut falsch. Bitte überprüfe und sichere deine geheimen Wörter und verifiziere dann von vorne.",
 
   "cancelTradeDialogTitle": "Handel abbrechen?",
   "cancelTradeDialogContent": "Kooperativen Abbruch angefragt. Die andere Partei muss ebenfalls zustimmen, damit der Handel vollständig abgebrochen wird.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -430,6 +430,8 @@
   "@relayRemoveFailed": {"description": "SnackBar message shown when removing a relay fails"},
   "backupConfirmCheckbox": "I have written down my words and backed them up securely",
   "@backupConfirmCheckbox": {"description": "Label for the backup confirmation checkbox on the Account screen"},
+  "backupRitualSecondFailureMessage": "That was incorrect again. Please review and back up your secret words, then verify from the start.",
+  "@backupRitualSecondFailureMessage": {"description": "Shown when the user picks a wrong word a second time during backup verification; sends them back to review the words and restart verification"},
 
   "cancelTradeDialogTitle": "Cancel trade?",
   "@cancelTradeDialogTitle": {"description": "Title for the cancel-trade confirmation dialog"},

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -203,6 +203,7 @@
   "relayAddFailed": "Error al añadir el relay",
   "relayRemoveFailed": "Error al eliminar el relay",
   "backupConfirmCheckbox": "He anotado mis palabras y las he guardado de forma segura",
+  "backupRitualSecondFailureMessage": "Eso fue incorrecto de nuevo. Por favor revisa y respalda tus palabras secretas, luego verifica desde el principio.",
 
   "cancelTradeDialogTitle": "¿Cancelar intercambio?",
   "cancelTradeDialogContent": "Se solicita una cancelación cooperativa. La otra parte también debe aceptar para que el intercambio quede cancelado.",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -203,6 +203,7 @@
   "relayAddFailed": "Échec de l'ajout du relais",
   "relayRemoveFailed": "Échec de la suppression du relais",
   "backupConfirmCheckbox": "J'ai noté mes mots et les ai sauvegardés en lieu sûr",
+  "backupRitualSecondFailureMessage": "C'est encore incorrect. Veuillez vérifier et sauvegarder vos mots secrets, puis recommencer la vérification depuis le début.",
 
   "cancelTradeDialogTitle": "Annuler l'échange ?",
   "cancelTradeDialogContent": "Annulation coopérative demandée. L'autre partie doit également accepter pour que l'échange soit entièrement annulé.",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -203,6 +203,7 @@
   "relayAddFailed": "Impossibile aggiungere il relay",
   "relayRemoveFailed": "Impossibile rimuovere il relay",
   "backupConfirmCheckbox": "Ho annotato le mie parole e le ho salvate in modo sicuro",
+  "backupRitualSecondFailureMessage": "Di nuovo errato. Per favore controlla e salva le tue parole segrete, poi verifica dall'inizio.",
 
   "cancelTradeDialogTitle": "Annullare lo scambio?",
   "cancelTradeDialogContent": "Annullamento cooperativo richiesto. Anche l'altra parte deve accettare affinché lo scambio venga annullato.",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1232,6 +1232,12 @@ abstract class AppLocalizations {
   /// **'I have written down my words and backed them up securely'**
   String get backupConfirmCheckbox;
 
+  /// Shown when the user picks a wrong word a second time during backup verification; sends them back to review the words and restart verification
+  ///
+  /// In en, this message translates to:
+  /// **'That was incorrect again. Please review and back up your secret words, then verify from the start.'**
+  String get backupRitualSecondFailureMessage;
+
   /// Title for the cancel-trade confirmation dialog
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -628,6 +628,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Ich habe meine Wörter aufgeschrieben und sicher gespeichert';
 
   @override
+  String get backupRitualSecondFailureMessage =>
+      'Das war erneut falsch. Bitte überprüfe und sichere deine geheimen Wörter und verifiziere dann von vorne.';
+
+  @override
   String get cancelTradeDialogTitle => 'Handel abbrechen?';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -620,6 +620,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'I have written down my words and backed them up securely';
 
   @override
+  String get backupRitualSecondFailureMessage =>
+      'That was incorrect again. Please review and back up your secret words, then verify from the start.';
+
+  @override
   String get cancelTradeDialogTitle => 'Cancel trade?';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -628,6 +628,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'He anotado mis palabras y las he guardado de forma segura';
 
   @override
+  String get backupRitualSecondFailureMessage =>
+      'Eso fue incorrecto de nuevo. Por favor revisa y respalda tus palabras secretas, luego verifica desde el principio.';
+
+  @override
   String get cancelTradeDialogTitle => '¿Cancelar intercambio?';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -632,6 +632,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'J\'ai noté mes mots et les ai sauvegardés en lieu sûr';
 
   @override
+  String get backupRitualSecondFailureMessage =>
+      'C\'est encore incorrect. Veuillez vérifier et sauvegarder vos mots secrets, puis recommencer la vérification depuis le début.';
+
+  @override
   String get cancelTradeDialogTitle => 'Annuler l\'échange ?';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -628,6 +628,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Ho annotato le mie parole e le ho salvate in modo sicuro';
 
   @override
+  String get backupRitualSecondFailureMessage =>
+      'Di nuovo errato. Per favore controlla e salva le tue parole segrete, poi verifica dall\'inizio.';
+
+  @override
   String get cancelTradeDialogTitle => 'Annullare lo scambio?';
 
   @override

--- a/test/features/account/backup_ritual_screen_test.dart
+++ b/test/features/account/backup_ritual_screen_test.dart
@@ -46,7 +46,9 @@ Finder _aWrongOption(WidgetTester tester) {
   final correct = _correctWord(tester);
   for (final w in _words) {
     if (w == correct) continue;
-    final f = find.text(w);
+    // Scope to the option buttons (InkWell), so a filled answer chip with the
+    // same text can't be matched instead once slots start filling.
+    final f = find.widgetWithText(InkWell, w);
     if (f.evaluate().isNotEmpty) return f.first;
   }
   fail('no wrong option visible');
@@ -106,7 +108,6 @@ void main() {
     await tester.pump();
     expect(find.text(l10n.backupRitualStep1Title), findsOneWidget);
 
-    // Clear the SnackBar so it can't intercept the restart tap, then restart.
     // The failure SnackBar sits at the bottom over the verify button; clear it
     // so it can't intercept the restart tap.
     ScaffoldMessenger.of(tester.element(find.byType(BackupRitualScreen)))
@@ -130,7 +131,7 @@ void main() {
     // Answer each of the three challenge slots with its correct word.
     for (var i = 0; i < 3; i++) {
       final correct = _correctWord(tester);
-      await tester.tap(find.text(correct).first);
+      await tester.tap(find.widgetWithText(InkWell, correct).first);
       await tester.pumpAndSettle();
     }
 

--- a/test/features/account/backup_ritual_screen_test.dart
+++ b/test/features/account/backup_ritual_screen_test.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:mostro/features/account/screens/backup_ritual_screen.dart';
+import 'package:mostro/l10n/app_localizations.dart';
+
+const _words = <String>[
+  'abandon', 'ability', 'able', 'about', 'above', 'absent',
+  'absorb', 'abstract', 'absurd', 'abuse', 'access', 'accident',
+];
+
+Future<void> _pumpRitual(WidgetTester tester) async {
+  tester.view.physicalSize = const Size(1200, 2400);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    const ProviderScope(
+      child: MaterialApp(
+        locale: Locale('en'),
+        localizationsDelegates: [
+          AppLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: BackupRitualScreen(debugWords: _words),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+String _correctWord(WidgetTester tester) {
+  final dynamic state = tester.state(find.byType(BackupRitualScreen));
+  final String? w = state.debugCorrectWordForActiveSlot as String?;
+  expect(w, isNotNull, reason: 'verification should be active');
+  return w!;
+}
+
+Finder _aWrongOption(WidgetTester tester) {
+  final correct = _correctWord(tester);
+  for (final w in _words) {
+    if (w == correct) continue;
+    final f = find.text(w);
+    if (f.evaluate().isNotEmpty) return f.first;
+  }
+  fail('no wrong option visible');
+}
+
+Future<void> _goToVerify(WidgetTester tester, AppLocalizations l10n) async {
+  await tester.tap(find.text(l10n.wroteThemDownVerifyButton));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  late AppLocalizations l10n;
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    l10n = await AppLocalizations.delegate.load(const Locale('en'));
+  });
+
+  testWidgets('first wrong pick keeps the user on step 2 with feedback',
+      (tester) async {
+    await _pumpRitual(tester);
+    await _goToVerify(tester, l10n);
+    expect(find.text(l10n.tapCorrectWordsTitle), findsOneWidget);
+
+    await tester.tap(_aWrongOption(tester));
+    await tester.pumpAndSettle();
+
+    expect(find.text(l10n.tapCorrectWordsTitle), findsOneWidget);
+    expect(find.text(l10n.wrongPickMessage), findsOneWidget);
+  });
+
+  testWidgets(
+      'second wrong pick on the same word returns to step 1 with the SnackBar',
+      (tester) async {
+    await _pumpRitual(tester);
+    await _goToVerify(tester, l10n);
+
+    await tester.tap(_aWrongOption(tester));
+    await tester.pumpAndSettle();
+    expect(find.text(l10n.tapCorrectWordsTitle), findsOneWidget);
+
+    await tester.tap(_aWrongOption(tester));
+    await tester.pump();
+
+    expect(find.text(l10n.backupRitualStep1Title), findsOneWidget);
+    expect(find.text(l10n.backupRitualSecondFailureMessage), findsOneWidget);
+  });
+
+  testWidgets(
+      'after restarting verification, one wrong pick is tolerated again',
+      (tester) async {
+    await _pumpRitual(tester);
+    await _goToVerify(tester, l10n);
+
+    await tester.tap(_aWrongOption(tester));
+    await tester.pumpAndSettle();
+    await tester.tap(_aWrongOption(tester));
+    await tester.pump();
+    expect(find.text(l10n.backupRitualStep1Title), findsOneWidget);
+
+    // Clear the SnackBar so it can't intercept the restart tap, then restart.
+    // The failure SnackBar sits at the bottom over the verify button; clear it
+    // so it can't intercept the restart tap.
+    ScaffoldMessenger.of(tester.element(find.byType(BackupRitualScreen)))
+        .clearSnackBars();
+    await tester.pumpAndSettle();
+
+    await _goToVerify(tester, l10n);
+    expect(find.text(l10n.tapCorrectWordsTitle), findsOneWidget);
+
+    await tester.tap(_aWrongOption(tester));
+    await tester.pumpAndSettle();
+    expect(find.text(l10n.tapCorrectWordsTitle), findsOneWidget);
+    expect(find.text(l10n.backupRitualStep1Title), findsNothing);
+  });
+
+  testWidgets('answering all three words correctly confirms the backup',
+      (tester) async {
+    await _pumpRitual(tester);
+    await _goToVerify(tester, l10n);
+
+    // Answer each of the three challenge slots with its correct word.
+    for (var i = 0; i < 3; i++) {
+      final correct = _correctWord(tester);
+      await tester.tap(find.text(correct).first);
+      await tester.pumpAndSettle();
+    }
+
+    expect(find.text(l10n.allWordsCorrectMessage), findsOneWidget);
+    await tester.tap(find.text(l10n.confirmButtonLabel));
+    await tester.pumpAndSettle();
+
+    expect(find.text(l10n.accountBackedUpTitle), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Refs #223 backup-verification UX (fail-twice -> re-show words).

## Problem
On the seed-confirmation step, a wrong pick only showed "incorrect" and let the
user keep tapping the same slot. Across retries they could eliminate the decoys
and land on the correct word by process of elimination  "completing" backup
without knowing the words.

## Fix
A per-word wrong-pick counter (`_failCount`), reset to 0 on each correct pick.
A **second wrong pick on the same word** sends the user back to the 12-words
screen with a localized message and restarts verification. The counter is reset
in both `_backToWords()` (the owner) and `_startVerification()` (belt-and-braces).

Practical effect: a user may miss once on each of the three challenge words and
still finish the round  strictly more lenient than "second wrong pick anywhere",
but elimination is still blocked (at most 2 of 4 options per slot).

## Tests
`test/features/account/backup_ritual_screen_test.dart` (4 cases):
- first wrong pick -> stays on step 2 with feedback
- second wrong pick on the same word -> back to step 1 with the SnackBar
- after restart, one wrong pick tolerated (proves the reset)
- all correct -> backup confirms

A `@visibleForTesting debugWords` seam lets the flow run without the Rust bridge;
it's enforced (a production call site fails `flutter analyze`).

## Note on the second part of #223
#223 also covers the Account "Secret Words" section. The current screen already
shows "To restore your account", Show/Hide, the confirm checkbox, and a
"✓ Backed up" badge after backup (banner disappears). I'll split that into its
own issue and update the #223 checklist using `Refs` here so #223 stays open.