### PR TITLE
ci(#154): run the web build on PRs and smoke-test the release bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,3 +131,15 @@ jobs:
 
       - name: Test
         run: flutter test
+
+  # Web is a first-class target (constitution, specs/004/plan.md), and its
+  # failure mode is a blank page that every static check passes. Building and
+  # smoke-testing it here means a PR that breaks the web target fails before it
+  # lands, instead of after deploy-pages.yml has already run on main (#154).
+  #
+  # Same reusable definition the deploy uses, so the two cannot drift apart.
+  web:
+    name: Web (wasm build / smoke test)
+    uses: ./.github/workflows/web-build.yml
+    permissions:
+      contents: read

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -5,6 +5,10 @@ name: Deploy web to GitHub Pages
 # The app is a pure client — outbound wss:// to Nostr relays, identity generated in the
 # browser, persistence in IndexedDB — so static hosting is enough (see issue #212).
 #
+# The bundle itself is built by the reusable web-build.yml, which CI also runs on
+# every pull request — so a web regression fails before it lands, and what CI
+# validates cannot drift from what gets published (issue #154).
+#
 # One-time repository setting this workflow depends on:
 #   Settings → Pages → Build and deployment → Source: "GitHub Actions"
 
@@ -13,7 +17,7 @@ on:
     branches: [main]
   workflow_dispatch:
 
-# Granted per job, not workflow-wide: the build job runs codegen and third-party
+# Granted per job, not workflow-wide: the build runs codegen and third-party
 # build scripts and has no business holding a Pages or OIDC write token.
 permissions: {}
 
@@ -23,133 +27,14 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
-env:
-  # Keep in sync with ci.yml.
-  FLUTTER_VERSION: "3.38.2"
-  RUST_VERSION: "1.97.0"
-  FRB_VERSION: "2.11.1"
-  CARGO_EXPAND_VERSION: "1.0.123"
-  # The version this pipeline was validated against locally.
-  WASM_PACK_VERSION: "0.15.0"
-
 jobs:
   build:
     name: Build web bundle
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/web-build.yml
     permissions:
       contents: read
-    # The first uncached run compiles std from source (-Z build-std), which is slow.
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      # Two toolchains are needed:
-      #   • pinned stable — flutter_rust_bridge_codegen shells out to `cargo expand`;
-      #   • nightly with rust-src — scripts/build-web.sh compiles the core to wasm
-      #     with -Z build-std (it selects nightly itself via RUSTUP_TOOLCHAIN).
-      # Nightly is installed first so the pinned stable stays the default toolchain.
-      - name: Install Rust nightly (wasm)
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          targets: wasm32-unknown-unknown
-          components: rust-src
-
-      - name: Install Rust ${{ env.RUST_VERSION }} (codegen)
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
-
-      - name: Cache cargo registry and target
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: rust
-
-      - name: Install Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: stable
-          cache: true
-
-      - name: Cache build tools
-        id: tools-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/flutter_rust_bridge_codegen
-            ~/.cargo/bin/cargo-expand
-            ~/.cargo/bin/wasm-pack
-          key: pages-tools-${{ runner.os }}-frb${{ env.FRB_VERSION }}-expand${{ env.CARGO_EXPAND_VERSION }}-wasmpack${{ env.WASM_PACK_VERSION }}
-
-      - name: Install build tools
-        if: steps.tools-cache.outputs.cache-hit != 'true'
-        run: |
-          cargo install flutter_rust_bridge_codegen --version "$FRB_VERSION" --locked
-          cargo install cargo-expand --version "$CARGO_EXPAND_VERSION" --locked
-          cargo install wasm-pack --version "$WASM_PACK_VERSION" --locked
-
-      - name: Resolve dependencies
-        run: flutter pub get
-
-      # lib/src/rust/ is gitignored and produced on the fly; without it the web
-      # build fails to compile. The script also verifies the FRB pins agree.
-      - name: Generate Rust bridge bindings
-        run: ./scripts/frb-generate.sh
-
-      # Compiles the Rust core to web/pkg/ with shared memory (wasm threads) and
-      # fails loudly if the emitted memory is not shared — the failure mode that
-      # otherwise only shows up at runtime as a blank page.
-      - name: Build Rust core to WASM (shared memory)
-        run: ./scripts/build-web.sh --release
-
-      # Project pages are served from a sub-path, so the base href must match the
-      # repository name or every asset 404s and the page stays blank.
-      #
-      # --pwa-strategy=none disables Flutter's (deprecated) service worker: it would
-      # register over the same scope as coi-serviceworker.min.js and evict the shim
-      # that supplies the COOP/COEP headers, un-isolating the page. Offline caching
-      # is the trade-off; cross-origin isolation is not optional here.
-      - name: Build Flutter web
-        run: |
-          flutter build web \
-            --release \
-            --base-href "/${GITHUB_REPOSITORY#*/}/" \
-            --pwa-strategy=none
-
-      # Guard the two silent-blank-page failure modes: the isolation shim must be
-      # in the bundle and referenced by index.html, and Flutter's service worker
-      # must not have been emitted alongside it.
-      - name: Verify bundle
-        run: |
-          set -euo pipefail
-          test -f build/web/coi-serviceworker.min.js \
-            || { echo "::error::coi-serviceworker.min.js missing from the bundle — the deployed page will not be cross-origin isolated."; exit 1; }
-          grep -q 'coi-serviceworker.min.js' build/web/index.html \
-            || { echo "::error::index.html does not load coi-serviceworker.min.js."; exit 1; }
-          # --pwa-strategy=none still emits flutter_service_worker.js (empty) and
-          # flutter_bootstrap.js still *embeds* flutter.js, whose minified loader
-          # mentions serviceWorkerSettings. The only meaningful signal is the
-          # generated call itself: `_flutter.loader.load()` with no settings.
-          loader_call="$(grep -o '_flutter\.loader\.load([^;]*)' build/web/flutter_bootstrap.js | tail -n 1)"
-          if [ -z "$loader_call" ]; then
-            echo "::error::flutter_bootstrap.js does not call _flutter.loader.load — the bundle layout changed; re-check this guard."
-            exit 1
-          fi
-          case "$loader_call" in
-            *serviceWorkerSettings*)
-              echo "::error::Flutter's service worker is being registered; it competes with the isolation shim for the same scope (expected --pwa-strategy=none)."
-              exit 1
-              ;;
-          esac
-          grep -q "base href=\"/${GITHUB_REPOSITORY#*/}/\"" build/web/index.html \
-            || { echo "::error::base href was not rewritten to the project sub-path — assets would 404."; exit 1; }
-          echo "Bundle looks deployable."
-
-      - uses: actions/upload-pages-artifact@v3
-        with:
-          path: build/web
+    with:
+      upload-pages-artifact: true
 
   deploy:
     name: Deploy to Pages

--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -173,6 +173,14 @@ jobs:
           # packages are not cached and are installed either way.
           npx playwright install --with-deps chromium
 
+      # Runs smoke.mjs against three static fixtures that differ by one thing
+      # each, and asserts the exit codes. Proves the gate still fails when it
+      # should — a healthy bundle passes whether or not the error checks work,
+      # so nothing else here would notice them rotting. Seconds, no build.
+      - name: Self-test the smoke test
+        working-directory: test/web/smoke
+        run: node selftest.mjs
+
       # Serves the release bundle cross-origin isolated under the production
       # sub-path, then asserts the page is isolated, the Flutter view mounted,
       # a Rust bridge call returned, and nothing errored.

