### PR TITLE
feat(orderbook): wire maker reputation from the Kind 38383 rating tag

### DIFF
--- a/lib/features/home/providers/home_order_providers.dart
+++ b/lib/features/home/providers/home_order_providers.dart
@@ -130,6 +130,9 @@ class OrderItem {
         status: info.status,
         amountSats: info.amountSats,
         isMine: info.isMine,
+        rating: info.rating,
+        tradeCount: info.totalReviews,
+        daysActive: info.daysActive,
       );
 }
 

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -684,6 +684,11 @@ pub async fn create_order(params: NewOrderParams) -> Result<OrderInfo> {
         created_at: now,
         expires_at: Some(now + 24 * 3600),
         is_mine: true,
+        // Own new order: the daemon's Kind 38383 confirmation carries the
+        // real reputation snapshot; until then there is none to show.
+        rating: 0.0,
+        total_reviews: 0,
+        days_active: 0,
     };
 
     // Derive a fresh trade key — each order must use a unique derived key index
@@ -3264,6 +3269,9 @@ mod tests {
             expires_at: None,
             amount_sats: None,
             creator_pubkey: String::new(),
+            rating: 0.0,
+            total_reviews: 0,
+            days_active: 0,
         }
     }
 

--- a/rust/src/api/types.rs
+++ b/rust/src/api/types.rs
@@ -213,10 +213,17 @@ pub struct OrderInfo {
     /// Maker reputation from the Kind 38383 `rating` tag (`total_rating`
     /// aggregate, 0–5). `0.0` when the maker has no reputation yet or
     /// publishes in full-privacy mode (`rating` = `"none"`).
+    ///
+    /// `serde(default)` on these three fields keeps rows persisted before
+    /// they existed (orders table, `OrderInfo` nested in trades JSON)
+    /// deserializable after an app upgrade.
+    #[serde(default)]
     pub rating: f64,
     /// Number of reviews behind [`Self::rating`] (`total_reviews`).
+    #[serde(default)]
     pub total_reviews: u32,
     /// Days the maker has been active on this Mostro node (`days`).
+    #[serde(default)]
     pub days_active: u32,
 }
 

--- a/rust/src/api/types.rs
+++ b/rust/src/api/types.rs
@@ -210,6 +210,14 @@ pub struct OrderInfo {
     pub created_at: i64,
     pub expires_at: Option<i64>,
     pub is_mine: bool,
+    /// Maker reputation from the Kind 38383 `rating` tag (`total_rating`
+    /// aggregate, 0–5). `0.0` when the maker has no reputation yet or
+    /// publishes in full-privacy mode (`rating` = `"none"`).
+    pub rating: f64,
+    /// Number of reviews behind [`Self::rating`] (`total_reviews`).
+    pub total_reviews: u32,
+    /// Days the maker has been active on this Mostro node (`days`).
+    pub days_active: u32,
 }
 
 /// Parameters for creating a new order via the Mostro protocol.

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -5256,6 +5256,9 @@ impl SseDecode for crate::api::types::OrderInfo {
         let mut var_createdAt = <i64>::sse_decode(deserializer);
         let mut var_expiresAt = <Option<i64>>::sse_decode(deserializer);
         let mut var_isMine = <bool>::sse_decode(deserializer);
+        let mut var_rating = <f64>::sse_decode(deserializer);
+        let mut var_totalReviews = <u32>::sse_decode(deserializer);
+        let mut var_daysActive = <u32>::sse_decode(deserializer);
         return crate::api::types::OrderInfo {
             id: var_id,
             kind: var_kind,
@@ -5271,6 +5274,9 @@ impl SseDecode for crate::api::types::OrderInfo {
             created_at: var_createdAt,
             expires_at: var_expiresAt,
             is_mine: var_isMine,
+            rating: var_rating,
+            total_reviews: var_totalReviews,
+            days_active: var_daysActive,
         };
     }
 }
@@ -6601,6 +6607,9 @@ impl flutter_rust_bridge::IntoDart for crate::api::types::OrderInfo {
             self.created_at.into_into_dart().into_dart(),
             self.expires_at.into_into_dart().into_dart(),
             self.is_mine.into_into_dart().into_dart(),
+            self.rating.into_into_dart().into_dart(),
+            self.total_reviews.into_into_dart().into_dart(),
+            self.days_active.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -7946,6 +7955,9 @@ impl SseEncode for crate::api::types::OrderInfo {
         <i64>::sse_encode(self.created_at, serializer);
         <Option<i64>>::sse_encode(self.expires_at, serializer);
         <bool>::sse_encode(self.is_mine, serializer);
+        <f64>::sse_encode(self.rating, serializer);
+        <u32>::sse_encode(self.total_reviews, serializer);
+        <u32>::sse_encode(self.days_active, serializer);
     }
 }
 

