### PR TITLE
fix(storage): keep the Linux databases out of the user's Documents folder

### DIFF
--- a/lib/core/storage/app_data_dir.dart
+++ b/lib/core/storage/app_data_dir.dart
@@ -1,0 +1,69 @@
+/// Where the app keeps its own persistent files (SQLite / Sembast databases).
+///
+/// This is deliberately NOT `getApplicationDocumentsDirectory()`: on Linux that
+/// resolves to the user's visible Documents folder (`XDG_DOCUMENTS_DIR`), so the
+/// identity, trade history and outbox lived one spring-clean away from deletion.
+/// Per the XDG Base Directory spec, app state belongs in `$XDG_DATA_HOME`
+/// (default `~/.local/share`), which is what this resolves to on Linux.
+///
+/// Native-only — the web build gets `app_data_dir_web.dart` through a
+/// conditional import (Sembast on web is keyed by name, not by path).
+library;
+
+import 'dart:io' show Directory, Platform;
+
+import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+/// Directory name used under the resolved data root. Kept short and stable:
+/// renaming it strands every existing installation's database.
+const _appDirName = 'mostro';
+
+/// Resolves the Linux data directory from [env], per the XDG Base Directory
+/// spec: `$XDG_DATA_HOME/mostro`, falling back to `$HOME/.local/share/mostro`
+/// when `XDG_DATA_HOME` is unset, empty, or relative (the spec says a relative
+/// value must be ignored). Returns `null` when neither variable is usable, so
+/// the caller can fall back to path_provider instead of guessing.
+String? resolveLinuxDataDir(Map<String, String> env) {
+  final xdgDataHome = env['XDG_DATA_HOME'];
+  if (xdgDataHome != null &&
+      xdgDataHome.isNotEmpty &&
+      p.isAbsolute(xdgDataHome)) {
+    return p.join(xdgDataHome, _appDirName);
+  }
+
+  final home = env['HOME'];
+  if (home != null && home.isNotEmpty && p.isAbsolute(home)) {
+    return p.join(home, '.local', 'share', _appDirName);
+  }
+
+  return null;
+}
+
+/// Absolute path of the app's data directory, created if it does not exist.
+///
+/// Linux uses the XDG data dir; every other platform keeps
+/// `getApplicationDocumentsDirectory()`, which is already app-private there
+/// (Android/iOS sandbox). macOS and Windows desktop have the same
+/// user-visible-folder problem and are left for their own change.
+Future<String> appDataDirPath() async {
+  if (Platform.isLinux) {
+    final resolved = resolveLinuxDataDir(Platform.environment);
+    if (resolved != null) {
+      try {
+        await Directory(resolved).create(recursive: true);
+        return resolved;
+      } catch (e) {
+        // An unwritable data dir is worth reporting, but not worth failing
+        // startup over while a usable fallback exists.
+        debugPrint('[storage] cannot create $resolved: $e — falling back');
+      }
+    } else {
+      debugPrint('[storage] no usable XDG_DATA_HOME or HOME — falling back');
+    }
+  }
+
+  final dir = await getApplicationDocumentsDirectory();
+  return dir.path;
+}

--- a/lib/core/storage/app_data_dir.dart
+++ b/lib/core/storage/app_data_dir.dart
@@ -25,17 +25,20 @@ const _appDirName = 'mostro';
 /// when `XDG_DATA_HOME` is unset, empty, or relative (the spec says a relative
 /// value must be ignored). Returns `null` when neither variable is usable, so
 /// the caller can fall back to path_provider instead of guessing.