--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -1,0 +1,197 @@
+name: Web build
+
+# Builds the web client (Rust core → wasm, then `flutter build web --release`),
+# verifies the bundle statically, and smoke-tests it in headless Chrome.
+#
+# Reusable on purpose (issue #154): ci.yml calls it on every pull request and
+# deploy-pages.yml calls it before publishing, so the bundle CI validates and
+# the bundle that ships come out of exactly the same steps. A copy-pasted build
+# job is a build that passes on PRs and breaks on deploy.
+
+on:
+  workflow_call:
+    inputs:
+      upload-pages-artifact:
+        description: >-
+          Upload build/web as a GitHub Pages artifact for a deploy job in the
+          calling workflow. Off by default — a pull request only needs the
+          build and the smoke test to pass.
+        type: boolean
+        default: false
+
+# The caller grants what it needs; this build runs codegen and third-party
+# build scripts and has no business holding a writable token.
+permissions: {}
+
+env:
+  # Keep in sync with ci.yml.
+  FLUTTER_VERSION: "3.38.2"
+  RUST_VERSION: "1.97.0"
+  FRB_VERSION: "2.11.1"
+  CARGO_EXPAND_VERSION: "1.0.123"
+  # The version this pipeline was validated against locally.
+  WASM_PACK_VERSION: "0.15.0"
+  NODE_VERSION: "22"
+  # Must match test/web/smoke/package.json — it keys the browser cache.
+  PLAYWRIGHT_VERSION: "1.56.0"
+
+jobs:
+  build:
+    name: Build and smoke-test web bundle
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # The first uncached run compiles std from source (-Z build-std), which is slow.
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # Two toolchains are needed:
+      #   • pinned stable — flutter_rust_bridge_codegen shells out to `cargo expand`;
+      #   • nightly with rust-src — scripts/build-web.sh compiles the core to wasm
+      #     with -Z build-std (it selects nightly itself via RUSTUP_TOOLCHAIN).
+      # Nightly is installed first so the pinned stable stays the default toolchain.
+      - name: Install Rust nightly (wasm)
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: wasm32-unknown-unknown
+          components: rust-src
+
+      - name: Install Rust ${{ env.RUST_VERSION }} (codegen)
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Cache build tools
+        id: tools-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/flutter_rust_bridge_codegen
+            ~/.cargo/bin/cargo-expand
+            ~/.cargo/bin/wasm-pack
+          key: web-tools-${{ runner.os }}-frb${{ env.FRB_VERSION }}-expand${{ env.CARGO_EXPAND_VERSION }}-wasmpack${{ env.WASM_PACK_VERSION }}
+
+      - name: Install build tools
+        if: steps.tools-cache.outputs.cache-hit != 'true'
+        run: |
+          cargo install flutter_rust_bridge_codegen --version "$FRB_VERSION" --locked
+          cargo install cargo-expand --version "$CARGO_EXPAND_VERSION" --locked
+          cargo install wasm-pack --version "$WASM_PACK_VERSION" --locked
+
+      - name: Resolve dependencies
+        run: flutter pub get
+
+      # lib/src/rust/ is gitignored and produced on the fly; without it the web
+      # build fails to compile. The script also verifies the FRB pins agree.
+      - name: Generate Rust bridge bindings
+        run: ./scripts/frb-generate.sh
+
+      # Compiles the Rust core to web/pkg/ with shared memory (wasm threads) and
+      # fails loudly if the emitted memory is not shared — the failure mode that
+      # otherwise only shows up at runtime as a blank page.
+      - name: Build Rust core to WASM (shared memory)
+        run: ./scripts/build-web.sh --release
+
+      # Project pages are served from a sub-path, so the base href must match the
+      # repository name or every asset 404s and the page stays blank.
+      #
+      # --pwa-strategy=none disables Flutter's (deprecated) service worker: it would
+      # register over the same scope as coi-serviceworker.min.js and evict the shim
+      # that supplies the COOP/COEP headers, un-isolating the page. Offline caching
+      # is the trade-off; cross-origin isolation is not optional here.
+      - name: Build Flutter web
+        run: |
+          flutter build web \
+            --release \
+            --base-href "/${GITHUB_REPOSITORY#*/}/" \
+            --pwa-strategy=none
+
+      # Guard the two silent-blank-page failure modes: the isolation shim must be
+      # in the bundle and referenced by index.html, and Flutter's service worker
+      # must not have been emitted alongside it.
+      - name: Verify bundle
+        run: |
+          set -euo pipefail
+          test -f build/web/coi-serviceworker.min.js \
+            || { echo "::error::coi-serviceworker.min.js missing from the bundle — the deployed page will not be cross-origin isolated."; exit 1; }
+          grep -q 'coi-serviceworker.min.js' build/web/index.html \
+            || { echo "::error::index.html does not load coi-serviceworker.min.js."; exit 1; }
+          # --pwa-strategy=none still emits flutter_service_worker.js (empty) and
+          # flutter_bootstrap.js still *embeds* flutter.js, whose minified loader
+          # mentions serviceWorkerSettings. The only meaningful signal is the
+          # generated call itself: `_flutter.loader.load()` with no settings.
+          loader_call="$(grep -o '_flutter\.loader\.load([^;]*)' build/web/flutter_bootstrap.js | tail -n 1)"
+          if [ -z "$loader_call" ]; then
+            echo "::error::flutter_bootstrap.js does not call _flutter.loader.load — the bundle layout changed; re-check this guard."
+            exit 1
+          fi
+          case "$loader_call" in
+            *serviceWorkerSettings*)
+              echo "::error::Flutter's service worker is being registered; it competes with the isolation shim for the same scope (expected --pwa-strategy=none)."
+              exit 1
+              ;;
+          esac
+          grep -q "base href=\"/${GITHUB_REPOSITORY#*/}/\"" build/web/index.html \
+            || { echo "::error::base href was not rewritten to the project sub-path — assets would 404."; exit 1; }
+          echo "Bundle looks deployable."
+
+      # Everything above only greps files, and every documented blank-page cause
+      # greps clean and dies at runtime — so load the bundle in a real browser.
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: test/web/smoke/package-lock.json
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ env.PLAYWRIGHT_VERSION }}
+
+      - name: Install smoke test dependencies
+        working-directory: test/web/smoke
+        run: |
+          npm ci
+          # The download is a no-op when the browser cache above hit; the OS
+          # packages are not cached and are installed either way.
+          npx playwright install --with-deps chromium
+
+      # Serves the release bundle cross-origin isolated under the production
+      # sub-path, then asserts the page is isolated, the Flutter view mounted,
+      # a Rust bridge call returned, and nothing errored.
+      - name: Smoke test the release bundle (headless Chrome)
+        working-directory: test/web/smoke
+        env:
+          BUNDLE_DIR: ${{ github.workspace }}/build/web
+        run: BASE_PATH="/${GITHUB_REPOSITORY#*/}/" node smoke.mjs
+
+      - name: Upload smoke test failure screenshot
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-smoke-failure
+          path: test/web/smoke/smoke-failure.png
+          if-no-files-found: ignore
+
+      - name: Upload Pages artifact
+        if: inputs.upload-pages-artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build/web

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ android/.kotlin/
 
 # Web service worker (generated at build time)
 web/flutter_service_worker.js
+
+# Headless web smoke test (test/web/smoke): deps and failure screenshots
+test/web/smoke/node_modules/
+test/web/smoke/smoke-failure.png

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,11 @@ cd rust && cargo test && cargo clippy      # mandated verify (Rust)
 ./scripts/frb-generate.sh                   # after ANY change to rust/src/api/
 ./scripts/build-web.sh                      # web only: compile the Rust core to web/pkg/
 flutter analyze && flutter test             # Dart side