--- a/rust/src/nostr/order_events.rs
+++ b/rust/src/nostr/order_events.rs
@@ -75,6 +75,8 @@ pub fn parse_order_event(event: &Event, my_pubkey: Option<&PublicKey>) -> Option
     let is_mine = false;
     let _ = my_pubkey; // unused — kept in signature for future use
 
+    let (rating, total_reviews, days_active) = parse_rating_tag(get("rating").as_deref());
+
     Some(OrderInfo {
         id,
         kind,
@@ -90,7 +92,45 @@ pub fn parse_order_event(event: &Event, my_pubkey: Option<&PublicKey>) -> Option
         created_at,
         expires_at,
         is_mine,
+        rating,
+        total_reviews,
+        days_active,
     })
+}
+
+/// Parse the `rating` tag value into `(total_rating, total_reviews, days)`.
+///
+/// The daemon publishes the maker's reputation snapshot on each order event:
+/// `"none"` for full-privacy makers, otherwise a JSON object
+/// `{"total_reviews":47,"total_rating":4.9,"last_rating":5,"max_rate":5,
+/// "min_rate":1,"days":312}` (mostro-core `Rating`). Some deployments wrap it
+/// as `["rating", {…}]` — v1 accepts both shapes, so we do too. Missing tag or
+/// malformed JSON degrades to zeros rather than dropping the order.
+fn parse_rating_tag(value: Option<&str>) -> (f64, u32, u32) {
+    const EMPTY: (f64, u32, u32) = (0.0, 0, 0);
+    let Some(raw) = value else { return EMPTY };
+    if raw == "none" {
+        return EMPTY;
+    }
+    let Ok(parsed) = serde_json::from_str::<serde_json::Value>(raw) else {
+        log::debug!("[parse] unparseable rating tag: {raw:?}");
+        return EMPTY;
+    };
+    let obj = match &parsed {
+        serde_json::Value::Object(map) => map,
+        serde_json::Value::Array(arr)
+            if arr.len() > 1 && arr[0].as_str() == Some("rating") && arr[1].is_object() =>
+        {
+            arr[1].as_object().expect("checked is_object above")
+        }
+        _ => return EMPTY,
+    };
+    let num = |key: &str| obj.get(key).and_then(|v| v.as_f64()).unwrap_or(0.0);
+    (
+        num("total_rating"),
+        num("total_reviews") as u32,
+        num("days") as u32,
+    )
 }
 
 /// Parse the `s` tag value into an [`OrderStatus`].
@@ -228,6 +268,77 @@ mod tests {
         assert_eq!(order.fiat_amount, None);
         assert_eq!(order.fiat_amount_min, None);
         assert_eq!(order.fiat_amount_max, None);
+    }
+
+    /// Build a signed Kind 38383 event carrying the given `rating` tag value.
+    fn order_event_with_rating(rating_value: &str) -> Event {
+        let keys = Keys::generate();
+        EventBuilder::new(Kind::from(KIND_ORDER), "")
+            .tags([
+                Tag::parse(["d", "308e1272-d5f4-47e6-bd97-3504baea9c23"]).unwrap(),
+                Tag::parse(["k", "sell"]).unwrap(),
+                Tag::parse(["s", "pending"]).unwrap(),
+                Tag::parse(["f", "USD"]).unwrap(),
+                Tag::parse(["fa", "20"]).unwrap(),
+                Tag::parse(["rating", rating_value]).unwrap(),
+                Tag::parse(["z", "order"]).unwrap(),
+            ])
+            .sign_with_keys(&keys)
+            .unwrap()
+    }
+
+    #[test]
+    fn parses_rating_tag_object_form() {
+        let order = parse_order_event(
+            &order_event_with_rating(
+                r#"{"total_reviews":47,"total_rating":4.9,"last_rating":5,"max_rate":5,"min_rate":1,"days":312}"#,
+            ),
+            None,
+        )
+        .unwrap();
+        assert_eq!(order.rating, 4.9);
+        assert_eq!(order.total_reviews, 47);
+        assert_eq!(order.days_active, 312);
+    }
+
+    #[test]
+    fn parses_rating_tag_array_wrapped_form() {
+        let order = parse_order_event(
+            &order_event_with_rating(
+                r#"["rating",{"total_reviews":11,"total_rating":4.8,"days":203}]"#,
+            ),
+            None,
+        )
+        .unwrap();
+        assert_eq!(order.rating, 4.8);
+        assert_eq!(order.total_reviews, 11);
+        assert_eq!(order.days_active, 203);
+    }
+
+    #[test]
+    fn full_privacy_rating_none_yields_zeros() {
+        let order = parse_order_event(&order_event_with_rating("none"), None).unwrap();
+        assert_eq!(order.rating, 0.0);
+        assert_eq!(order.total_reviews, 0);
+        assert_eq!(order.days_active, 0);
+    }
+
+    #[test]
+    fn malformed_rating_json_degrades_to_zeros_without_dropping_order() {
+        let order = parse_order_event(&order_event_with_rating("{not json"), None).unwrap();
+        assert_eq!(order.rating, 0.0);
+        assert_eq!(order.total_reviews, 0);
+        assert_eq!(order.days_active, 0);
+        // The order itself must survive a bad rating tag.
+        assert_eq!(order.fiat_amount, Some(20.0));
+    }
+
+    #[test]
+    fn missing_rating_tag_yields_zeros() {
+        let order = parse_order_event(&order_event(&["20"]), None).unwrap();
+        assert_eq!(order.rating, 0.0);
+        assert_eq!(order.total_reviews, 0);
+        assert_eq!(order.days_active, 0);
     }
 
     #[test]