+/// Uses `p.posix` rather than the ambient path style on purpose: these are
+/// Linux paths, and they must not pick up Windows separators when this runs on
+/// another host (the analyzer, or the test suite on a developer's machine).
 String? resolveLinuxDataDir(Map<String, String> env) {
   final xdgDataHome = env['XDG_DATA_HOME'];
   if (xdgDataHome != null &&
       xdgDataHome.isNotEmpty &&
-      p.isAbsolute(xdgDataHome)) {
-    return p.join(xdgDataHome, _appDirName);
+      p.posix.isAbsolute(xdgDataHome)) {
+    return p.posix.join(xdgDataHome, _appDirName);
   }
 
   final home = env['HOME'];
-  if (home != null && home.isNotEmpty && p.isAbsolute(home)) {
-    return p.join(home, '.local', 'share', _appDirName);
+  if (home != null && home.isNotEmpty && p.posix.isAbsolute(home)) {
+    return p.posix.join(home, '.local', 'share', _appDirName);
   }
 
   return null;
@@ -47,9 +50,18 @@ String? resolveLinuxDataDir(Map<String, String> env) {
 /// `getApplicationDocumentsDirectory()`, which is already app-private there
 /// (Android/iOS sandbox). macOS and Windows desktop have the same
 /// user-visible-folder problem and are left for their own change.
-Future<String> appDataDirPath() async {
-  if (Platform.isLinux) {
-    final resolved = resolveLinuxDataDir(Platform.environment);
+///
+/// [env], [isLinux] and [documentsDirPath] exist only as test seams — they
+/// default to the real platform, so callers pass nothing. They let a test drive
+/// the Linux branch and observe the fallback on any host, without a filesystem
+/// abstraction: an unwritable directory is provoked with a real path instead.
+Future<String> appDataDirPath({
+  Map<String, String>? env,
+  bool? isLinux,
+  Future<String> Function()? documentsDirPath,
+}) async {
+  if (isLinux ?? Platform.isLinux) {
+    final resolved = resolveLinuxDataDir(env ?? Platform.environment);
     if (resolved != null) {
       try {
         await Directory(resolved).create(recursive: true);
@@ -64,6 +76,8 @@ Future<String> appDataDirPath() async {
     }
   }
 
-  final dir = await getApplicationDocumentsDirectory();
-  return dir.path;
+  return (documentsDirPath ?? _documentsDirPath)();
 }
+
+Future<String> _documentsDirPath() async =>
+    (await getApplicationDocumentsDirectory()).path;

--- a/lib/core/storage/app_data_dir_web.dart
+++ b/lib/core/storage/app_data_dir_web.dart
@@ -1,0 +1,9 @@
+// Web stub — there is no filesystem path to hand out on web, where Sembast
+// keys its database by name and the Rust core uses IndexedDB.
+// Mirrors app_data_dir.dart's signature so conditional imports compile; the
+// implementation is never called (callers guard with kIsWeb before use).
+library;
+
+Future<String> appDataDirPath() async {
+  throw UnsupportedError('appDataDirPath is not supported on web');
+}

--- a/lib/features/notifications/providers/notifications_provider.dart
+++ b/lib/features/notifications/providers/notifications_provider.dart
@@ -6,9 +6,10 @@ import 'package:uuid/uuid.dart';
 
 import 'package:mostro/features/notifications/models/notification_model.dart';
 
-// Platform-specific imports — path_provider is only needed on non-web.
-import 'package:path_provider/path_provider.dart'
-    if (dart.library.html) 'package:mostro/core/stubs/path_provider_stub.dart';
+// Platform-specific imports — the data directory only exists off web.
+import 'package:path/path.dart' as p;
+import 'package:mostro/core/storage/app_data_dir.dart'
+    if (dart.library.html) 'package:mostro/core/storage/app_data_dir_web.dart';
 import 'package:sembast/sembast.dart';
 import 'package:mostro/features/notifications/providers/sembast_factory_io.dart'
     if (dart.library.html) 'package:mostro/features/notifications/providers/sembast_factory_web.dart';
@@ -50,9 +51,8 @@ class SembastNotificationsStore {
       } else if (kIsWeb) {
         db = await databaseFactoryWeb.openDatabase(_dbName);
       } else {
-        final dir = await getApplicationDocumentsDirectory();
-        final path = '${dir.path}/$_dbName';
-        db = await databaseFactoryIo.openDatabase(path);
+        final dir = await appDataDirPath();
+        db = await databaseFactoryIo.openDatabase(p.join(dir, _dbName));
       }
       _db = db;
       _opening!.complete(db);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,8 +3,11 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:path/path.dart' as p;
-import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+// Resolves the app's own data directory — never the user-visible Documents
+// folder. Web gets the stub; main() only calls it behind `!kIsWeb`.
+import 'package:mostro/core/storage/app_data_dir.dart'
+    if (dart.library.html) 'package:mostro/core/storage/app_data_dir_web.dart';
 import 'package:mostro/core/app.dart';
 import 'package:mostro/core/mostro_defaults.dart';
 import 'package:mostro/core/services/identity_service.dart';
@@ -58,8 +61,8 @@ Future<void> main() async {
   // operations that read or write trade keys and trade records.
   if (!kIsWeb) {
     try {
-      final docsDir = await getApplicationDocumentsDirectory();
-      await rust_api.initDb(path: p.join(docsDir.path, 'mostro.db'));
+      final dataDir = await appDataDirPath();
+      await rust_api.initDb(path: p.join(dataDir, 'mostro.db'));
     } catch (e, st) {
       // DB init failure is non-fatal: trade-key and role persistence won't
       // work for this session, but the app can still browse orders and relay

--- a/test/core/storage/app_data_dir_test.dart
+++ b/test/core/storage/app_data_dir_test.dart
@@ -1,7 +1,75 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mostro/core/storage/app_data_dir.dart';
+import 'package:path/path.dart' as p;
 
 void main() {
+  group('appDataDirPath', () {
+    late Directory tmp;
+
+    setUp(() async {
+      tmp = await Directory.systemTemp.createTemp('mostro_data_dir_test_');
+    });
+
+    tearDown(() async {
+      if (tmp.existsSync()) await tmp.delete(recursive: true);
+    });
+
+    test('creates the resolved directory and returns it', () async {
+      // Arrange — a data root that exists but has no 'mostro' subdirectory yet.
+      final env = {'XDG_DATA_HOME': tmp.path, 'HOME': tmp.path};
+
+      // Act
+      final path = await appDataDirPath(
+        env: env,
+        isLinux: true,
+        documentsDirPath: () async => fail('must not fall back'),
+      );
+
+      // Assert — created, and inside the data root rather than Documents.
+      expect(path, p.posix.join(tmp.path, 'mostro'));
+      expect(Directory(path).existsSync(), isTrue);
+    });
+
+    test('falls back to the documents directory when creation fails', () async {
+      // Arrange — XDG_DATA_HOME points at a *file*, so creating a directory
+      // under it fails the way an unwritable data root would.
+      final blocker = File(p.join(tmp.path, 'not-a-dir'))..writeAsStringSync('');
+      final env = {'XDG_DATA_HOME': blocker.path, 'HOME': blocker.path};
+
+      // Act
+      final path = await appDataDirPath(
+        env: env,
+        isLinux: true,
+        documentsDirPath: () async => '/fallback/documents',
+      );
+
+      // Assert — startup survives on the fallback instead of throwing.
+      expect(path, '/fallback/documents');
+    });
+
+    test('uses the documents directory on platforms other than Linux', () async {
+      final path = await appDataDirPath(
+        env: {'XDG_DATA_HOME': tmp.path},
+        isLinux: false,
+        documentsDirPath: () async => '/fallback/documents',
+      );
+
+      expect(path, '/fallback/documents');
+    });
+
+    test('falls back when the environment resolves to no path at all', () async {
+      final path = await appDataDirPath(
+        env: const {},
+        isLinux: true,
+        documentsDirPath: () async => '/fallback/documents',
+      );
+
+      expect(path, '/fallback/documents');
+    });
+  });
+
   group('resolveLinuxDataDir', () {
     test('uses XDG_DATA_HOME when it is set to an absolute path', () {
       // Arrange

--- a/test/core/storage/app_data_dir_test.dart
+++ b/test/core/storage/app_data_dir_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro/core/storage/app_data_dir.dart';
+
+void main() {
+  group('resolveLinuxDataDir', () {
+    test('uses XDG_DATA_HOME when it is set to an absolute path', () {
+      // Arrange
+      final env = {'XDG_DATA_HOME': '/home/u/.local/share', 'HOME': '/home/u'};
+
+      // Act
+      final dir = resolveLinuxDataDir(env);
+
+      // Assert
+      expect(dir, '/home/u/.local/share/mostro');
+    });
+
+    test('honours an XDG_DATA_HOME pointing outside ~/.local/share', () {
+      final dir =
+          resolveLinuxDataDir({'XDG_DATA_HOME': '/data/xdg', 'HOME': '/home/u'});
+
+      expect(dir, '/data/xdg/mostro');
+    });
+
+    test('falls back to \$HOME/.local/share when XDG_DATA_HOME is unset', () {
+      final dir = resolveLinuxDataDir({'HOME': '/home/u'});
+
+      expect(dir, '/home/u/.local/share/mostro');
+    });
+
+    test('falls back to \$HOME when XDG_DATA_HOME is empty', () {
+      // The XDG spec treats an empty value exactly like an unset one.
+      final dir =
+          resolveLinuxDataDir({'XDG_DATA_HOME': '', 'HOME': '/home/u'});
+
+      expect(dir, '/home/u/.local/share/mostro');
+    });
+
+    test('ignores a relative XDG_DATA_HOME, as the XDG spec requires', () {
+      // A relative value would resolve against the process working directory,
+      // putting the database somewhere unpredictable.
+      final dir =
+          resolveLinuxDataDir({'XDG_DATA_HOME': '.share', 'HOME': '/home/u'});
+
+      expect(dir, '/home/u/.local/share/mostro');
+    });
+
+    test('returns null when neither XDG_DATA_HOME nor HOME is usable', () {
+      // The caller must fall back to path_provider rather than guess a path.
+      expect(resolveLinuxDataDir(const {}), isNull);
+      expect(resolveLinuxDataDir(const {'HOME': ''}), isNull);
+      expect(resolveLinuxDataDir(const {'HOME': 'relative/home'}), isNull);
+    });
+
+    test('never resolves inside the user-visible Documents folder', () {
+      // Regression: the database used to live in getApplicationDocumentsDirectory(),
+      // i.e. XDG_DOCUMENTS_DIR — a folder users tidy up, deleting their identity
+      // and trade history by accident.
+      final dir = resolveLinuxDataDir({
+        'HOME': '/home/u',
+        'XDG_DOCUMENTS_DIR': '/home/u/Documentos',
+      });
+
+      expect(dir, isNot(contains('Documentos')));
+      expect(dir, isNot(contains('Documents')));
+    });
+  });
+}


### PR DESCRIPTION
## Problem

On Linux, `getApplicationDocumentsDirectory()` resolves to `XDG_DOCUMENTS_DIR`, so both databases were written into the user's **visible Documents folder**:

```
~/Documentos/mostro.db        # SQLite: trades, orders, chat, outbox, trade keys
~/Documentos/notifications.db # Sembast
```

That is a folder people clean out. Deleting `mostro.db` there silently wipes trade history, chat history, the outbox and the persisted BIP-32 trade-key indices — with no warning and no way back.

## Fix

Resolve an app-owned directory, per the [XDG Base Directory spec](https://specifications.freedesktop.org/basedir-spec/latest/):

| Environment | Resulting directory |
| --- | --- |
| `XDG_DATA_HOME=/data/xdg` | `/data/xdg/mostro` |
| unset / empty / **relative** (spec says ignore) | `$HOME/.local/share/mostro` |
| no usable `XDG_DATA_HOME` nor `HOME` | falls back to `path_provider` |

New `lib/core/storage/app_data_dir.dart` exposes a pure `resolveLinuxDataDir(env)` (fully unit-tested) plus `appDataDirPath()`, which creates the directory and falls back rather than failing startup if it cannot.

**Scope:** Linux only. Other platforms keep the documents directory — it is already app-private on Android/iOS. macOS and Windows desktop have the same user-visible-folder problem and deserve their own change.

**No migration.** An existing database in the old location is left untouched and the new location starts empty. The Nostr identity lives in `flutter_secure_storage`, so keys survive a fresh start; local trade/chat history does not.

**Web unaffected:** `app_data_dir_web.dart` keeps the conditional import compiling, and Sembast/IndexedDB there are keyed by name, not by path.

## Test plan

- [x] `flutter test` — 180 passing, including 7 new cases for `resolveLinuxDataDir` (XDG set / unset / empty / relative, no-HOME, and a regression assert that the path never lands in a `Documents`-like folder)
- [x] `flutter analyze` — no issues
- [x] `flutter build linux --release` + launch: no `DB init failed`, and both `mostro.db` and `notifications.db` are created under `~/.local/share/mostro/`
- [x] `flutter build web --release` — compiles, conditional import intact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added platform-aware app data storage for persistent files.
  * Linux now follows standard data directory settings and creates the directory when needed.
  * Web builds clearly indicate that filesystem storage is unavailable.

* **Bug Fixes**
  * Moved local database storage away from user-visible Documents folders.

* **Tests**
  * Added coverage for Linux storage path selection and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->