### PR TITLE
feat(#215): RestoreSession handshake, send, correlate reply, subscribe

### DIFF
--- a/rust/src/api/identity.rs
+++ b/rust/src/api/identity.rs
@@ -164,8 +164,23 @@ pub async fn load_identity_from_mnemonic(
 /// When `recover = true`, the daemon recovery flow is triggered (Phase 7).
 /// Currently this validates and loads the mnemonic; recovery contacts are
 /// initiated separately via the daemon API.
-pub async fn import_from_mnemonic(words: Vec<String>, _recover: bool) -> Result<IdentityInfo> {
-    load_identity_from_mnemonic(words, 0, false, None).await
+pub async fn import_from_mnemonic(words: Vec<String>, recover: bool) -> Result<IdentityInfo> {
+    // Source the authoritative privacy mode BEFORE loading, so the imported
+    // identity reflects the current session's mode and the recovery guard is
+    // enforced consistently (a hardcoded `false` here left info.privacy_mode
+    // always false, so the guard below could never fire — while
+    // restore_session() reads the real flag from reputation::get_privacy_mode()).
+    let privacy_mode = crate::api::reputation::get_privacy_mode();
+    let info = load_identity_from_mnemonic(words, 0, privacy_mode, None).await?;
+    if recover {
+        // Recovery is only possible in Reputation mode; Full-Privacy trades
+        // are anonymous by design and cannot be replayed by the daemon.
+        if privacy_mode {
+            bail!("PrivacyModeRecoveryUnavailable");
+        }
+        crate::api::orders::restore_session().await?;
+    }
+    Ok(info)
 }
 
 /// Import identity from an nsec (bech32-encoded Nostr secret key).

--- a/rust/src/api/identity.rs
+++ b/rust/src/api/identity.rs
@@ -165,19 +165,18 @@ pub async fn load_identity_from_mnemonic(
 /// Currently this validates and loads the mnemonic; recovery contacts are
 /// initiated separately via the daemon API.
 pub async fn import_from_mnemonic(words: Vec<String>, recover: bool) -> Result<IdentityInfo> {
-    // Source the authoritative privacy mode BEFORE loading, so the imported
-    // identity reflects the current session's mode and the recovery guard is
-    // enforced consistently (a hardcoded `false` here left info.privacy_mode
-    // always false, so the guard below could never fire — while
-    // restore_session() reads the real flag from reputation::get_privacy_mode()).
+    // Source the authoritative privacy mode up front. Recovery is only possible
+    // in Reputation mode; Full-Privacy trades are anonymous by design and can't
+    // be replayed by the daemon.
     let privacy_mode = crate::api::reputation::get_privacy_mode();
+    // Reject privacy-mode recovery BEFORE loading — otherwise the identity is
+    // already swapped when we bail, leaving the user in a mutated state, and it
+    // violates the "reject before any network traffic" contract for restore.
+    if recover && privacy_mode {
+        bail!("PrivacyModeRecoveryUnavailable");
+    }
     let info = load_identity_from_mnemonic(words, 0, privacy_mode, None).await?;
     if recover {
-        // Recovery is only possible in Reputation mode; Full-Privacy trades
-        // are anonymous by design and cannot be replayed by the daemon.
-        if privacy_mode {
-            bail!("PrivacyModeRecoveryUnavailable");
-        }
         crate::api::orders::restore_session().await?;
     }
     Ok(info)

--- a/rust/src/api/identity.rs
+++ b/rust/src/api/identity.rs
@@ -177,6 +177,12 @@ pub async fn import_from_mnemonic(words: Vec<String>, recover: bool) -> Result<I
     }
     let info = load_identity_from_mnemonic(words, 0, privacy_mode, None).await?;
     if recover {
+        // NOTE: recovery is best-effort relative to the import, but this `?`
+        // propagates a restore failure AFTER the identity has already been
+        // swapped — so a slow/unreachable daemon makes the caller see "import
+        // failed" when the import itself succeeded and only recovery didn't.
+        // Not reachable today (identity_service.dart passes recover: false).
+        // #219 restructures the waiting; revisit this propagation when it lands.
         crate::api::orders::restore_session().await?;
     }
     Ok(info)

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -53,6 +53,10 @@ enum DaemonReply {
     Acknowledged,
     /// Daemon rejected the request with a CantDo reason.
     Rejected { reason: String, message: String },
+    /// Daemon replied to a RestoreSession with the user's active trades and
+    /// disputes. Correlated by identity pubkey (RestoreSession carries no
+    /// request_id) — see take_matching_restore.
+    Restored(mostro_core::message::RestoreSessionInfo),
 }
 
 /// What kind of outgoing request a pending record tracks.
@@ -72,6 +76,10 @@ enum PendingRequestKind {
     Take,
     /// A buyer's add-invoice awaiting the daemon's acknowledgement.
     AddInvoice,
+    /// A session-restore awaiting the daemon's RestoreData reply. Correlated
+    /// by identity pubkey, not request_id (the RestoreSession message carries
+    /// no request_id — see mostro-core Message::new_restore).
+    Restore,
 }
 
 /// Everything one outgoing daemon request needs tracked until its reply is
@@ -124,6 +132,18 @@ fn request_id_matches(expected: u64, got: Option<u64>) -> bool {
 /// in place: relays can replay historical events, and a stale reply must not
 /// confirm, reject, or reconcile a live request — the genuine reply (carrying
 /// the nonce) arrives later and finds the record.
+/// Remove and return the pending RESTORE request for `pubkey_hex`. Unlike
+/// `take_matching_request`, there is no request_id gate: the RestoreSession
+/// message carries no request_id, so the daemon's RestoreData reply is
+/// correlated purely by the identity pubkey it is addressed to.
+fn take_matching_restore(pubkey_hex: &str) -> Option<PendingRequest> {
+    let mut map = pending_requests().lock().ok()?;
+    match map.get(pubkey_hex) {
+        Some(p) if matches!(p.kind, PendingRequestKind::Restore) => map.remove(pubkey_hex),
+        _ => None,
+    }
+}
+
 fn take_matching_request(trade_pubkey_hex: &str, got: Option<u64>) -> Option<PendingRequest> {
     let mut map = pending_requests().lock().ok()?;
     match map.get(trade_pubkey_hex) {
@@ -1745,6 +1765,44 @@ async fn dispatch_mostro_message(
                 log::warn!("[orders] gift-wrap NewOrder has no order id");
             }
         }
+        Action::RestoreSession => {
+            // Daemon's restore reply (mostro send_restore_session_response ->
+            // Message::new_restore(RestoreData), addressed to the sending trade
+            // key). Correlated by trade pubkey only — RestoreSession carries no
+            // request_id — so take_matching_restore skips the nonce gate.
+            match &kind.payload {
+                Some(mostro_core::message::Payload::RestoreData(info)) => {
+                    if let Some(pending) = take_matching_restore(trade_pubkey_hex) {
+                        if let Some(tx) = pending.tx {
+                            let _ = tx.send(DaemonReply::Restored(info.clone()));
+                            crate::api::logging::blog_info("gift-wrap", format!(
+                                "RestoreData: notified waiting restore_session ({} orders, {} disputes)",
+                                info.restore_orders.len(),
+                                info.restore_disputes.len()
+                            ));
+                        } else {
+                            // Post-timeout late reply: the caller already
+                            // returned NoDaemonResponse and detached its waiter.
+                            // Logged for parity with the NewOrder/take/add-invoice arms.
+                            crate::api::logging::blog_info("gift-wrap", format!(
+                                "RestoreData: late reply for timed-out restore on trade={}",
+                                &trade_pubkey_hex[..8]
+                            ));
+                        }
+                    } else {
+                        crate::api::logging::blog_info("gift-wrap", format!(
+                            "RestoreData with no waiting caller for trade={}",
+                            &trade_pubkey_hex[..8]
+                        ));
+                    }
+                }
+                _ => {
+                    log::warn!(
+                        "[orders] RestoreSession reply payload is not RestoreData for trade={trade_pubkey_hex}"
+                    );
+                }
+            }
+        }
         Action::Canceled => {
             log::info!("[orders] gift-wrap Canceled for trade={trade_pubkey_hex}");
             if let Some(order_id) = &kind.id {
@@ -3315,5 +3373,153 @@ mod tests {
         )
         .await;
         // If we reach here without panicking the test passes.
+    }
+}
+
+/// Send a `RestoreSession` to the active daemon and return the user's active
+/// trades/disputes. Mirrors create_order's send/await, minus the order payload.
+///
+/// Correlation: the request is sent from a fresh TRADE key (event.sender) while
+/// the Seal carries the IDENTITY key (event.identity). The daemon looks up
+/// trades by identity/master key and replies to the trade key
+/// (mostro restore_session.rs: master_key = event.identity, reply -> event.sender),
+/// so we subscribe on the trade key and correlate the reply by that pubkey.
+#[flutter_rust_bridge::frb(ignore)]
+pub async fn restore_session() -> Result<mostro_core::message::RestoreSessionInfo> {
+    // Fresh trade key -> event.sender (daemon replies here).
+    let trade_key_info = crate::api::identity::derive_trade_key().await?;
+    let trade_index = trade_key_info.index;
+    let sender_keys = crate::api::identity::get_active_trade_keys(trade_index).await?;
+    let trade_pk_hex = sender_keys.public_key().to_hex();
+
+    let mostro_pubkey = nostr_sdk::PublicKey::from_hex(&active_mostro_pubkey())?;
+    // Identity/transport keys sign the Seal -> event.identity (master key).
+    let identity_keys =
+        crate::api::identity::get_transport_identity_keys(&sender_keys).await?;
+
+    let event_json =
+        actions::restore_session(&identity_keys, &sender_keys, &mostro_pubkey).await?;
+
+    // Register the pending-restore record BEFORE publishing so the reply can't
+    // race the map. Correlated by trade pubkey only (RestoreSession carries no
+    // request_id) -> take_matching_restore.
+    let (conf_tx, conf_rx) = tokio::sync::oneshot::channel::<DaemonReply>();
+    if let Ok(mut map) = pending_requests().lock() {
+        map.insert(
+            trade_pk_hex.clone(),
+            PendingRequest {
+                request_id: 0,
+                trade_index,
+                kind: PendingRequestKind::Restore,
+                tx: Some(conf_tx),
+            },
+        );
+    }
+
+    subscribe_gift_wraps(sender_keys.public_key(), trade_index).await;
+
+    if let Err(e) = publish_event_json(&event_json).await {
+        remove_pending_request(&trade_pk_hex, 0);
+        return Err(e);
+    }
+    crate::api::logging::blog_info(
+        "restore",
+        format!("RestoreSession published trade_index={trade_index} — waiting for daemon"),
+    );
+
+    let confirmation = crate::rt::time::timeout(
+        std::time::Duration::from_secs(10),
+        conf_rx,
+    ).await;
+
+    if !matches!(confirmation, Ok(Ok(_))) {
+        detach_request_waiter(&trade_pk_hex, 0);
+    }
+
+    match confirmation {
+        Ok(Ok(DaemonReply::Restored(info))) => Ok(info),
+        Ok(Ok(_other)) => Err(anyhow::anyhow!("unexpected restore reply")),
+        _ => Err(anyhow::anyhow!("NoDaemonResponse")),
+    }
+}
+
+#[cfg(test)]
+mod restore_e2e_tests {
+    //! E2E smoke test for the RestoreSession handshake (#142).
+    //! Requires a live regtest stack: mostrod + relay on ws://localhost:7000.
+    //! Run with:  cargo test --lib restore_session_roundtrip -- --ignored --nocapture
+    //! Ignored by default so it never runs in CI without the stack.
+    use super::*;
+
+    #[tokio::test]
+    #[ignore = "requires live regtest daemon + relay on ws://localhost:7000"]
+    async fn restore_session_roundtrip() {
+        // Point ONLY at the local regtest relay.
+        crate::api::nostr::initialize(Some(vec!["ws://localhost:7000".to_string()]))
+            .await
+            .expect("relay pool init");
+
+        // Regtest daemon pubkey (from mostrod startup logs).
+        crate::config::set_active_mostro_pubkey(Some(
+            "bae71ea2566771ed45b1d267dc0c0753028fe960a7bc4aeee08a44da0cb91520".to_string(),
+        ));
+
+        // Fresh in-memory identity (no keyring needed — Rust never persists it).
+        let id = crate::api::identity::create_identity().await.expect("create identity");
+        println!("[test] created identity pubkey={}", id.public_key);
+
+        // Let the relay connection settle.
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+
+        // Fire the handshake.
+        println!("[test] calling restore_session()...");
+        let result = restore_session().await;
+        println!("[test] restore_session result: {:?}", result.is_ok());
+
+        match result {
+            Ok(info) => {
+                println!(
+                    "[test] ✓ round-trip OK — {} orders, {} disputes",
+                    info.restore_orders.len(),
+                    info.restore_disputes.len()
+                );
+            }
+            Err(e) => panic!("[test] restore_session failed: {e}"),
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "requires live regtest daemon + relay on ws://localhost:7000"]
+    async fn trade_then_restore_recovers_order() {
+        crate::api::nostr::initialize(Some(vec!["ws://localhost:7000".to_string()]))
+            .await
+            .expect("relay pool init");
+        crate::config::set_active_mostro_pubkey(Some(
+            "bae71ea2566771ed45b1d267dc0c0753028fe960a7bc4aeee08a44da0cb91520".to_string(),
+        ));
+        let id = crate::api::identity::create_identity().await.expect("create identity");
+        println!("[test] identity A pubkey={}", id.public_key);
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        let params = crate::api::types::NewOrderParams {
+            kind: crate::api::types::OrderKind::Sell,
+            fiat_amount: Some(100.0),
+            fiat_amount_min: None,
+            fiat_amount_max: None,
+            fiat_code: "USD".to_string(),
+            payment_method: "cash".to_string(),
+            premium: 0.0,
+            amount_sats: None,
+        };
+        println!("[test] creating order...");
+        let order = create_order(params).await.expect("create_order (may need bond flow)");
+        println!("[test] order created id={}", order.id);
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        println!("[test] calling restore_session()...");
+        let info = restore_session().await.expect("restore round-trip");
+        println!("[test] restored {} orders", info.restore_orders.len());
+        for o in &info.restore_orders {
+            println!("[test]   order_id={} status={}", o.order_id, o.status);
+        }
+        assert!(!info.restore_orders.is_empty(), "restore should recover the created order");
     }
 }

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -54,7 +54,7 @@ enum DaemonReply {
     /// Daemon rejected the request with a CantDo reason.
     Rejected { reason: String, message: String },
     /// Daemon replied to a RestoreSession with the user's active trades and
-    /// disputes. Correlated by identity pubkey (RestoreSession carries no
+    /// disputes. Correlated by trade pubkey (RestoreSession carries no
     /// request_id) — see take_matching_restore.
     Restored(mostro_core::message::RestoreSessionInfo),
 }
@@ -77,7 +77,7 @@ enum PendingRequestKind {
     /// A buyer's add-invoice awaiting the daemon's acknowledgement.
     AddInvoice,
     /// A session-restore awaiting the daemon's RestoreData reply. Correlated
-    /// by identity pubkey, not request_id (the RestoreSession message carries
+    /// by trade pubkey, not request_id (the RestoreSession message carries
     /// no request_id — see mostro-core Message::new_restore).
     Restore,
 }
@@ -127,15 +127,10 @@ fn request_id_matches(expected: u64, got: Option<u64>) -> bool {
     got == Some(expected)
 }
 
-/// Remove and return the pending request for `trade_pubkey_hex` **only** when
-/// `got` echoes its `request_id`. A mismatched or absent id leaves the record
-/// in place: relays can replay historical events, and a stale reply must not
-/// confirm, reject, or reconcile a live request — the genuine reply (carrying
-/// the nonce) arrives later and finds the record.
 /// Remove and return the pending RESTORE request for `pubkey_hex`. Unlike
 /// `take_matching_request`, there is no request_id gate: the RestoreSession
 /// message carries no request_id, so the daemon's RestoreData reply is
-/// correlated purely by the identity pubkey it is addressed to.
+/// correlated purely by the trade pubkey it is addressed to.
 fn take_matching_restore(pubkey_hex: &str) -> Option<PendingRequest> {
     let mut map = pending_requests().lock().ok()?;
     match map.get(pubkey_hex) {
@@ -144,6 +139,11 @@ fn take_matching_restore(pubkey_hex: &str) -> Option<PendingRequest> {
     }
 }
 
+/// Remove and return the pending request for `trade_pubkey_hex` **only** when
+/// `got` echoes its `request_id`. A mismatched or absent id leaves the record
+/// in place: relays can replay historical events, and a stale reply must not
+/// confirm, reject, or reconcile a live request — the genuine reply (carrying
+/// the nonce) arrives later and finds the record.
 fn take_matching_request(trade_pubkey_hex: &str, got: Option<u64>) -> Option<PendingRequest> {
     let mut map = pending_requests().lock().ok()?;
     match map.get(trade_pubkey_hex) {
@@ -1786,13 +1786,13 @@ async fn dispatch_mostro_message(
                             // Logged for parity with the NewOrder/take/add-invoice arms.
                             crate::api::logging::blog_info("gift-wrap", format!(
                                 "RestoreData: late reply for timed-out restore on trade={}",
-                                &trade_pubkey_hex[..8]
+                                trade_pubkey_hex.get(..8).unwrap_or(trade_pubkey_hex)
                             ));
                         }
                     } else {
                         crate::api::logging::blog_info("gift-wrap", format!(
                             "RestoreData with no waiting caller for trade={}",
-                            &trade_pubkey_hex[..8]
+                            trade_pubkey_hex.get(..8).unwrap_or(trade_pubkey_hex)
                         ));
                     }
                 }
@@ -2919,6 +2919,86 @@ pub async fn get_trade_role(order_id: String) -> Result<Option<crate::api::types
     }
 }
 
+/// Send a `RestoreSession` to the active daemon and return the user's active
+/// trades/disputes. Mirrors create_order's send/await, minus the order payload.
+///
+/// Correlation: the request is sent from a fresh TRADE key (event.sender) while
+/// the Seal carries the IDENTITY key (event.identity). The daemon looks up
+/// trades by identity/master key and replies to the trade key
+/// (mostro restore_session.rs: master_key = event.identity, reply -> event.sender),
+/// so we subscribe on the trade key and correlate the reply by that pubkey.
+#[flutter_rust_bridge::frb(ignore)]
+pub async fn restore_session() -> Result<mostro_core::message::RestoreSessionInfo> {
+    // Fresh trade key -> event.sender (daemon replies here).
+    let trade_key_info = crate::api::identity::derive_trade_key().await?;
+    let trade_index = trade_key_info.index;
+    let sender_keys = crate::api::identity::get_active_trade_keys(trade_index).await?;
+    let trade_pk_hex = sender_keys.public_key().to_hex();
+
+    let mostro_pubkey = nostr_sdk::PublicKey::from_hex(&active_mostro_pubkey())?;
+    // Identity/transport keys sign the Seal -> event.identity (master key).
+    let identity_keys =
+        crate::api::identity::get_transport_identity_keys(&sender_keys).await?;
+
+    let event_json =
+        actions::restore_session(&identity_keys, &sender_keys, &mostro_pubkey).await?;
+
+    // Register the pending-restore record BEFORE publishing so the reply can't
+    // race the map. Correlated by trade pubkey only (RestoreSession carries no
+    // request_id) -> take_matching_restore.
+    let (conf_tx, conf_rx) = tokio::sync::oneshot::channel::<DaemonReply>();
+    // If the lock is poisoned we can't register the pending record, so the
+    // reply could never be correlated — bail rather than publish an event
+    // that would strand the caller for the full timeout only to report
+    // NoDaemonResponse (a lock bug wearing a network bug's mask).
+    {
+        let mut map = pending_requests()
+            .lock()
+            .map_err(|_| anyhow::anyhow!("PendingRequestsLockPoisoned"))?;
+        map.insert(
+            trade_pk_hex.clone(),
+            PendingRequest {
+                request_id: 0,
+                trade_index,
+                kind: PendingRequestKind::Restore,
+                tx: Some(conf_tx),
+            },
+        );
+    }
+
+    subscribe_gift_wraps(sender_keys.public_key(), trade_index).await;
+
+    if let Err(e) = publish_event_json(&event_json).await {
+        remove_pending_request(&trade_pk_hex, 0);
+        return Err(e);
+    }
+    crate::api::logging::blog_info(
+        "restore",
+        format!("RestoreSession published trade_index={trade_index} — waiting for daemon"),
+    );
+
+    let confirmation = crate::rt::time::timeout(
+        std::time::Duration::from_secs(10),
+        conf_rx,
+    ).await;
+
+    if !matches!(confirmation, Ok(Ok(_))) {
+        detach_request_waiter(&trade_pk_hex, 0);
+    }
+
+    match confirmation {
+        Ok(Ok(DaemonReply::Restored(info))) => Ok(info),
+        Ok(Ok(DaemonReply::Rejected { reason, message })) => {
+            crate::api::logging::blog_warn("orders", format!(
+                "restore_session rejected: {reason} — {message}"
+            ));
+            Err(anyhow::anyhow!("{message}"))
+        }
+        Ok(Ok(_other)) => Err(anyhow::anyhow!("unexpected restore reply")),
+        _ => Err(anyhow::anyhow!("NoDaemonResponse")),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3374,78 +3454,54 @@ mod tests {
         .await;
         // If we reach here without panicking the test passes.
     }
-}
 
-/// Send a `RestoreSession` to the active daemon and return the user's active
-/// trades/disputes. Mirrors create_order's send/await, minus the order payload.
-///
-/// Correlation: the request is sent from a fresh TRADE key (event.sender) while
-/// the Seal carries the IDENTITY key (event.identity). The daemon looks up
-/// trades by identity/master key and replies to the trade key
-/// (mostro restore_session.rs: master_key = event.identity, reply -> event.sender),
-/// so we subscribe on the trade key and correlate the reply by that pubkey.
-#[flutter_rust_bridge::frb(ignore)]
-pub async fn restore_session() -> Result<mostro_core::message::RestoreSessionInfo> {
-    // Fresh trade key -> event.sender (daemon replies here).
-    let trade_key_info = crate::api::identity::derive_trade_key().await?;
-    let trade_index = trade_key_info.index;
-    let sender_keys = crate::api::identity::get_active_trade_keys(trade_index).await?;
-    let trade_pk_hex = sender_keys.public_key().to_hex();
+    /// `take_matching_restore` returns and removes a pending RESTORE record for
+    /// the given trade pubkey, and ignores non-RESTORE kinds — the nonce-gate
+    /// asymmetry #215 relies on (RestoreSession carries no request_id).
+    #[test]
+    fn take_matching_restore_returns_restore_and_ignores_others() {
+        // Distinct keys so the shared global map can't collide across tests.
+        let restore_key = "ra".repeat(32); // 64-char hex, unique to this test
+        let other_key = "cb".repeat(32);
 
-    let mostro_pubkey = nostr_sdk::PublicKey::from_hex(&active_mostro_pubkey())?;
-    // Identity/transport keys sign the Seal -> event.identity (master key).
-    let identity_keys =
-        crate::api::identity::get_transport_identity_keys(&sender_keys).await?;
-
-    let event_json =
-        actions::restore_session(&identity_keys, &sender_keys, &mostro_pubkey).await?;
-
-    // Register the pending-restore record BEFORE publishing so the reply can't
-    // race the map. Correlated by trade pubkey only (RestoreSession carries no
-    // request_id) -> take_matching_restore.
-    let (conf_tx, conf_rx) = tokio::sync::oneshot::channel::<DaemonReply>();
-    if let Ok(mut map) = pending_requests().lock() {
-        map.insert(
-            trade_pk_hex.clone(),
-            PendingRequest {
-                request_id: 0,
-                trade_index,
-                kind: PendingRequestKind::Restore,
-                tx: Some(conf_tx),
-            },
-        );
-    }
-
-    subscribe_gift_wraps(sender_keys.public_key(), trade_index).await;
-
-    if let Err(e) = publish_event_json(&event_json).await {
-        remove_pending_request(&trade_pk_hex, 0);
-        return Err(e);
-    }
-    crate::api::logging::blog_info(
-        "restore",
-        format!("RestoreSession published trade_index={trade_index} — waiting for daemon"),
-    );
-
-    let confirmation = crate::rt::time::timeout(
-        std::time::Duration::from_secs(10),
-        conf_rx,
-    ).await;
-
-    if !matches!(confirmation, Ok(Ok(_))) {
-        detach_request_waiter(&trade_pk_hex, 0);
-    }
-
-    match confirmation {
-        Ok(Ok(DaemonReply::Restored(info))) => Ok(info),
-        Ok(Ok(DaemonReply::Rejected { reason, message })) => {
-            crate::api::logging::blog_warn("orders", format!(
-                "restore_session rejected: {reason} — {message}"
-            ));
-            Err(anyhow::anyhow!("{message}"))
+        {
+            let mut map = pending_requests().lock().unwrap();
+            map.insert(
+                restore_key.clone(),
+                PendingRequest {
+                    request_id: 0,
+                    trade_index: 7,
+                    kind: PendingRequestKind::Restore,
+                    tx: None,
+                },
+            );
+            map.insert(
+                other_key.clone(),
+                PendingRequest {
+                    request_id: 9,
+                    trade_index: 3,
+                    kind: PendingRequestKind::Create {
+                        local_uuid: "uuid".to_string(),
+                        content_key: "ck".to_string(),
+                    },
+                    tx: None,
+                },
+            );
         }
-        Ok(Ok(_other)) => Err(anyhow::anyhow!("unexpected restore reply")),
-        _ => Err(anyhow::anyhow!("NoDaemonResponse")),
+
+        // A non-RESTORE kind on other_key is never matched by take_matching_restore.
+        assert!(take_matching_restore(&other_key).is_none());
+
+        // The RESTORE record is returned...
+        let taken = take_matching_restore(&restore_key);
+        assert!(taken.is_some());
+        assert!(matches!(taken.unwrap().kind, PendingRequestKind::Restore));
+
+        // ...and removed on take (second call finds nothing).
+        assert!(take_matching_restore(&restore_key).is_none());
+
+        // Clean up the leftover non-restore record so we don't leak global state.
+        let _ = remove_pending_request(&other_key, 9);
     }
 }
 

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -3438,6 +3438,9 @@ pub async fn restore_session() -> Result<mostro_core::message::RestoreSessionInf
 
     match confirmation {
         Ok(Ok(DaemonReply::Restored(info))) => Ok(info),
+        Ok(Ok(DaemonReply::Rejected { reason, message })) => {
+            Err(anyhow::anyhow!("CantDo:{reason}: {message}"))
+        }
         Ok(Ok(_other)) => Err(anyhow::anyhow!("unexpected restore reply")),
         _ => Err(anyhow::anyhow!("NoDaemonResponse")),
     }

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -3439,7 +3439,10 @@ pub async fn restore_session() -> Result<mostro_core::message::RestoreSessionInf
     match confirmation {
         Ok(Ok(DaemonReply::Restored(info))) => Ok(info),
         Ok(Ok(DaemonReply::Rejected { reason, message })) => {
-            Err(anyhow::anyhow!("CantDo:{reason}: {message}"))
+            crate::api::logging::blog_warn("orders", format!(
+                "restore_session rejected: {reason} — {message}"
+            ));
+            Err(anyhow::anyhow!("{message}"))
         }
         Ok(Ok(_other)) => Err(anyhow::anyhow!("unexpected restore reply")),
         _ => Err(anyhow::anyhow!("NoDaemonResponse")),

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -2031,12 +2031,17 @@ async fn dispatch_mostro_message(
                 other => format!("Order rejected by Mostro: {other}"),
             };
 
-            // Consume the pending request ONLY when this rejection echoes its
-            // request_id — a genuine rejection ends the attempt, so the whole
-            // record goes with it (whatever its kind). Stale replayed CantDo
-            // events (no or foreign request_id) touch nothing and leave the
-            // record for the genuine reply.
-            if let Some(pending) = take_matching_request(trade_pubkey_hex, kind.request_id) {
+            // Consume the pending request on a genuine rejection. A restore is
+            // nonce-less (RestoreSession carries no request_id), so its record
+            // is correlated by trade pubkey via take_matching_restore — try that
+            // first. It only matches a Restore record, so order requests keep
+            // their nonce gate: a stale replayed CantDo (no or foreign
+            // request_id) still touches nothing and leaves the order record for
+            // the genuine reply. For non-restore requests the nonce-gated
+            // take_matching_request path is unchanged.
+            let matched = take_matching_restore(trade_pubkey_hex)
+                .or_else(|| take_matching_request(trade_pubkey_hex, kind.request_id));
+            if let Some(pending) = matched {
                 if let Some(tx) = pending.tx {
                     crate::api::logging::blog_warn("gift-wrap", format!(
                         "CantDo: reason={reason} — notifying waiting caller"
@@ -3051,6 +3056,42 @@ mod tests {
             },
         );
         rx
+    }
+
+    /// #215: a restore is nonce-less, so `take_matching_restore` must match its
+    /// pending record by trade pubkey alone — that is what lets a `CantDo`
+    /// rejecting a restore reach the waiter instead of timing out. It must NOT
+    /// match a non-restore record, so order requests keep their nonce gate.
+    #[tokio::test]
+    async fn take_matching_restore_matches_restore_records_only() {
+        let restore_key = "test-restore-pubkey";
+        let order_key = "test-order-pubkey";
+
+        // A pending Restore record (request_id 0, nonce-less).
+        let (rtx, _rrx) = tokio::sync::oneshot::channel::<DaemonReply>();
+        pending_requests().lock().unwrap().insert(
+            restore_key.to_string(),
+            PendingRequest {
+                request_id: 0,
+                trade_index: 4,
+                kind: PendingRequestKind::Restore,
+                tx: Some(rtx),
+            },
+        );
+        // A pending non-restore (Create) record on a different pubkey.
+        let _orx = insert_pending_create(order_key, 7);
+
+        // take_matching_restore ignores the order record (wrong kind)...
+        assert!(take_matching_restore(order_key).is_none());
+        assert!(pending_requests().lock().unwrap().contains_key(order_key));
+        // ...and matches the restore record with no request_id involved.
+        let taken = take_matching_restore(restore_key).expect("restore must match");
+        assert!(matches!(taken.kind, PendingRequestKind::Restore));
+        // Consumed on take (the CantDo path removes it exactly once).
+        assert!(take_matching_restore(restore_key).is_none());
+
+        // Cleanup the order record so global state does not leak to other tests.
+        let _ = take_matching_request(order_key, Some(7));
     }
 
     /// A reply with a foreign or missing request_id must leave the record in

--- a/rust/src/mostro/actions.rs
+++ b/rust/src/mostro/actions.rs
@@ -459,3 +459,22 @@ mod tests {
         assert!(matches!(kind.payload, Some(Payload::Amount(100))));
     }
 }
+
+/// Build a `RestoreSession` request (mostro-core `Message::new_restore`).
+///
+/// Payload MUST be `None` — the daemon rejects any other payload
+/// (`MessageKind::verify`). The Seal is signed by the identity key (used by
+/// the daemon to look up the user's trades); the rumor is signed by a fresh
+/// trade key, and the daemon's restore reply is addressed to that trade key.
+/// Returns the NIP-59 Gift Wrap event JSON.
+pub async fn restore_session(
+    identity_keys: &Keys,
+    trade_keys: &Keys,
+    mostro_pubkey: &PublicKey,
+) -> Result<String> {
+    // identity_keys sign the Seal (-> event.identity = master key, used by the
+    // daemon to look up the user's trades); trade_keys sign the rumor
+    // (-> event.sender, the key the daemon replies to). Mirrors new_order.
+    let msg = Message::new_restore(None);
+    wrap_message(identity_keys, trade_keys, mostro_pubkey, &msg).await
+}

--- a/rust/src/mostro/actions.rs
+++ b/rust/src/mostro/actions.rs
@@ -503,6 +503,9 @@ mod tests {
         // The rumor is authored by the trade key: that is the pubkey the daemon
         // replies to, and what the client subscribes/correlates on.
         assert_eq!(unwrapped.sender, trade_keys.public_key());
+        // The Seal carries the identity key: that is what the daemon uses to
+        // locate the user's trades. Both halves of the key split matter.
+        assert_eq!(unwrapped.identity, identity_keys.public_key());
     }
 }
 

--- a/rust/src/mostro/actions.rs
+++ b/rust/src/mostro/actions.rs
@@ -1,8 +1,9 @@
 /// Mostro action dispatch — builds and wraps `mostro_core::Message` values.
 ///
 /// Each function constructs a `Message` using the `mostro-core` types,
-/// wraps it via NIP-59 Gift Wrap using `mostro_core::nip59::wrap_message`,
-/// and returns the event JSON ready for publication.
+/// wraps it as a transport-v2 (NIP-44, signed Kind 14) event via
+/// `gift_wrap::wrap_mostro_message`, and returns the event JSON ready for
+/// publication.
 ///
 /// **Key split.** Mostro-core 0.10 requires two `Keys` values per wrap:
 /// `identity_keys` sign the Seal (Kind 13) so the node can tie the rumor to
@@ -28,7 +29,7 @@ use crate::nostr::gift_wrap;
 /// `create_order` tells the genuine reply apart from stale relay-replayed
 /// events addressed to the same trade key.
 ///
-/// Returns the NIP-59 Gift Wrap event JSON ready for publication.
+/// Returns the transport-v2 (NIP-44, signed Kind 14) event JSON ready for publication.
 pub async fn new_order(
     identity_keys: &Keys,
     trade_keys: &Keys,
@@ -216,7 +217,7 @@ pub async fn dispute(
 /// Build and wrap a RateUser MostroMessage.
 ///
 /// Sends a 1–5 star rating for the counterparty to the Mostro daemon via
-/// NIP-59 Gift Wrap after a trade completes.
+/// the transport-v2 (NIP-44, signed Kind 14) wrap after a trade completes.
 pub async fn rate_user(
     identity_keys: &Keys,
     trade_keys: &Keys,
@@ -337,8 +338,9 @@ async fn simple_action(
     wrap_message(identity_keys, trade_keys, mostro_pubkey, &msg).await
 }
 
-/// Wrap `msg` as a NIP-59 Gift Wrap via `mostro_core::nip59::wrap_message`,
-/// applying the daemon-advertised PoW difficulty, and return the event JSON.
+/// Wrap `msg` as a transport-v2 (NIP-44, signed Kind 14) event via
+/// `gift_wrap::wrap_mostro_message`, applying the daemon-advertised PoW
+/// difficulty, and return the event JSON.
 async fn wrap_message(
     identity_keys: &Keys,
     trade_keys: &Keys,
@@ -349,6 +351,25 @@ async fn wrap_message(
     let event =
         gift_wrap::wrap_mostro_message(identity_keys, trade_keys, mostro_pubkey, msg, pow).await?;
     Ok(event.as_json())
+}
+
+/// Build a `RestoreSession` request (mostro-core `Message::new_restore`).
+///
+/// Payload MUST be `None` — the daemon rejects any other payload
+/// (`MessageKind::verify`). The Seal is signed by the identity key (used by
+/// the daemon to look up the user's trades); the rumor is signed by a fresh
+/// trade key, and the daemon's restore reply is addressed to that trade key.
+/// Returns the transport-v2 (NIP-44, signed Kind 14) event JSON.
+pub async fn restore_session(
+    identity_keys: &Keys,
+    trade_keys: &Keys,
+    mostro_pubkey: &PublicKey,
+) -> Result<String> {
+    // identity_keys sign the Seal (-> event.identity = master key, used by the
+    // daemon to look up the user's trades); trade_keys sign the rumor
+    // (-> event.sender, the key the daemon replies to). Mirrors new_order.
+    let msg = Message::new_restore(None);
+    wrap_message(identity_keys, trade_keys, mostro_pubkey, &msg).await
 }
 
 #[cfg(test)]
@@ -458,23 +479,30 @@ mod tests {
         assert!(matches!(kind.action, Action::TakeBuy));
         assert!(matches!(kind.payload, Some(Payload::Amount(100))));
     }
+
+    /// #215 handshake contract: a RestoreSession carries no payload (the daemon
+    /// rejects anything else in `MessageKind::verify`), its action is
+    /// `RestoreSession`, and the rumor is authored by the trade key — the
+    /// `event.sender` the daemon addresses its RestoreData reply to.
+    #[tokio::test]
+    async fn restore_session_payload_none_action_restore_rumor_by_trade_key() {
+        let identity_keys = Keys::generate();
+        let trade_keys = Keys::generate();
+        let mostro_keys = Keys::generate();
+        let json = restore_session(&identity_keys, &trade_keys, &mostro_keys.public_key())
+            .await
+            .unwrap();
+        let event = Event::from_json(&json).unwrap();
+        let unwrapped = gift_wrap::unwrap_mostro_message(&mostro_keys, &event)
+            .await
+            .unwrap()
+            .expect("message must decrypt for the recipient");
+        let kind = unwrapped.message.get_inner_message_kind();
+        assert!(kind.payload.is_none(), "RestoreSession payload must be None");
+        assert!(matches!(kind.action, Action::RestoreSession));
+        // The rumor is authored by the trade key: that is the pubkey the daemon
+        // replies to, and what the client subscribes/correlates on.
+        assert_eq!(unwrapped.sender, trade_keys.public_key());
+    }
 }
 
-/// Build a `RestoreSession` request (mostro-core `Message::new_restore`).
-///
-/// Payload MUST be `None` — the daemon rejects any other payload
-/// (`MessageKind::verify`). The Seal is signed by the identity key (used by
-/// the daemon to look up the user's trades); the rumor is signed by a fresh
-/// trade key, and the daemon's restore reply is addressed to that trade key.
-/// Returns the NIP-59 Gift Wrap event JSON.
-pub async fn restore_session(
-    identity_keys: &Keys,
-    trade_keys: &Keys,
-    mostro_pubkey: &PublicKey,
-) -> Result<String> {
-    // identity_keys sign the Seal (-> event.identity = master key, used by the
-    // daemon to look up the user's trades); trade_keys sign the rumor
-    // (-> event.sender, the key the daemon replies to). Mirrors new_order.
-    let msg = Message::new_restore(None);
-    wrap_message(identity_keys, trade_keys, mostro_pubkey, &msg).await
-}


### PR DESCRIPTION
Refs #215 RestoreSession handshake (send, correlate reply, subscribe).

Re-lands the handshake from the closed #204, scoped to the handshake only no
reconstruction side effects (those are #217/#218/#219).

## What it does
Sends a `RestoreSession` request to the active daemon and correlates the
`RestoreData` reply. The Seal is signed by the identity key (daemon looks up
trades by master key); the rumor is signed by a fresh trade key (daemon replies
to `event.sender`). Correlation is by trade pubkey, not `request_id`
`RestoreSession` carries no `request_id`, so `take_matching_restore()` skips the
nonce gate.

## Scope
- `mostro::actions::restore_session()` `Message::new_restore(None)`
- `PendingRequestKind::Restore` + `take_matching_restore()`
- `Action::RestoreSession` arm in `dispatch_mostro_message()`
- subscribe on the fresh trade key + register the pending record before publishing
- privacy-mode guard returning `PrivacyModeRecoveryUnavailable` before any
  network traffic
- `restore_session()` stays `#[frb(ignore)]` (internal until UI wiring)

## Out of scope (separate sub-issues)
- `order_id -> trade_index` persistence
- retroactive `is_mine` on cached orders
- `trade_key_index` resync (#217)
- durable/background behaviour, progress, UI (#219)

## Note on state (corrects an inaccurate claim in an earlier revision)
`restore_session()` consumes one trade-key index via `derive_trade_key()`, which
increments and persists `trade_key_index`. This is inherent to the derivation
the daemon registers every index it sees, so the counter must survive even
timed-out operations. Restore is therefore **not** zero-side-effect: it burns one
index per attempt. #217's resync must be `max(recovered, current)`, never a plain
assignment, or it would rewind past an index consumed here (noted on #217). No
`is_mine` mutation and no reconstruction, as before.

Separately: `import_from_mnemonic` now sources the real `privacy_mode` (was
hardcoded `false`, which meant the recovery guard could never fire). This affects
the `recover: false` path Dart uses today an intentional fix; happy to split it
out if preferred.

## Tests
CI-runnable unit tests (no daemon needed):
- `restore_session_payload_none_action_restore_rumor_by_trade_key` asserts the
  payload is `None` (daemon rejects anything else in `MessageKind::verify`), the
  action is `RestoreSession`, the rumor is authored by the trade key
  (`event.sender`, the daemon's reply target), and the Seal is signed by the
  identity key (how the daemon locates the user's trades) both signing roles.
- `take_matching_restore_returns_restore_and_ignores_others` returns and removes
  a pending RESTORE record, ignores non-RESTORE kinds (pins the nonce-gate
  asymmetry).

`cargo test --lib` -> 113 passed, 0 failed (2 E2E tests still `#[ignore]`d, run
command documented in the test module). `cargo clippy` clean. Build clean, CI green.