--- a/rust/src/nostr/order_events.rs
+++ b/rust/src/nostr/order_events.rs
@@ -125,11 +125,22 @@ fn parse_rating_tag(value: Option<&str>) -> (f64, u32, u32) {
         }
         _ => return EMPTY,
     };
-    let num = |key: &str| obj.get(key).and_then(|v| v.as_f64()).unwrap_or(0.0);
+    // Validate ranges instead of blindly casting: total_rating is defined as
+    // 0–5, and counts must be non-negative whole numbers that fit u32. Any
+    // out-of-range value falls back to that field's zero default.
     (
-        num("total_rating"),
-        num("total_reviews") as u32,
-        num("days") as u32,
+        obj.get("total_rating")
+            .and_then(|v| v.as_f64())
+            .filter(|rating| (0.0..=5.0).contains(rating))
+            .unwrap_or(0.0),
+        obj.get("total_reviews")
+            .and_then(|v| v.as_u64())
+            .and_then(|value| u32::try_from(value).ok())
+            .unwrap_or(0),
+        obj.get("days")
+            .and_then(|v| v.as_u64())
+            .and_then(|value| u32::try_from(value).ok())
+            .unwrap_or(0),
     )
 }
 
@@ -331,6 +342,72 @@ mod tests {
         assert_eq!(order.days_active, 0);
         // The order itself must survive a bad rating tag.
         assert_eq!(order.fiat_amount, Some(20.0));
+    }
+
+    #[test]
+    fn out_of_range_rating_values_fall_back_to_zeros() {
+        // total_rating above 5, negative reviews, fractional days: each
+        // invalid field independently degrades to its zero default.
+        let order = parse_order_event(
+            &order_event_with_rating(
+                r#"{"total_reviews":-3,"total_rating":9.7,"days":2.5}"#,
+            ),
+            None,
+        )
+        .unwrap();
+        assert_eq!(order.rating, 0.0);
+        assert_eq!(order.total_reviews, 0);
+        assert_eq!(order.days_active, 0);
+    }
+
+    #[test]
+    fn boundary_rating_values_are_accepted() {
+        let order = parse_order_event(
+            &order_event_with_rating(r#"{"total_reviews":0,"total_rating":5.0,"days":0}"#),
+            None,
+        )
+        .unwrap();
+        assert_eq!(order.rating, 5.0);
+
+        let order = parse_order_event(
+            &order_event_with_rating(r#"{"total_reviews":1,"total_rating":0.0,"days":1}"#),
+            None,
+        )
+        .unwrap();
+        assert_eq!(order.rating, 0.0);
+        assert_eq!(order.total_reviews, 1);
+        assert_eq!(order.days_active, 1);
+    }
+
+    #[test]
+    fn review_count_larger_than_u32_falls_back_to_zero() {
+        let order = parse_order_event(
+            &order_event_with_rating(
+                r#"{"total_reviews":4294967296,"total_rating":4.0,"days":10}"#,
+            ),
+            None,
+        )
+        .unwrap();
+        assert_eq!(order.rating, 4.0);
+        assert_eq!(order.total_reviews, 0);
+        assert_eq!(order.days_active, 10);
+    }
+
+    #[test]
+    fn order_info_json_without_reputation_fields_deserializes_with_zeros() {
+        // Rows persisted before the reputation fields existed (orders table,
+        // trades JSON) must keep loading after an app upgrade.
+        let legacy = r#"{
+            "id":"308e1272-d5f4-47e6-bd97-3504baea9c23",
+            "kind":"Buy","status":"Pending","amount_sats":null,
+            "fiat_amount":100.0,"fiat_amount_min":null,"fiat_amount_max":null,
+            "fiat_code":"USD","payment_method":"Bank","premium":0.0,
+            "creator_pubkey":"","created_at":0,"expires_at":null,"is_mine":false
+        }"#;
+        let order: OrderInfo = serde_json::from_str(legacy).unwrap();
+        assert_eq!(order.rating, 0.0);
+        assert_eq!(order.total_reviews, 0);
+        assert_eq!(order.days_active, 0);
     }
 
     #[test]

--- a/specs/004-mostro-p2p-client/data-model.md
+++ b/specs/004-mostro-p2p-client/data-model.md
@@ -51,12 +51,16 @@ A buy or sell offer on the Mostro network.
 | nostr_event_id | String? | Kind 38383 event ID on relay |
 | is_mine | bool | Whether current user created this order |
 | cached_at | Timestamp | When this order was last fetched/updated locally |
+| rating | f64 | Maker reputation from the Kind 38383 `rating` tag (`total_rating`, 0–5; 0.0 = none/full privacy) |
+| total_reviews | u32 | Number of reviews behind `rating` (`total_reviews`) |
+| days_active | u32 | Days the maker has been active on the node (`days`) |
 
 **Validation rules**:
 - `fiat_code` MUST be a valid ISO 4217 code.
 - Either `fiat_amount` OR both `fiat_amount_min` and `fiat_amount_max` MUST be provided, but NOT both. If `fiat_amount` is present, `fiat_amount_min` and `fiat_amount_max` MUST be absent; if `fiat_amount_min`/`fiat_amount_max` are present, `fiat_amount` MUST be absent.
 - If range: `fiat_amount_min` MUST be > 0 and < `fiat_amount_max`.
 - `premium` is a signed float (negative = discount).
+- `rating` MUST be within 0–5; out-of-range or malformed `rating`-tag values degrade to 0 without rejecting the order.
 
 **State machine** (15 mostro-core states):
 ```text

--- a/specs/004-mostro-p2p-client/data-model.md
+++ b/specs/004-mostro-p2p-client/data-model.md
@@ -51,7 +51,7 @@ A buy or sell offer on the Mostro network.
 | nostr_event_id | String? | Kind 38383 event ID on relay |
 | is_mine | bool | Whether current user created this order |
 | cached_at | Timestamp | When this order was last fetched/updated locally |
-| rating | f64 | Maker reputation from the Kind 38383 `rating` tag (`total_rating`, 0–5; 0.0 = none/full privacy) |
+| rating | f64 | Maker reputation from the Kind 38383 `rating` tag (`total_rating`, 0–5; 0.0 = no reputation: full privacy (`none`), missing tag, or malformed/invalid data) |
 | total_reviews | u32 | Number of reviews behind `rating` (`total_reviews`) |
 | days_active | u32 | Days the maker has been active on the node (`days`) |
 
@@ -60,7 +60,7 @@ A buy or sell offer on the Mostro network.
 - Either `fiat_amount` OR both `fiat_amount_min` and `fiat_amount_max` MUST be provided, but NOT both. If `fiat_amount` is present, `fiat_amount_min` and `fiat_amount_max` MUST be absent; if `fiat_amount_min`/`fiat_amount_max` are present, `fiat_amount` MUST be absent.
 - If range: `fiat_amount_min` MUST be > 0 and < `fiat_amount_max`.
 - `premium` is a signed float (negative = discount).
-- `rating` MUST be within 0–5; out-of-range or malformed `rating`-tag values degrade to 0 without rejecting the order.
+- `rating` MUST be within 0–5. Each reputation field (`rating`, `total_reviews`, `days_active`) is validated independently: an out-of-range, non-integer, or malformed value degrades that field alone to 0, and the order is never rejected because of its `rating` tag.
 
 **State machine** (15 mostro-core states):
 ```text

--- a/test/features/home/order_item_reputation_test.dart
+++ b/test/features/home/order_item_reputation_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro/features/home/providers/home_order_providers.dart';
+import 'package:mostro/src/rust/api/types.dart';
+
+OrderInfo _info({
+  double rating = 0,
+  int totalReviews = 0,
+  int daysActive = 0,
+}) {
+  return OrderInfo(
+    id: 'order-1',
+    kind: OrderKind.sell,
+    status: OrderStatus.pending,
+    fiatAmount: 100,
+    fiatCode: 'USD',
+    paymentMethod: 'Wire',
+    premium: 1.5,
+    creatorPubkey: 'node-pubkey',
+    createdAt: 1000,
+    isMine: false,
+    rating: rating,
+    totalReviews: totalReviews,
+    daysActive: daysActive,
+  );
+}
+
+void main() {
+  group('OrderItem.fromInfo reputation mapping', () {
+    test('maps rating, totalReviews, and daysActive from the bridge', () {
+      // Arrange
+      final info = _info(rating: 4.9, totalReviews: 47, daysActive: 312);
+
+      // Act
+      final item = OrderItem.fromInfo(info);
+
+      // Assert
+      expect(item.rating, 4.9);
+      expect(item.tradeCount, 47);
+      expect(item.daysActive, 312);
+    });
+
+    test('keeps zeros for makers with no reputation (full privacy)', () {
+      // Arrange
+      final info = _info();
+
+      // Act
+      final item = OrderItem.fromInfo(info);
+
+      // Assert
+      expect(item.rating, 0.0);
+      expect(item.tradeCount, 0);
+      expect(item.daysActive, 0);
+    });
+  });
+}

--- a/test/support/fake_trades.dart
+++ b/test/support/fake_trades.dart
@@ -23,6 +23,9 @@ TradeInfo fakeTrade({
     creatorPubkey: 'pubkey-$id',
     createdAt: startedAt,
     isMine: isMine,
+    rating: 0,
+    totalReviews: 0,
+    daysActive: 0,
   );
 
   return TradeInfo(


### PR DESCRIPTION
## Summary

Fixes the order book showing **0.0 rating / 0 trades / 0 days** for every live order. This gap predates the UI redesign (#243): when the real Kind 38383 bridge replaced the phase-5 demo data (`8bc109f`), `OrderInfo` never gained reputation fields and the parser silently dropped the daemon's `rating` tag — so both the order-book card and the take-order "Creator reputation" block have rendered zeros ever since.

### What changed

- **`rust/src/nostr/order_events.rs`**: `parse_order_event` now parses the `rating` tag the daemon publishes on each 38383 order (mostro-core `Rating` snapshot). Accepted shapes, mirroring the v1 client:
  - plain JSON object `{"total_reviews":47,"total_rating":4.9,...,"days":312}`
  - legacy array wrapping `["rating", {…}]`
  - `"none"` (full-privacy maker) → zeros
  - missing tag or malformed JSON → zeros, **without dropping the order**
- **`rust/src/api/types.rs`**: `OrderInfo` gains `rating: f64`, `total_reviews: u32`, `days_active: u32` (documented; zeros mean "no reputation to show").
- **`lib/features/home/providers/home_order_providers.dart`**: `OrderItem.fromInfo` maps the three new fields, so the redesigned order-book card and `take_order_screen`'s reputation block now display real maker reputation with no further UI change.
- flutter_rust_bridge bindings regenerated (pinned codegen 2.11.1).

### Tests

- 5 new Rust parser cases: object form, array-wrapped form, `"none"`, malformed JSON (order must survive), missing tag.
- New Dart test `order_item_reputation_test.dart` covering the `fromInfo` mapping (real values and full-privacy zeros).
- `cargo test` 143/143, `cargo clippy` clean, `flutter analyze` clean, `flutter test` 158/158.

## Manual testing guide

1. `flutter run` against a Mostro node with active makers (or use mostro-cli to publish an order from an identity with completed trades).
2. Open the Order Book: cards from makers with history must show non-zero `★ rating · N trades · N days` matching the `rating` tag content of their 38383 events (inspect with any Nostr relay browser).
3. Orders from full-privacy makers (`rating: none`) and freshly created identities must still render `0 · 0 trades · 0 days` and must not disappear from the book.
4. Tap an order → the "Creator reputation" card on the take-order screen shows the same values.
5. Regression: creating your own order still works (own orders carry zeros until the daemon's confirmation event arrives with the real snapshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQUKX88xRBCPsHQTXBEiYa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Order listings now show maker reputation details: rating, total review count, and activity duration.
  - Reputation data is supported end-to-end through newly created/updated orders and incoming order events.

- **Bug Fixes**
  - Fixed order-to-UI mapping so reputation fields populate correctly instead of defaulting.

- **Tests**
  - Added widget and parsing coverage for valid reputation values, private/none handling, missing tags, malformed input, and out-of-range/boundary cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->