+
+# web smoke test — needs a release bundle first (see "Web (wasm)" below):
+#   ./scripts/build-web.sh --release
+#   flutter build web --release --base-href "/app/" --pwa-strategy=none
+cd test/web/smoke && npm ci && npx playwright install chromium && BASE_PATH=/app/ node smoke.mjs
 flutter run -d linux|chrome|android         # Rust is a lib — there is no `cargo run`
 flutter gen-l10n                            # after editing lib/l10n/*.arb
 ```
@@ -43,7 +48,16 @@ flutter gen-l10n                            # after editing lib/l10n/*.arb
 - `main` deploys to <https://mostro.network/app/> via `.github/workflows/deploy-pages.yml`
   (`--base-href` for the sub-path, `--pwa-strategy=none` so Flutter's service worker does not
   take the isolation shim's scope). Every one of these, when wrong, yields a **blank page** —
-  `test/web/pages_bundle_test.dart` guards them.
+  `test/web/pages_bundle_test.dart` guards them statically.
+- The build itself lives in the reusable **`.github/workflows/web-build.yml`**, called by both
+  `ci.yml` (every PR) and `deploy-pages.yml` — edit it there, never in a caller, or the bundle
+  CI validates drifts from the one that ships.
+- Static greps pass on a page that dies at runtime, so that workflow also runs
+  **`test/web/smoke/smoke.mjs`**: it serves the release bundle cross-origin isolated under
+  `/app/` and asserts in headless Chrome that the page is isolated, the Flutter view mounted,
+  a **Rust bridge call returned**, and nothing errored. The bridge signal comes from
+  `lib/core/web/bridge_probe.dart`, which `main()` sets after its first successful Rust call
+  (no-op off web) — rename that flag on one side only and the check silently never fires.
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -367,12 +367,21 @@ order book populate from the daemon's Kind 38383 events without running anything
 (The organization serves its Pages sites from that domain, so this project page lives under
 `mostro.network/app/` rather than `mostrop2p.github.io/app/`, which 301s to it. The sub-path
 is the same either way.)
-The workflow runs the same steps as above (`scripts/frb-generate.sh`, then
-`scripts/build-web.sh --release`) and finishes with:
+The build itself lives in the reusable
+[`.github/workflows/web-build.yml`](.github/workflows/web-build.yml), which the deploy calls
+and **CI also runs on every pull request** — so a change that breaks the web target fails
+before it lands, and what CI validates cannot drift from what ships. It runs the same steps as
+above (`scripts/frb-generate.sh`, then `scripts/build-web.sh --release`) and finishes with:
 
 ```bash
 flutter build web --release --base-href "/app/" --pwa-strategy=none
 ```
+
+It then verifies the bundle and smoke-tests it in headless Chrome
+([`test/web/smoke/smoke.mjs`](test/web/smoke/smoke.mjs)): the release bundle is served
+cross-origin isolated under `/app/`, and the test asserts the page is isolated, the Flutter
+view mounted, a Rust bridge call returned, and nothing errored. Static checks alone cannot
+catch that — every blank-page cause below greps perfectly clean.
 
 Three things make it work on a static host that cannot set HTTP headers:
 

--- a/lib/core/web/bridge_probe.dart
+++ b/lib/core/web/bridge_probe.dart
@@ -1,0 +1,16 @@
+/// Health signal published to the page once the Rust bridge has answered.
+///
+/// On web the app ships as a wasm bundle whose worst failure mode is silent: a
+/// toolchain or bundling regression kills flutter_rust_bridge's worker pool
+/// (`DataCloneError`) while the DOM still looks perfectly healthy — the blank
+/// page documented in `CLAUDE.md` under "Web (wasm) — non-obvious constraints".
+/// Nothing observable from outside the app tells that apart from a working
+/// build, so `main()` publishes the outcome of a real bridge call and the
+/// headless smoke test in CI waits for it (issue #154).
+///
+/// Off web this is a no-op: there is no page to publish to, and the native
+/// targets fail loudly at build time instead.
+library;
+
+export 'bridge_probe_stub.dart'
+    if (dart.library.js_interop) 'bridge_probe_web.dart';

--- a/lib/core/web/bridge_probe_stub.dart
+++ b/lib/core/web/bridge_probe_stub.dart
@@ -1,0 +1,10 @@
+/// Non-web implementation of the bridge readiness probe.
+///
+/// See `bridge_probe.dart` for why the probe exists.
+library;
+
+/// No-op off web.
+void markBridgeReady() {}
+
+/// No-op off web.
+void markBridgeFailed(Object error) {}

--- a/lib/core/web/bridge_probe_web.dart
+++ b/lib/core/web/bridge_probe_web.dart
@@ -1,0 +1,37 @@
+/// Web implementation of the bridge readiness probe.
+///
+/// See `bridge_probe.dart` for why the probe exists.
+///
+/// Two globals rather than one tri-state value, so the smoke test can poll for
+/// success and still fail fast — with a reason — when the bridge is broken:
+///
+/// ```js
+/// await page.waitForFunction(
+///   () => window.mostroBridgeReady === true || window.mostroBridgeError,
+/// );
+/// ```
+library;
+
+import 'dart:js_interop';
+// setProperty — "unsafe" only in the sense of a dynamically-keyed property,
+// which is exactly what writing a named global is.
+import 'dart:js_interop_unsafe';
+
+/// Set to `true` once a Rust bridge call has completed successfully.
+const kBridgeReadyFlag = 'mostroBridgeReady';
+
+/// Set to the error string when that call threw instead.
+const kBridgeErrorFlag = 'mostroBridgeError';
+
+/// Publishes a successful Rust bridge round-trip to the page.
+void markBridgeReady() {
+  globalContext.setProperty(kBridgeReadyFlag.toJS, true.toJS);
+}
+
+/// Publishes a failed Rust bridge round-trip, with [error] for the CI log.
+///
+/// The app itself keeps going — the caller already treats this failure as
+/// non-fatal — but a build that reaches here is not deployable.
+void markBridgeFailed(Object error) {
+  globalContext.setProperty(kBridgeErrorFlag.toJS, error.toString().toJS);
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:mostro/core/app.dart';
 import 'package:mostro/core/mostro_defaults.dart';
 import 'package:mostro/core/services/identity_service.dart';
+import 'package:mostro/core/web/bridge_probe.dart';
 import 'package:mostro/features/settings/providers/settings_provider.dart';
 import 'package:mostro/features/settings/widgets/mostro_node_selector.dart';
 import 'package:mostro/features/walkthrough/providers/first_run_provider.dart';
@@ -58,12 +59,18 @@ Future<void> main() async {
   // node. No-op when none was saved (the compiled-in default then applies).
   // The resolved pubkey seeds mostroPubkeyProvider so Settings shows the real
   // active node on launch.
+  //
+  // This is also the first call that proves the Rust bridge is alive end to
+  // end, so its outcome doubles as the web readiness probe CI waits on — see
+  // lib/core/web/bridge_probe.dart (no-op off web).
   String activeMostroPubkey = defaultMostroPubkey;
   try {
     await settings_api.rehydrateActiveMostroNode();
     activeMostroPubkey = await settings_api.getMostroPubkey();
+    markBridgeReady();
   } catch (e) {
     debugPrint('[main] rehydrate active Mostro node failed: $e');
+    markBridgeFailed(e);
   }
 
   // Initialize identity: creates on first launch, reloads on subsequent launches.

--- a/scripts/frb-generate.sh
+++ b/scripts/frb-generate.sh
@@ -21,7 +21,9 @@ PUBSPEC='pubspec.yaml'
 CARGO_TOML='rust/Cargo.toml'
 CI_WORKFLOW='.github/workflows/ci.yml'
 GOLDENS_WORKFLOW='.github/workflows/update-goldens.yml'
-PAGES_WORKFLOW='.github/workflows/deploy-pages.yml'
+# The web build moved out of deploy-pages.yml into this reusable workflow, which
+# both it and ci.yml call — so this is where the web pipeline now states the pin.
+WEB_WORKFLOW='.github/workflows/web-build.yml'
 
 SEMVER='[0-9]+\.[0-9]+\.[0-9]+'
 
@@ -60,7 +62,7 @@ check_pin() {
 check_pin "$CARGO_TOML" "^[[:space:]]*flutter_rust_bridge[[:space:]]*=[[:space:]]*\"=?(${SEMVER})\".*$"
 check_pin "$CI_WORKFLOW" "^[[:space:]]*FRB_VERSION:[[:space:]]*\"?(${SEMVER})\"?.*$"
 check_pin "$GOLDENS_WORKFLOW" "^[[:space:]]*FRB_VERSION:[[:space:]]*\"?(${SEMVER})\"?.*$"
-check_pin "$PAGES_WORKFLOW" "^[[:space:]]*FRB_VERSION:[[:space:]]*\"?(${SEMVER})\"?.*$"
+check_pin "$WEB_WORKFLOW" "^[[:space:]]*FRB_VERSION:[[:space:]]*\"?(${SEMVER})\"?.*$"
 
 if (( ${#mismatches[@]} > 0 )); then
   echo "✗ flutter_rust_bridge is pinned inconsistently across the repository." >&2

--- a/test/web/pages_bundle_test.dart
+++ b/test/web/pages_bundle_test.dart
@@ -15,7 +15,10 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   final indexHtml = File('web/index.html');
   final shim = File('web/coi-serviceworker.min.js');
-  final workflow = File('.github/workflows/deploy-pages.yml');
+  final webBuild = File('.github/workflows/web-build.yml');
+  final deploy = File('.github/workflows/deploy-pages.yml');
+  final ci = File('.github/workflows/ci.yml');
+  final smoke = File('test/web/smoke/smoke.mjs');
 
   group('web/index.html', () {
     test('loads the cross-origin isolation shim', () {
@@ -67,12 +70,21 @@ void main() {
     });
   });
 
-  group('deploy-pages workflow', () {
+  group('web-build workflow (shared definition)', () {
+    test('is reusable, so CI and the deploy cannot drift apart', () {
+      // Arrange
+      final yaml = webBuild.readAsStringSync();
+
+      // Act / Assert — one definition, two callers (issue #154). A copy-pasted
+      // build job is a build that passes on PRs and breaks on deploy.
+      expect(yaml, contains('workflow_call'));
+    });
+
     test(
       'builds with the project sub-path and without Flutter service worker',
       () {
         // Arrange
-        final yaml = workflow.readAsStringSync();
+        final yaml = webBuild.readAsStringSync();
 
         // Act / Assert — a missing --base-href 404s every asset; Flutter's own
         // service worker would evict the isolation shim from the same scope.
@@ -81,9 +93,42 @@ void main() {
       },
     );
 
+    test('compiles the Rust core through scripts/build-web.sh', () {
+      // Arrange
+      final yaml = webBuild.readAsStringSync();
+
+      // Act / Assert — the shared-memory linker flags live in that script only;
+      // `flutter build web` alone never compiles the Rust core.
+      expect(yaml, contains('./scripts/build-web.sh --release'));
+    });
+
+    test('smoke-tests the release bundle it just built', () {
+      // Arrange
+      final yaml = webBuild.readAsStringSync();
+
+      // Act / Assert — the static "Verify bundle" greps pass on a page that
+      // dies at runtime with DataCloneError, so the bundle must also be loaded
+      // in a real browser before it is deployable.
+      expect(yaml, contains('smoke.mjs'));
+      expect(yaml, contains(r'BUNDLE_DIR'));
+    });
+  });
+
+  group('deploy-pages workflow', () {
+    test('delegates the build to the shared workflow', () {
+      // Arrange
+      final yaml = deploy.readAsStringSync();
+
+      // Act / Assert — it must call web-build.yml rather than carry its own
+      // copy of the toolchain setup and build steps.
+      expect(yaml, contains('uses: ./.github/workflows/web-build.yml'));
+      expect(yaml, isNot(contains('flutter build web')));
+      expect(yaml, isNot(contains('build-web.sh')));
+    });
+
     test('only deploys from main, even on a manual dispatch', () {
       // Arrange
-      final yaml = workflow.readAsStringSync();
+      final yaml = deploy.readAsStringSync();
 
       // Act / Assert — workflow_dispatch lets the operator pick any ref; without
       // this guard a branch build could be published to the production URL.
@@ -92,7 +137,7 @@ void main() {
 
     test('grants Pages and OIDC write tokens to the deploy job only', () {
       // Arrange
-      final yaml = workflow.readAsStringSync();
+      final yaml = deploy.readAsStringSync();
 
       // Act — everything before the deploy job: workflow-wide scope plus build.
       final beforeDeploy = yaml.substring(0, yaml.indexOf('  deploy:'));
@@ -104,14 +149,62 @@ void main() {
       expect(yaml, contains('pages: write'));
       expect(yaml, contains('id-token: write'));
     });
+  });
 
-    test('compiles the Rust core through scripts/build-web.sh', () {
+  group('CI', () {
+    test('runs the shared web build on pull requests', () {
       // Arrange
-      final yaml = workflow.readAsStringSync();
+      final yaml = ci.readAsStringSync();
 
-      // Act / Assert — the shared-memory linker flags live in that script only;
-      // `flutter build web` alone never compiles the Rust core.
-      expect(yaml, contains('./scripts/build-web.sh --release'));
+      // Act / Assert — the whole point of issue #154: a PR that breaks the web
+      // target must fail before it lands, not after deploy-pages runs on main.
+      expect(yaml, contains('pull_request'));
+      expect(yaml, contains('uses: ./.github/workflows/web-build.yml'));
+    });
+  });
+
+  group('headless smoke test', () {
+    test('asserts every precondition a blank page would hide', () {
+      // Arrange
+      final js = smoke.readAsStringSync();
+
+      // Act / Assert — each of these stands for a documented blank-page cause:
+      // lost isolation, an engine that never mounted, a dead FRB worker pool,
+      // and errors the page swallows instead of surfacing.
+      expect(js, contains('crossOriginIsolated'));
+      expect(js, contains('flutter-view'));
+      expect(js, contains(bridgeReadyFlag));
+      expect(js, contains('console'));
+    });
+
+    test('serves the bundle cross-origin isolated, under the sub-path', () {
+      // Arrange
+      final js = smoke.readAsStringSync();
+
+      // Act / Assert — the isolation shim only registers when the headers are
+      // absent, and it takes effect one load late; serving the headers directly
+      // keeps the first load deterministic. Serving from the root instead of the
+      // production sub-path would let --base-href breakage pass here.
+      expect(js, contains('Cross-Origin-Opener-Policy'));
+      expect(js, contains('Cross-Origin-Embedder-Policy'));
+      expect(js, contains('BASE_PATH'));
+    });
+  });
+
+  group('bridge readiness probe', () {
+    test('Dart and the smoke test agree on the flag name', () {
+      // Arrange — the probe is the only positive signal that the Rust bridge
+      // survived; a rename on one side would silently never be awaited.
+      final dart = File('lib/core/web/bridge_probe_web.dart').readAsStringSync();
+      final js = smoke.readAsStringSync();
+
+      // Act / Assert
+      expect(dart, contains(bridgeReadyFlag));
+      expect(js, contains(bridgeReadyFlag));
     });
   });
 }
+
+/// The `window` property `main()` sets once a real Rust bridge call has
+/// returned on web, and that the headless smoke test waits for.
+const bridgeReadyFlag = 'mostroBridgeReady';

--- a/test/web/pages_bundle_test.dart
+++ b/test/web/pages_bundle_test.dart
@@ -171,10 +171,37 @@ void main() {
       // Act / Assert — each of these stands for a documented blank-page cause:
       // lost isolation, an engine that never mounted, a dead FRB worker pool,
       // and errors the page swallows instead of surfacing.
+      //
+      // Presence, not behaviour: searching source cannot prove the run fails
+      // when it should — `if (errors.length)` could be mutated to `if (false)`
+      // and every line here would still pass. test/web/smoke/selftest.mjs is
+      // what actually holds that down, by running smoke.mjs against fixtures
+      // and asserting exit codes. This is only a cheap early warning that runs
+      // without a browser.
       expect(js, contains('crossOriginIsolated'));
       expect(js, contains('flutter-view'));
       expect(js, contains(bridgeReadyFlag));
-      expect(js, contains('console'));
+      expect(js, contains('errors.length'));
+    });
+
+    test('is itself tested, and that self-test runs in CI', () {
+      // Arrange
+      final selftest = File('test/web/smoke/selftest.mjs');
+      final yaml = webBuild.readAsStringSync();
+
+      // Act / Assert — a healthy bundle goes green whether or not the error
+      // checks still work, so without this the gate could rot unnoticed. The
+      // fixtures are the executable form of issue #154's "fail on any console
+      // error" requirement.
+      expect(selftest.existsSync(), isTrue);
+      for (final fixture in ['healthy', 'console-error', 'page-error']) {
+        expect(
+          File('test/web/smoke/fixtures/$fixture/index.html').existsSync(),
+          isTrue,
+          reason: 'missing smoke self-test fixture: $fixture',
+        );
+      }
+      expect(yaml, contains('selftest.mjs'));
     });
 
     test('serves the bundle cross-origin isolated, under the sub-path', () {

--- a/test/web/smoke/fixtures/console-error/index.html
+++ b/test/web/smoke/fixtures/console-error/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<!--
+  Identical to the healthy fixture except for one console.error.
+
+  Issue #154 requires the smoke test to fail on console errors. A source grep
+  cannot prove that — mutate `if (errors.length)` to `if (false)` and the grep
+  still passes — so this page makes the requirement executable: everything
+  else smoke.mjs asserts is satisfied, and the run must still exit non-zero.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="data:," />
+    <title>smoke fixture — console error</title>
+  </head>
+  <body>
+    <flutter-view></flutter-view>
+    <script>
+      window.mostroBridgeReady = true;
+      console.error('synthetic console error from the smoke self-test fixture');
+    </script>
+  </body>
+</html>

--- a/test/web/smoke/fixtures/healthy/index.html
+++ b/test/web/smoke/fixtures/healthy/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<!--
+  Control fixture: the minimum a page must show to satisfy smoke.mjs.
+
+  It exists so the two failing fixtures beside it prove something. Without a
+  passing baseline, "console-error fails the run" could just as well mean the
+  fixture harness itself is broken.
+
+  The inline data: icon stops Chrome from requesting /favicon.ico outside the
+  served sub-path.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="data:," />
+    <title>smoke fixture — healthy</title>
+  </head>
+  <body>
+    <flutter-view></flutter-view>
+    <script>
+      window.mostroBridgeReady = true;
+    </script>
+  </body>
+</html>

--- a/test/web/smoke/fixtures/page-error/index.html
+++ b/test/web/smoke/fixtures/page-error/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<!--
+  Identical to the healthy fixture except for one uncaught exception.
+
+  The throw sits in its own <script> so it cannot stop the block above it: the
+  view element and the bridge flag are already in place, which is the point —
+  every other assertion passes and the run must still exit non-zero.
+
+  Uncaught rather than caught-and-logged, because it reaches smoke.mjs through
+  a different channel than console.error: Playwright's `pageerror` event.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="data:," />
+    <title>smoke fixture — uncaught page error</title>
+  </head>
+  <body>
+    <flutter-view></flutter-view>
+    <script>
+      window.mostroBridgeReady = true;
+    </script>
+    <script>
+      throw new Error('synthetic uncaught page error from the smoke self-test fixture');
+    </script>
+  </body>
+</html>

--- a/test/web/smoke/package-lock.json
+++ b/test/web/smoke/package-lock.json
@@ -1,0 +1,63 @@
+{
+  "name": "mostro-web-smoke",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mostro-web-smoke",
+      "version": "0.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "playwright": "1.56.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.0.tgz",
+      "integrity": "sha512-X5Q1b8lOdWIE4KAoHpW3SE8HvUB+ZZsUoN64ZhjnN8dOb1UpujxBtENGiZFE+9F/yhzJwYa+ca3u43FeLbboHA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.56.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.0.tgz",
+      "integrity": "sha512-1SXl7pMfemAMSDn5rkPeZljxOCYAmQnYLBTExuh6E8USHXGSX3dx6lYZN/xPpTz1vimXmPA9CDnILvmJaB8aSQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/test/web/smoke/package.json
+++ b/test/web/smoke/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "mostro-web-smoke",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Headless-Chrome smoke test for the release web bundle (issue #154).",
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "smoke": "node smoke.mjs"
+  },
+  "devDependencies": {
+    "playwright": "1.56.0"
+  }
+}

--- a/test/web/smoke/selftest.mjs
+++ b/test/web/smoke/selftest.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+// Behavioural test for smoke.mjs itself.
+//
+// smoke.mjs is a gate, and a gate nobody tests is a gate that quietly stops
+// gating. Grepping its source cannot prove it fails when it should: mutate
+// `if (errors.length)` to `if (false)` and every source assertion still
+// passes, while a healthy release bundle produces a green run either way — so
+// issue #154's "fail on any console error" requirement would be gone with
+// nothing to show for it.
+//
+// So run the real script, unmodified, against fixtures that differ by exactly
+// one thing, and assert the exit code. The healthy fixture is the control: it
+// is what makes a failure in the other two mean "the error was detected"
+// rather than "the fixture never loaded".
+//
+// Cheap — three static pages, no build required. Runs in CI before the real
+// bundle smoke test, so a broken harness is reported as a broken harness
+// rather than as a broken bundle.
+//
+// Usage:  node selftest.mjs
+
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+const CASES = [
+  {
+    fixture: 'healthy',
+    expected: 0,
+    what: 'a page with a mounted view and a live bridge passes',
+  },
+  {
+    fixture: 'console-error',
+    expected: 1,
+    what: 'one console.error fails the run',
+  },
+  {
+    fixture: 'page-error',
+    expected: 1,
+    what: 'one uncaught page error fails the run',
+  },
+];
+
+let failures = 0;
+
+for (const { fixture, expected, what } of CASES) {
+  const result = spawnSync(process.execPath, [join(here, 'smoke.mjs')], {
+    cwd: here,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      BUNDLE_DIR: join(here, 'fixtures', fixture),
+      BASE_PATH: '/app/',
+      // Static fixtures load instantly; no reason to wait out the bundle's
+      // budget when something is wrong.
+      SMOKE_TIMEOUT_MS: '30000',
+    },
+  });
+
+  const actual = result.status;
+  const ok = actual === expected;
+  console.log(`${ok ? '✓' : '✗'} ${what} — exit ${actual}, expected ${expected}`);
+
+  if (!ok) {
+    failures += 1;
+    // Only on failure: the passing cases' output is noise, and smoke.mjs is
+    // deliberately chatty when it fails.
+    if (result.stdout) console.log(result.stdout.trimEnd());
+    if (result.stderr) console.error(result.stderr.trimEnd());
+    if (result.error) console.error(result.error);
+  }
+}
+
+if (failures) {
+  console.error(`\n✗ smoke.mjs self-test: ${failures} of ${CASES.length} cases failed.`);
+  process.exitCode = 1;
+} else {
+  console.log(`\n✓ smoke.mjs self-test: all ${CASES.length} cases behaved as expected.`);
+}

--- a/test/web/smoke/smoke.mjs
+++ b/test/web/smoke/smoke.mjs
@@ -149,23 +149,28 @@ async function main() {
   const url = `http://127.0.0.1:${port}${BASE_PATH}`;
   console.log(`serving ${BUNDLE_DIR} at ${url}`);
 
-  const browser = await chromium.launch();
-  const page = await browser.newPage();
-
-  const record = (origin, text) => {
-    (isIgnorable(text) ? ignored : errors).push(`[${origin}] ${text}`);
-  };
-  page.on('console', (msg) => {
-    if (msg.type() === 'error') record('console', msg.text());
-  });
-  page.on('pageerror', (err) => record('pageerror', err.message));
-
-  const fail = async (message) => {
-    await page.screenshot({ path: 'smoke-failure.png' }).catch(() => {});
-    throw new Error(message);
-  };
-
+  // Everything past this point runs under the finally that closes the server:
+  // a listening socket keeps the event loop alive, so leaking one turns a
+  // browser that failed to start into a job that hangs until its timeout
+  // instead of a smoke test that fails in seconds.
+  let browser;
   try {
+    browser = await chromium.launch();
+    const page = await browser.newPage();
+
+    const record = (origin, text) => {
+      (isIgnorable(text) ? ignored : errors).push(`[${origin}] ${text}`);
+    };
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') record('console', msg.text());
+    });
+    page.on('pageerror', (err) => record('pageerror', err.message));
+
+    const fail = async (message) => {
+      await page.screenshot({ path: 'smoke-failure.png' }).catch(() => {});
+      throw new Error(message);
+    };
+
     await page.goto(url, { waitUntil: 'domcontentloaded', timeout: TIMEOUT_MS });
 
     // 1. Isolation. Cheap, unambiguous, and everything after it depends on it.
@@ -216,7 +221,11 @@ async function main() {
     }
     console.log('✓ no console or page errors\n\nweb bundle smoke test passed.');
   } finally {
-    await browser.close().catch(() => {});
+    // browser is undefined when chromium.launch() itself threw.
+    await browser?.close().catch(() => {});
+    // close() only stops new connections; a keep-alive socket the browser left
+    // behind would hold the process open just as a listening one would.
+    server.closeAllConnections();
     server.close();
   }
 }

--- a/test/web/smoke/smoke.mjs
+++ b/test/web/smoke/smoke.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+// Headless-Chrome smoke test for the release web bundle (issue #154).
+//
+// The static guards around this bundle — the "Verify bundle" step in
+// web-build.yml and test/web/pages_bundle_test.dart — only grep files. Every
+// blank-page cause documented in CLAUDE.md under "Web (wasm) — non-obvious
+// constraints" greps perfectly clean and fails at runtime, so this test loads
+// the real artifact in a real browser and asserts it is alive:
+//
+//   1. the page is cross-origin isolated  (no SharedArrayBuffer → no wasm threads)
+//   2. the Flutter engine mounted         (the view element exists)
+//   3. a Rust bridge call returned        (the FRB worker pool survived)
+//   4. nothing errored along the way      (console + uncaught page errors)
+//   5. every asset the page asked for was served (catches --base-href breakage)
+//
+// (3) is what separates this from a "did the HTML load" test: a DataCloneError
+// kills the worker pool while the DOM still looks perfectly healthy.
+//
+// The bundle is served with COOP/COEP set directly rather than through
+// web/coi-serviceworker.min.js. The shim only registers when the headers are
+// absent and takes effect one load late, which would make a first-load
+// assertion flaky; serving the headers reaches the same isolated state
+// deterministically. That is also why the shim is inert here — it is covered
+// statically by pages_bundle_test.dart instead.
+//
+// Usage:
+//   BUNDLE_DIR=../../../build/web BASE_PATH=/app/ node smoke.mjs
+
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { dirname, extname, join, normalize, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+/** The bundle under test. Must be the release build that actually ships. */
+const BUNDLE_DIR = resolve(process.env.BUNDLE_DIR || join(here, '../../../build/web'));
+
+/**
+ * Sub-path the bundle is served from, matching production (`/app/`). Serving
+ * from the root instead would let a broken `--base-href` pass here and fail
+ * only once deployed to Pages.
+ */
+const BASE_PATH = process.env.BASE_PATH || '/app/';
+
+/** Generous: a cold CI runner instantiates the wasm core before anything runs. */
+const TIMEOUT_MS = Number(process.env.SMOKE_TIMEOUT_MS || 120_000);
+
+const MIME = {
+  '.bin': 'application/octet-stream',
+  '.css': 'text/css; charset=utf-8',
+  '.html': 'text/html; charset=utf-8',
+  '.ico': 'image/x-icon',
+  '.js': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.map': 'application/json; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.otf': 'font/otf',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.symbols': 'text/plain; charset=utf-8',
+  '.ttf': 'font/ttf',
+  '.wasm': 'application/wasm',
+  '.woff2': 'font/woff2',
+};
+
+/**
+ * Console/page errors that say nothing about the bundle.
+ *
+ * The app dials real Nostr relays on startup; one being unreachable from a CI
+ * runner is a fact about the internet, not about this build. Keep this list
+ * narrow — anything broader hides the failures this test exists to catch.
+ * Ignored entries are still printed.
+ */
+const IGNORABLE = [/WebSocket connection to 'wss:\/\//i, /favicon\.ico/i];
+
+const isIgnorable = (text) => IGNORABLE.some((re) => re.test(text));
+
+/**
+ * Serves BUNDLE_DIR under BASE_PATH, cross-origin isolated.
+ *
+ * Every request it cannot satisfy is pushed to [misses]: a page whose
+ * `--base-href` was not rewritten asks for `/main.dart.js` instead of
+ * `/app/main.dart.js`, and that miss is the earliest unambiguous signal of it.
+ */
+function serveBundle(misses) {
+  const server = createServer(async (req, res) => {
+    const pathname = decodeURIComponent(new URL(req.url, 'http://localhost').pathname);
+
+    const send = (status, body, type) => {
+      res.writeHead(status, {
+        'Content-Type': type || 'text/plain; charset=utf-8',
+        // The whole point: SharedArrayBuffer, and therefore wasm threads.
+        'Cross-Origin-Opener-Policy': 'same-origin',
+        'Cross-Origin-Embedder-Policy': 'require-corp',
+        'Cross-Origin-Resource-Policy': 'same-origin',
+        'Cache-Control': 'no-store',
+      });
+      res.end(body);
+    };
+
+    if (!pathname.startsWith(BASE_PATH)) {
+      misses.push(pathname);
+      return send(404, `outside ${BASE_PATH}`);
+    }
+
+    let rel = pathname.slice(BASE_PATH.length);
+    if (rel === '' || rel.endsWith('/')) rel += 'index.html';
+
+    // Containment check: normalize collapses any ../ before we touch the disk.
+    const file = normalize(join(BUNDLE_DIR, rel));
+    if (!file.startsWith(BUNDLE_DIR)) {
+      misses.push(pathname);
+      return send(403, 'forbidden');
+    }
+
+    try {
+      const body = await readFile(file);
+      send(200, body, MIME[extname(file).toLowerCase()]);
+    } catch {
+      misses.push(pathname);
+      send(404, 'not found');
+    }
+  });
+
+  return new Promise((ok, fail) => {
+    server.on('error', fail);
+    server.listen(0, '127.0.0.1', () => ok(server));
+  });
+}
+
+async function main() {
+  // Fail with a useful message rather than 404-ing every asset.
+  await readFile(join(BUNDLE_DIR, 'index.html')).catch(() => {
+    throw new Error(
+      `No bundle at ${BUNDLE_DIR}. Build it first:\n` +
+        '  ./scripts/build-web.sh --release && flutter build web --release ' +
+        `--base-href "${BASE_PATH}" --pwa-strategy=none`,
+    );
+  });
+
+  const misses = [];
+  const errors = [];
+  const ignored = [];
+
+  const server = await serveBundle(misses);
+  const { port } = server.address();
+  const url = `http://127.0.0.1:${port}${BASE_PATH}`;
+  console.log(`serving ${BUNDLE_DIR} at ${url}`);
+
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+
+  const record = (origin, text) => {
+    (isIgnorable(text) ? ignored : errors).push(`[${origin}] ${text}`);
+  };
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') record('console', msg.text());
+  });
+  page.on('pageerror', (err) => record('pageerror', err.message));
+
+  const fail = async (message) => {
+    await page.screenshot({ path: 'smoke-failure.png' }).catch(() => {});
+    throw new Error(message);
+  };
+
+  try {
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: TIMEOUT_MS });
+
+    // 1. Isolation. Cheap, unambiguous, and everything after it depends on it.
+    const isolated = await page.evaluate(() => globalThis.crossOriginIsolated);
+    if (isolated !== true) {
+      await fail('page is not cross-origin isolated — SharedArrayBuffer is unavailable');
+    }
+    console.log('✓ cross-origin isolated');
+
+    // 2. The engine mounted. Flutter paints to canvas, so there is no text to
+    //    assert on — the view element is the observable signal.
+    await page
+      .waitForSelector('flutter-view, flt-glass-pane', { timeout: TIMEOUT_MS })
+      .catch(() => fail('the Flutter view never mounted'));
+    console.log('✓ Flutter view mounted');
+
+    // 3. The Rust bridge answered. Poll for either outcome so a broken bridge
+    //    fails immediately with its reason instead of timing out silently.
+    await page
+      .waitForFunction(
+        () =>
+          globalThis.mostroBridgeReady === true ||
+          typeof globalThis.mostroBridgeError === 'string',
+        undefined,
+        { timeout: TIMEOUT_MS },
+      )
+      .catch(() =>
+        fail(
+          'no Rust bridge call completed — the FRB worker pool is probably dead ' +
+            '(DataCloneError); check that web/pkg was built by scripts/build-web.sh',
+        ),
+      );
+    const bridgeError = await page.evaluate(() => globalThis.mostroBridgeError);
+    if (bridgeError) await fail(`Rust bridge call failed: ${bridgeError}`);
+    console.log('✓ Rust bridge call returned');
+
+    // 4/5. Anything the page complained about, and anything it asked for that
+    //      this server could not serve.
+    if (ignored.length) {
+      console.log("\nignored (outside this bundle's control):");
+      for (const e of ignored) console.log(`  ${e}`);
+    }
+    if (misses.length) {
+      await fail(`unserved requests (check --base-href):\n  ${misses.join('\n  ')}`);
+    }
+    if (errors.length) {
+      await fail(`page reported errors:\n  ${errors.join('\n  ')}`);
+    }
+    console.log('✓ no console or page errors\n\nweb bundle smoke test passed.');
+  } finally {
+    await browser.close().catch(() => {});
+    server.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(`\n✗ web bundle smoke test failed: ${err.message}`);
+  process.exitCode = 1;
+});

--- a/test/web/smoke/smoke.mjs
+++ b/test/web/smoke/smoke.mjs
@@ -156,7 +156,13 @@ async function main() {
   let browser;
   try {
     browser = await chromium.launch();
-    const page = await browser.newPage();
+    // Pin the locale. A CI container usually has none configured, so Chromium
+    // reports something Dart's intl rejects outright — `RangeError: Incorrect
+    // locale information provided` thrown from main(), before runApp, leaving
+    // the engine bootstrapped but no view mounted. Real browsers always report
+    // a locale, so leaving it unset tests a situation no user is ever in while
+    // hiding every failure that comes after it.
+    const page = await browser.newPage({ locale: 'en-US' });
 
     const record = (origin, text) => {
       (isIgnorable(text) ? ignored : errors).push(`[${origin}] ${text}`);
@@ -220,8 +226,17 @@ async function main() {
 
     // 2. The engine mounted. Flutter paints to canvas, so there is no text to
     //    assert on — the view element is the observable signal.
+    //
+    //    state: 'attached', not Playwright's default of 'visible'. "Visible"
+    //    means a non-empty bounding box, which is a fact about layout, not
+    //    about whether the engine came up — a host element the engine has not
+    //    sized yet is still proof it mounted. Waiting on 'visible' here timed
+    //    out on a page that demonstrably had the element in its DOM.
     await page
-      .waitForSelector('flutter-view, flt-glass-pane', { timeout: TIMEOUT_MS })
+      .waitForSelector('flutter-view, flt-glass-pane', {
+        state: 'attached',
+        timeout: TIMEOUT_MS,
+      })
       .catch(() => fail('the Flutter view never mounted'));
     console.log('✓ Flutter view mounted');
 

--- a/test/web/smoke/smoke.mjs
+++ b/test/web/smoke/smoke.mjs
@@ -166,8 +166,46 @@ async function main() {
     });
     page.on('pageerror', (err) => record('pageerror', err.message));
 
+    // Collected but never fatal on its own: a cancelled preload is routine,
+    // while a blocked CDN fetch is not, and only the surrounding failure says
+    // which one this was. Printed whenever something else fails.
+    const aborted = [];
+    page.on('requestfailed', (req) => {
+      const text = `${req.url()} — ${req.failure()?.errorText ?? 'unknown'}`;
+      (isIgnorable(text) ? ignored : aborted).push(text);
+    });
+
+    const dump = (label, lines) => {
+      if (!lines.length) return;
+      console.error(`\n${label}:`);
+      for (const line of lines) console.error(`  ${line}`);
+    };
+
+    // A CI log is the only evidence anyone will ever have about a failure here,
+    // and none of what follows is reachable after the throw — so empty the
+    // collectors first. Without this, a red run says nothing beyond "it did
+    // not work", which is how the first one went.
     const fail = async (message) => {
       await page.screenshot({ path: 'smoke-failure.png' }).catch(() => {});
+      dump('console and page errors', errors);
+      dump("ignored (outside this bundle's control)", ignored);
+      dump('requests this server could not serve', misses);
+      dump('requests the browser gave up on', aborted);
+
+      // What the engine actually got to. Flutter paints to canvas, so the body
+      // is short — it is the <script> tags and whichever host elements the
+      // bootstrap managed to create before it stopped.
+      const snapshot = await page
+        .evaluate(() => ({
+          readyState: document.readyState,
+          body: document.body ? document.body.outerHTML.slice(0, 1500) : '(no body)',
+        }))
+        .catch(() => null);
+      if (snapshot) {
+        console.error(`\ndocument.readyState: ${snapshot.readyState}`);
+        console.error(`document.body:\n  ${snapshot.body}`);
+      }
+
       throw new Error(message);
     };
 
@@ -213,12 +251,9 @@ async function main() {
       console.log("\nignored (outside this bundle's control):");
       for (const e of ignored) console.log(`  ${e}`);
     }
-    if (misses.length) {
-      await fail(`unserved requests (check --base-href):\n  ${misses.join('\n  ')}`);
-    }
-    if (errors.length) {
-      await fail(`page reported errors:\n  ${errors.join('\n  ')}`);
-    }
+    // fail() prints the contents; these only have to name the failure.
+    if (misses.length) await fail('some requests were not served (check --base-href)');
+    if (errors.length) await fail('the page reported errors');
     console.log('✓ no console or page errors\n\nweb bundle smoke test passed.');
   } finally {
     // browser is undefined when chromium.launch() itself threw.


### PR DESCRIPTION
Refs #154 — deliberately **not** `Closes`. The issue's "job is required in branch protection"
acceptance criterion is not met by this PR and cannot be: per the issue's own step 3, the job
should be marked required only once it has been green and non-flaky for a few PRs. Auto-closing
would drop that work off the backlog, so #154 stays open until the check is actually required.

## Why

Two gaps from the issue:

1. **The web build never ran on a PR.** `deploy-pages.yml` is `on: push: branches: [main]`, so a PR that broke the web target was only discovered *after* merge.
2. **Nothing ever loaded the built page.** The "Verify bundle" step and `test/web/pages_bundle_test.dart` both only grep files. Every blank-page cause documented in `CLAUDE.md` under "Web (wasm) — non-obvious constraints" greps perfectly clean and dies at runtime — `DataCloneError` in particular kills the FRB worker pool while the DOM still looks healthy.

## What changed

**Shared build definition.** The build job moved verbatim out of `deploy-pages.yml` into a reusable `.github/workflows/web-build.yml` (`on: workflow_call`). `ci.yml` calls it on every PR; `deploy-pages.yml` calls it with `upload-pages-artifact: true` and then deploys. One definition, two callers — the bundle CI validates and the bundle that ships cannot drift.

**Headless-Chrome smoke test** (`test/web/smoke/smoke.mjs`, Playwright) runs inside that workflow, against the release bundle it just built. It serves the bundle **cross-origin isolated under the production sub-path** (`/app/`) and asserts:

- `crossOriginIsolated === true`
- the Flutter view mounted (`flutter-view` / `flt-glass-pane` — Flutter paints to canvas, so there is no text to assert on)
- **a Rust bridge call returned**
- zero `console.error` and zero uncaught page errors
- every asset the page requested was served (catches `--base-href` breakage precisely)

COOP/COEP are set by the test server directly rather than via `coi-serviceworker.min.js`: the shim only registers when the headers are *absent* and takes effect one load late, which would make a first-load assertion flaky. Same isolated end state, deterministic. The shim path stays covered statically by `pages_bundle_test.dart`.

**Bridge readiness probe.** The bridge assertion needs a signal from inside the app, so `main()` publishes the outcome of its *existing* first Rust call (`settings_api.getMostroPubkey()`) to the page — `window.mostroBridgeReady` on success, `window.mostroBridgeError` on failure. `lib/core/web/bridge_probe.dart` is a conditional export; off web it is a no-op. No behavior change: the surrounding `try`/`catch` already treated that failure as non-fatal.

## Test plan

Verified locally against a real release build (`./scripts/build-web.sh --release` + `flutter build web --release --base-href "/app/" --pwa-strategy=none`):

- [x] Passes end to end — all four assertions, including the Rust bridge call
- [x] Wrong sub-path (simulates broken `--base-href`) → fails, `the Flutter view never mounted`, exit 1, failure screenshot written
- [x] Probe renamed in the compiled bundle (simulates a dead worker pool) → view mounts, then fails with `no Rust bridge call completed — the FRB worker pool is probably dead (DataCloneError)`, exit 1

So assertions 2 and 3 are independently load-bearing — the second case proves the bridge check is not riding on the DOM check.

- [x] `flutter analyze` clean
- [x] `flutter test` — 143 passing, including 15 in `pages_bundle_test.dart` (updated for the workflow split, plus new guards: the shared workflow is reusable, the deploy delegates to it and carries no build steps of its own, CI runs it on PRs, the smoke test asserts each precondition, and Dart and JS agree on the probe flag name)
- [x] `cargo clippy -- -D warnings` clean (Rust untouched)
- [x] All three workflow YAMLs parse

## Review follow-ups

- **Server leak on browser-start failure** (Codex): fixed in `ad31fb4`, verified — exit 124 (hung) before, exit 1 after.
- **FRB pin check** pointed at `deploy-pages.yml`, where `FRB_VERSION` no longer lives after the split. Repointed at `web-build.yml` in `ad31fb4`; Flutter and Rust jobs green again.
- **The web job was red** (ermeme P1): fixed in `bf1e47c`. It was never the bundle — every build and verification step passed. A CI container has no locale configured, so Chromium reported one Dart's intl rejects (`RangeError: Incorrect locale information provided`), and `main()` threw before `runApp`: engine bootstrapped, no view mounted. The test now pins `locale: 'en-US'`, since a real browser always reports one.
- **Source-token test did not prove the failure path** (ermeme P2): fixed in `bf1e47c` with `test/web/smoke/selftest.mjs` — three fixtures differing by one thing each (healthy control, one `console.error`, one uncaught page error), asserting `smoke.mjs`'s exit code, run in CI before the real bundle. This is what caught the locale bug: its healthy control failed while the DOM snapshot plainly showed `<flutter-view>`, which exposed a second bug — `waitForSelector` was defaulting to `state: 'visible'` (a layout fact) instead of `'attached'`.
- **`Closes #154`** (ermeme P2): changed to a non-closing `Refs`, see top.

### Follow-up issue filed: #227

The locale crash is masked here, not fixed. The app throws `RangeError: Incorrect locale information provided` from `main()` when the browser reports a locale Dart's intl cannot parse. No mainstream browser does that, so this is low severity and out of scope here — but it is a real startup fragility with no error path, and so it is tracked separately in #227, which carries the full diagnosis, a 30-second reproduction, and the fix plan.

## Not in this PR

- **Branch protection.** Per the issue's step 3, the job should be marked required only once it has been green and non-flaky for a few PRs. This PR is the first real measurement of its wall-clock cost on a cold cache — worth reading the timing before deciding whether it stays unfiltered (issue's step 1 note on path filters).
- **`cargo check --target wasm32` in the `rust` job** is left as is. It is now redundant with the full `build-web.sh` in the same run, but it is also much cheaper and fails faster on an obvious wasm break, so it earns its place as a quick pre-filter.

