### PR TITLE
fix(identity): keep the trade-key counter durable outside mostro.db

### DIFF
--- a/lib/core/services/identity_service.dart
+++ b/lib/core/services/identity_service.dart
@@ -52,6 +52,40 @@ class IdentityService {
     }
   }
 
+  /// Decide what to write to secure storage for an [incoming] consumed trade
+  /// key index, given the [current] stored raw value. Returns null when the
+  /// write should be skipped.
+  ///
+  /// The counter must never move backwards — a lower value means re-deriving
+  /// keys the daemon already registered, which it rejects with
+  /// `InvalidTradeIndex`. An unparsable or missing stored value is treated as
+  /// "nothing known", so [incoming] wins.
+  static int? nextStoredTradeKeyIndex(String? current, int incoming) {
+    final stored = int.tryParse(current ?? '');
+    if (stored != null && stored >= incoming) return null;
+    return incoming;
+  }
+
+  /// Mirror a consumed trade key index into secure storage.
+  ///
+  /// Rust owns the counter and persists it in `mostro.db`; this is the second
+  /// durable copy, and the only one that survives loss of that file. On the
+  /// next launch [_loadExisting] passes it back and Rust reconciles the two by
+  /// taking the higher (issue #249).
+  ///
+  /// Never throws: failing to mirror must not break an order that has already
+  /// been created, and the database copy still holds.
+  static Future<void> saveTradeKeyIndex(int index) async {
+    try {
+      final current = await _storage.read(key: _kTradeKeyIndex);
+      final next = nextStoredTradeKeyIndex(current, index);
+      if (next == null) return;
+      await _storage.write(key: _kTradeKeyIndex, value: next.toString());
+    } catch (e) {
+      debugPrint('[identity] saveTradeKeyIndex($index) error: $e');
+    }
+  }
+
   /// Persist privacy mode setting.
   static Future<void> savePrivacyMode(bool enabled) async {
     try {

--- a/lib/features/order/screens/add_order_screen.dart
+++ b/lib/features/order/screens/add_order_screen.dart
@@ -204,7 +204,11 @@ class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
       // instead of the raw marker. The order was not created.
       final display = msg.contains('NoDaemonResponse')
           ? AppLocalizations.of(context).sessionTimeoutMessage
-          : msg;
+          // No durable storage means the trade-key counter cannot be recorded,
+          // so no key is derived and no order is created (issue #249).
+          : msg.contains('StorageUnavailable')
+              ? AppLocalizations.of(context).storageUnavailable
+              : msg;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(display)),
       );

--- a/lib/features/order/screens/take_order_screen.dart
+++ b/lib/features/order/screens/take_order_screen.dart
@@ -165,7 +165,11 @@ class _TakeOrderScreenState extends ConsumerState<TakeOrderScreen> {
             ? l10n.sessionTimeoutMessage
             : msg.contains('BondRequired')
                 ? l10n.bondRequired
-                : msg;
+                // No durable storage means the trade-key counter cannot be
+                // recorded, so no key is derived and the take never happens.
+                : msg.contains('StorageUnavailable')
+                    ? l10n.storageUnavailable
+                    : msg;
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text(display)),
         );

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -71,6 +71,7 @@
   "submitButtonLabel": "Absenden",
   "orderAlreadyTaken": "Die Bestellung wurde bereits angenommen",
   "bondRequired": "Dieser Node verlangt eine Anti-Missbrauch-Kaution, die noch nicht unterstützt wird",
+  "storageUnavailable": "Die App kann keine Orders erstellen oder annehmen, solange ihre lokale Datenbank nicht verfügbar ist. Starte die App neu und versuche es erneut",
   "addInvoiceAmount": "Zu erhaltender Betrag: {sats} sats",
   "payInvoiceAmount": "Zu zahlender Betrag: {sats} sats",
   "orderIdCopied": "Bestell-ID kopiert",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -156,6 +156,8 @@
   "@orderAlreadyTaken": {"description": "Error message when attempting to take an already-taken order"},
   "bondRequired": "This node requires an anti-abuse bond, which is not supported yet",
   "@bondRequired": {"description": "Error shown when the Mostro node asks for an anti-abuse bond before accepting the order — the app does not support bonds yet"},
+  "storageUnavailable": "The app cannot create or take orders while its local database is unavailable. Restart the app and try again",
+  "@storageUnavailable": {"description": "Error shown when a trade key cannot be derived because the local database is unavailable, so orders cannot be created or taken"},
   "addInvoiceAmount": "Amount to receive: {sats} sats",
   "@addInvoiceAmount": {
     "description": "Sats amount (calculated by the Mostro daemon) the buyer's invoice must be for, shown on the add-invoice screen",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -71,6 +71,7 @@
   "submitButtonLabel": "Enviar",
   "orderAlreadyTaken": "La orden ya fue tomada",
   "bondRequired": "Este nodo requiere un bono anti-abuso, que aún no está soportado",
+  "storageUnavailable": "La app no puede crear ni tomar órdenes mientras su base de datos local no esté disponible. Reinicia la app e inténtalo de nuevo",
   "addInvoiceAmount": "Cantidad a recibir: {sats} sats",
   "payInvoiceAmount": "Cantidad a pagar: {sats} sats",
   "orderIdCopied": "ID de orden copiado",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -71,6 +71,7 @@
   "submitButtonLabel": "Soumettre",
   "orderAlreadyTaken": "Cet ordre a déjà été pris",
   "bondRequired": "Ce nœud exige une caution anti-abus, qui n'est pas encore prise en charge",
+  "storageUnavailable": "L'application ne peut pas créer ni prendre d'ordres tant que sa base de données locale est indisponible. Redémarrez l'application et réessayez",
   "addInvoiceAmount": "Montant à recevoir : {sats} sats",
   "payInvoiceAmount": "Montant à payer : {sats} sats",
   "orderIdCopied": "ID d'ordre copié",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -71,6 +71,7 @@
   "submitButtonLabel": "Invia",
   "orderAlreadyTaken": "L'ordine è già stato preso",
   "bondRequired": "Questo nodo richiede una cauzione anti-abuso, non ancora supportata",
+  "storageUnavailable": "L'app non può creare né prendere ordini finché il suo database locale non è disponibile. Riavvia l'app e riprova",
   "addInvoiceAmount": "Importo da ricevere: {sats} sats",
   "payInvoiceAmount": "Importo da pagare: {sats} sats",
   "orderIdCopied": "ID ordine copiato",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -488,6 +488,12 @@ abstract class AppLocalizations {
   /// **'This node requires an anti-abuse bond, which is not supported yet'**
   String get bondRequired;
 
+  /// Error shown when a trade key cannot be derived because the local database is unavailable, so orders cannot be created or taken
+  ///
+  /// In en, this message translates to:
+  /// **'The app cannot create or take orders while its local database is unavailable. Restart the app and try again'**
+  String get storageUnavailable;
+
   /// Sats amount (calculated by the Mostro daemon) the buyer's invoice must be for, shown on the add-invoice screen
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -236,6 +236,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Dieser Node verlangt eine Anti-Missbrauch-Kaution, die noch nicht unterstützt wird';
 
   @override
+  String get storageUnavailable =>
+      'Die App kann keine Orders erstellen oder annehmen, solange ihre lokale Datenbank nicht verfügbar ist. Starte die App neu und versuche es erneut';
+
+  @override
   String addInvoiceAmount(String sats) {
     return 'Zu erhaltender Betrag: $sats sats';
   }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -233,6 +233,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'This node requires an anti-abuse bond, which is not supported yet';
 
   @override
+  String get storageUnavailable =>
+      'The app cannot create or take orders while its local database is unavailable. Restart the app and try again';
+
+  @override
   String addInvoiceAmount(String sats) {
     return 'Amount to receive: $sats sats';
   }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -236,6 +236,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Este nodo requiere un bono anti-abuso, que aún no está soportado';
 
   @override
+  String get storageUnavailable =>
+      'La app no puede crear ni tomar órdenes mientras su base de datos local no esté disponible. Reinicia la app e inténtalo de nuevo';
+
+  @override
   String addInvoiceAmount(String sats) {
     return 'Cantidad a recibir: $sats sats';
   }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -238,6 +238,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Ce nœud exige une caution anti-abus, qui n\'est pas encore prise en charge';
 
   @override
+  String get storageUnavailable =>
+      'L\'application ne peut pas créer ni prendre d\'ordres tant que sa base de données locale est indisponible. Redémarrez l\'application et réessayez';
+
+  @override
   String addInvoiceAmount(String sats) {
     return 'Montant à recevoir : $sats sats';
   }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -236,6 +236,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Questo nodo richiede una cauzione anti-abuso, non ancora supportata';
 
   @override
+  String get storageUnavailable =>
+      'L\'app non può creare né prendere ordini finché il suo database locale non è disponibile. Riavvia l\'app e riprova';
+
+  @override
   String addInvoiceAmount(String sats) {
     return 'Importo da ricevere: $sats sats';
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,6 +25,7 @@ import 'package:mostro/src/rust/api/nostr.dart' as nostr_api;
 import 'package:mostro/src/rust/api/orders.dart' as orders_api;
 import 'package:mostro/src/rust/api/settings.dart' as settings_api;
 import 'package:mostro/src/rust/api/bond.dart' as bond_api;
+import 'package:mostro/src/rust/api/identity.dart' as identity_api;
 import 'package:mostro/src/rust/api/types.dart' show SlashCause, BondSlashedEvent;
 import 'package:mostro/features/notifications/models/notification_model.dart';
 import 'package:mostro/features/notifications/providers/notifications_provider.dart';
@@ -94,6 +95,15 @@ Future<void> main() async {
     markBridgeFailed(e);
   }
 
+  // Mirror consumed trade-key indices into secure storage — the copy that
+  // outlives mostro.db, which Rust keeps as the primary record (issue #249).
+  //
+  // Subscribed BEFORE identity init on purpose: loading the identity is itself
+  // a publication point (when the database knew a higher counter than secure
+  // storage, the reconciled value is published so this copy catches up), and
+  // the Tokio broadcast channel drops a value that has no receiver yet.
+  _mirrorTradeKeyIndex(await identity_api.onTradeKeyIndexChanged());
+
   // Initialize identity: creates on first launch, reloads on subsequent launches.
   // Must run before Nostr init so the identity key is available for relay auth.
   try {
@@ -149,6 +159,27 @@ Future<void> main() async {
     container: container,
     child: const MostroApp(),
   ));
+}
+
+/// Persists every consumed trade-key index reported by Rust.
+///
+/// Runs for the process lifetime. A write failure is logged and the loop
+/// continues: the database copy is still authoritative, and the next index
+/// (or the load-time reconciliation) supersedes the one that was missed.
+void _mirrorTradeKeyIndex(identity_api.TradeKeyIndexStream stream) {
+  Future.microtask(() async {
+    while (true) {
+      final int index;
+      try {
+        index = await stream.next();
+      } catch (e) {
+        debugPrint('[identity] trade-key index stream closed: $e');
+        break;
+      }
+      debugPrint('[identity] mirroring trade-key index $index to secure storage');
+      await IdentityService.saveTradeKeyIndex(index);
+    }
+  });
 }
 
 /// Reconnect a previously saved NWC wallet in the background.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -102,7 +102,14 @@ Future<void> main() async {
   // a publication point (when the database knew a higher counter than secure
   // storage, the reconciled value is published so this copy catches up), and
   // the Tokio broadcast channel drops a value that has no receiver yet.
-  _mirrorTradeKeyIndex(await identity_api.onTradeKeyIndexChanged());
+  // Guarded like every other optional startup step: if the bridge is broken
+  // the mirror is simply absent — the database copy is still the primary
+  // record — rather than taking main() down before the UI renders.
+  try {
+    _mirrorTradeKeyIndex(await identity_api.onTradeKeyIndexChanged());
+  } catch (e) {
+    debugPrint('[identity] trade-key index mirror unavailable: $e');
+  }
 
   // Initialize identity: creates on first launch, reloads on subsequent launches.
   // Must run before Nostr init so the identity key is available for relay auth.

--- a/rust/src/api/identity.rs
+++ b/rust/src/api/identity.rs
@@ -14,6 +14,8 @@
 use anyhow::{anyhow, bail, Result};
 use nostr_sdk::prelude::*;
 use std::sync::OnceLock;
+use tokio::sync::broadcast;
+use tokio::sync::broadcast::error::RecvError;
 use tokio::sync::RwLock;
 
 use crate::api::types::{IdentityInfo, NymIdentity};
@@ -31,6 +33,59 @@ struct IdentityState {
 fn identity_lock() -> &'static RwLock<Option<IdentityState>> {
     static IDENTITY: OnceLock<RwLock<Option<IdentityState>>> = OnceLock::new();
     IDENTITY.get_or_init(|| RwLock::new(None))
+}
+
+// ── Trade-key counter publication ────────────────────────────────────────────
+
+/// Derivations are rare and Dart consumes them immediately; a small buffer is
+/// ample. `Lagged` is skipped rather than fatal, and the counter is monotonic,
+/// so a skipped value is superseded by the next one.
+const TRADE_KEY_INDEX_CHANNEL_CAPACITY: usize = 16;
+
+fn trade_key_index_tx() -> &'static broadcast::Sender<u32> {
+    static TX: OnceLock<broadcast::Sender<u32>> = OnceLock::new();
+    TX.get_or_init(|| broadcast::channel(TRADE_KEY_INDEX_CHANNEL_CAPACITY).0)
+}
+
+/// Publishes a consumed trade-key index so Flutter can mirror it into secure
+/// storage — the one store that survives loss of `mostro.db` (issue #249).
+/// Send failures mean nobody is listening yet, which is not an error: the DB
+/// row remains the primary record and load-time reconciliation catches up.
+fn publish_trade_key_index(index: u32) {
+    let _ = trade_key_index_tx().send(index);
+}
+
+/// A stream of consumed trade-key indices for the Dart layer to persist.
+pub struct TradeKeyIndexStream {
+    rx: broadcast::Receiver<u32>,
+}
+
+impl TradeKeyIndexStream {
+    /// Poll for the next consumed index.
+    ///
+    /// `RecvError::Lagged` is skipped: the counter only moves forward, so the
+    /// next value received is at least as high as the one missed.
+    pub async fn next(&mut self) -> Result<u32> {
+        loop {
+            match self.rx.recv().await {
+                Ok(index) => return Ok(index),
+                Err(RecvError::Lagged(n)) => {
+                    log::warn!("[identity] trade-key index stream lagged {n} value(s)");
+                }
+                Err(RecvError::Closed) => {
+                    bail!("TradeKeyIndexStream closed: sender dropped")
+                }
+            }
+        }
+    }
+}
+
+/// Subscribe to consumed trade-key indices. Flutter calls this once at startup
+/// and writes every value it receives to secure storage.
+pub fn on_trade_key_index_changed() -> TradeKeyIndexStream {
+    TradeKeyIndexStream {
+        rx: trade_key_index_tx().subscribe(),
+    }
 }
 
 // ── Return types ──────────────────────────────────────────────────────────────
@@ -135,7 +190,7 @@ pub async fn load_identity_from_mnemonic(
         None => None,
     };
     let trade_key_index =
-        reconcile_trade_key_index(trade_key_index, stored.as_ref(), &public_key);
+        reconcile_and_publish_trade_key_index(trade_key_index, stored.as_ref(), &public_key);
 
     let created_at = match created_at {
         Some(ts) if ts > 0 => ts,
@@ -255,6 +310,22 @@ pub async fn delete_identity() -> Result<()> {
 /// Derive a new trade key, auto-incrementing the index.
 /// Returns the new key's info and updates the stored `trade_key_index`.
 pub async fn derive_trade_key() -> Result<TradeKeyInfo> {
+    // Precondition, checked before any identity work because it depends on
+    // nothing else: without durable storage a derived index is consumed with
+    // no record of it, so the next session re-derives the same key and the
+    // daemon answers CantDo(InvalidTradeIndex). Memory-only mode therefore
+    // cannot create or take orders — refusing here is what makes that
+    // explicit instead of silently corrupting the counter (issue #249).
+    let Some(db) = crate::db::app_db::db() else {
+        bail!("StorageUnavailable: deriving a trade key requires durable storage");
+    };
+
+    derive_trade_key_with(db).await
+}
+
+/// [`derive_trade_key`] against an explicit store, so the increment / persist /
+/// publish sequence is testable without initialising the global singleton.
+async fn derive_trade_key_with<S: Storage>(db: &S) -> Result<TradeKeyInfo> {
     let mut guard = identity_lock().write().await;
     let state = guard.as_mut().ok_or_else(|| anyhow!("NoIdentity"))?;
 
@@ -274,13 +345,13 @@ pub async fn derive_trade_key() -> Result<TradeKeyInfo> {
     // consumption is not durably recorded reopens the counter-regression
     // window this exists to close. The in-memory increment is kept, so a
     // retry moves on to the next index — never back.
-    if let Some(db) = crate::db::app_db::db() {
-        db.save_identity(&state.identity_info).await.map_err(|e| {
-            anyhow!(
-                "StorageError: failed to persist trade_key_index {candidate_index}: {e}"
-            )
-        })?;
-    }
+    db.save_identity(&state.identity_info).await.map_err(|e| {
+        anyhow!("StorageError: failed to persist trade_key_index {candidate_index}: {e}")
+    })?;
+
+    // Only after the primary record is durable: Flutter mirrors this into
+    // secure storage, which outlives the database file itself.
+    publish_trade_key_index(candidate_index);
 
     Ok(TradeKeyInfo {
         index: candidate_index,
@@ -391,6 +462,23 @@ fn reconcile_trade_key_index(
     }
 }
 
+/// [`reconcile_trade_key_index`], publishing the result when the database knew
+/// a higher counter than the value Flutter passed in. That is exactly the case
+/// where secure storage is behind — an installation from before it was kept in
+/// sync — so this is what lets it catch up without a derivation happening
+/// first (issue #249).
+fn reconcile_and_publish_trade_key_index(
+    passed: u32,
+    stored: Option<&IdentityInfo>,
+    public_key: &str,
+) -> u32 {
+    let reconciled = reconcile_trade_key_index(passed, stored, public_key);
+    if reconciled > passed {
+        publish_trade_key_index(reconciled);
+    }
+    reconciled
+}
+
 use crate::rt::unix_now;
 
 /// Expose the in-memory `Keys` for other Rust modules (relay pool, gift wrap).
@@ -451,6 +539,59 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn deriving_without_durable_storage_is_refused() {
+        // The DB singleton is uninitialised in unit tests, which is exactly
+        // the app's memory-only mode. Handing out an index there would consume
+        // it with no record, so the call must fail with a stable marker.
+        let err = match derive_trade_key().await {
+            Err(e) => e.to_string(),
+            Ok(info) => panic!("derived index {} without durable storage", info.index),
+        };
+
+        assert!(
+            err.starts_with("StorageUnavailable:"),
+            "expected a StorageUnavailable marker, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_consumed_index_reaches_the_stream() {
+        let mut stream = on_trade_key_index_changed();
+
+        publish_trade_key_index(7);
+
+        assert_eq!(stream.next().await.unwrap(), 7);
+    }
+
+    #[tokio::test]
+    async fn reconciliation_publishes_only_when_the_database_is_ahead() {
+        let stored = stored_identity("abc", 22);
+        let mut stream = on_trade_key_index_changed();
+
+        // Secure storage behind the database: Dart must learn the real value.
+        assert_eq!(
+            reconcile_and_publish_trade_key_index(20, Some(&stored), "abc"),
+            22
+        );
+        assert_eq!(stream.next().await.unwrap(), 22);
+
+        // Already in sync, and a counter belonging to another mnemonic: no
+        // publication, so Dart never rewrites a value it already holds.
+        assert_eq!(
+            reconcile_and_publish_trade_key_index(22, Some(&stored), "abc"),
+            22
+        );
+        assert_eq!(
+            reconcile_and_publish_trade_key_index(30, Some(&stored), "other"),
+            30
+        );
+        assert!(
+            stream.rx.try_recv().is_err(),
+            "nothing further should have been published"
+        );
+    }
+
     #[test]
     fn reconcile_prefers_higher_stored_index() {
         let stored = stored_identity("abc", 22);
@@ -487,11 +628,31 @@ mod tests {
             .unwrap();
         assert_eq!(info.trade_key_index, 20);
 
-        let first = derive_trade_key().await.unwrap();
-        let second = derive_trade_key().await.unwrap();
+        // A real store, but a throwaway one: derivation now requires durable
+        // storage, and the global singleton must stay uninitialised so the
+        // memory-only case remains testable in this same process.
+        let db_path = std::env::temp_dir().join(format!(
+            "mostro_identity_lifecycle_{}.db",
+            std::process::id()
+        ));
+        let db = crate::db::sqlite::SqliteStorage::open(db_path.to_str().unwrap())
+            .await
+            .unwrap();
+
+        let mut published = on_trade_key_index_changed();
+
+        let first = derive_trade_key_with(&db).await.unwrap();
+        let second = derive_trade_key_with(&db).await.unwrap();
         assert_eq!(first.index, 21);
         assert_eq!(second.index, 22);
         assert_ne!(first.public_key, second.public_key);
+
+        // Every consumed index is published for Flutter to mirror into secure
+        // storage, and only after it is durable in the store.
+        assert_eq!(published.next().await.unwrap(), 21);
+        assert_eq!(published.next().await.unwrap(), 22);
+        let persisted = db.get_identity().await.unwrap().unwrap();
+        assert_eq!(persisted.trade_key_index, 22);
 
         let current = get_identity().await.unwrap().unwrap();
         assert_eq!(current.trade_key_index, 22);

--- a/rust/src/api/identity.rs
+++ b/rust/src/api/identity.rs
@@ -51,8 +51,11 @@ fn trade_key_index_tx() -> &'static broadcast::Sender<u32> {
 /// storage — the one store that survives loss of `mostro.db` (issue #249).
 /// Send failures mean nobody is listening yet, which is not an error: the DB
 /// row remains the primary record and load-time reconciliation catches up.
-fn publish_trade_key_index(index: u32) {
-    let _ = trade_key_index_tx().send(index);
+///
+/// The channel is a parameter rather than the global so tests can assert on
+/// their own, giving each one a stream nothing else publishes to.
+fn publish_index(tx: &broadcast::Sender<u32>, index: u32) {
+    let _ = tx.send(index);
 }
 
 /// A stream of consumed trade-key indices for the Dart layer to persist.
@@ -189,8 +192,12 @@ pub async fn load_identity_from_mnemonic(
         },
         None => None,
     };
-    let trade_key_index =
-        reconcile_and_publish_trade_key_index(trade_key_index, stored.as_ref(), &public_key);
+    let trade_key_index = reconcile_and_publish_to(
+        trade_key_index_tx(),
+        trade_key_index,
+        stored.as_ref(),
+        &public_key,
+    );
 
     let created_at = match created_at {
         Some(ts) if ts > 0 => ts,
@@ -310,22 +317,53 @@ pub async fn delete_identity() -> Result<()> {
 /// Derive a new trade key, auto-incrementing the index.
 /// Returns the new key's info and updates the stored `trade_key_index`.
 pub async fn derive_trade_key() -> Result<TradeKeyInfo> {
+    let db = crate::db::app_db::db();
+
     // Precondition, checked before any identity work because it depends on
     // nothing else: without durable storage a derived index is consumed with
     // no record of it, so the next session re-derives the same key and the
     // daemon answers CantDo(InvalidTradeIndex). Memory-only mode therefore
     // cannot create or take orders — refusing here is what makes that
     // explicit instead of silently corrupting the counter (issue #249).
-    let Some(db) = crate::db::app_db::db() else {
-        bail!("StorageUnavailable: deriving a trade key requires durable storage");
-    };
+    #[cfg(not(target_arch = "wasm32"))]
+    require_durable_storage(db)?;
 
-    derive_trade_key_with(db).await
+    // Web is exempt: `init_db` is never called there (main.dart guards it with
+    // `!kIsWeb`) and the IndexedDB backend does not implement `save_identity`
+    // yet, so requiring a store would break every create/take on web. The
+    // published index still reaches Flutter, which persists it — that mirror
+    // is web's durable record until IndexedDB identity support lands (#233).
+    #[cfg(target_arch = "wasm32")]
+    if db.is_none() {
+        log::warn!(
+            "[identity] no local store on web — the trade-key counter is durable \
+             only through the Flutter mirror"
+        );
+    }
+
+    derive_trade_key_with(db, trade_key_index_tx()).await
 }
 
-/// [`derive_trade_key`] against an explicit store, so the increment / persist /
-/// publish sequence is testable without initialising the global singleton.
-async fn derive_trade_key_with<S: Storage>(db: &S) -> Result<TradeKeyInfo> {
+/// Fails when no durable store is available, with the marker Dart localizes.
+///
+/// Split out so the refusal is testable as a pure decision: asserting it
+/// through `derive_trade_key` would depend on the process-wide `APP_DB` being
+/// uninitialised, which any other test may change first.
+#[cfg(not(target_arch = "wasm32"))]
+fn require_durable_storage<S>(db: Option<&S>) -> Result<()> {
+    if db.is_none() {
+        bail!("StorageUnavailable: deriving a trade key requires durable storage");
+    }
+    Ok(())
+}
+
+/// [`derive_trade_key`] against an explicit store and publication channel, so
+/// the increment / persist / publish sequence is testable without touching the
+/// global singleton or the process-wide channel other tests share.
+async fn derive_trade_key_with<S: Storage>(
+    db: Option<&S>,
+    tx: &broadcast::Sender<u32>,
+) -> Result<TradeKeyInfo> {
     let mut guard = identity_lock().write().await;
     let state = guard.as_mut().ok_or_else(|| anyhow!("NoIdentity"))?;
 
@@ -345,13 +383,15 @@ async fn derive_trade_key_with<S: Storage>(db: &S) -> Result<TradeKeyInfo> {
     // consumption is not durably recorded reopens the counter-regression
     // window this exists to close. The in-memory increment is kept, so a
     // retry moves on to the next index — never back.
-    db.save_identity(&state.identity_info).await.map_err(|e| {
-        anyhow!("StorageError: failed to persist trade_key_index {candidate_index}: {e}")
-    })?;
+    if let Some(db) = db {
+        db.save_identity(&state.identity_info).await.map_err(|e| {
+            anyhow!("StorageError: failed to persist trade_key_index {candidate_index}: {e}")
+        })?;
+    }
 
     // Only after the primary record is durable: Flutter mirrors this into
     // secure storage, which outlives the database file itself.
-    publish_trade_key_index(candidate_index);
+    publish_index(tx, candidate_index);
 
     Ok(TradeKeyInfo {
         index: candidate_index,
@@ -467,14 +507,15 @@ fn reconcile_trade_key_index(
 /// where secure storage is behind — an installation from before it was kept in
 /// sync — so this is what lets it catch up without a derivation happening
 /// first (issue #249).
-fn reconcile_and_publish_trade_key_index(
+fn reconcile_and_publish_to(
+    tx: &broadcast::Sender<u32>,
     passed: u32,
     stored: Option<&IdentityInfo>,
     public_key: &str,
 ) -> u32 {
     let reconciled = reconcile_trade_key_index(passed, stored, public_key);
     if reconciled > passed {
-        publish_trade_key_index(reconciled);
+        publish_index(tx, reconciled);
     }
     reconciled
 }
@@ -529,6 +570,16 @@ pub(crate) async fn get_transport_identity_keys(trade_keys: &Keys) -> Result<Key
 mod tests {
     use super::*;
 
+    /// A throwaway SQLite store, named per test so parallel runs never collide.
+    async fn temp_store(tag: &str) -> crate::db::sqlite::SqliteStorage {
+        let path = std::env::temp_dir()
+            .join(format!("mostro_identity_{tag}_{}.db", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        crate::db::sqlite::SqliteStorage::open(path.to_str().unwrap())
+            .await
+            .unwrap()
+    }
+
     fn stored_identity(public_key: &str, trade_key_index: u32) -> IdentityInfo {
         IdentityInfo {
             public_key: public_key.to_string(),
@@ -539,15 +590,22 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn deriving_without_durable_storage_is_refused() {
-        // The DB singleton is uninitialised in unit tests, which is exactly
-        // the app's memory-only mode. Handing out an index there would consume
-        // it with no record, so the call must fail with a stable marker.
-        let err = match derive_trade_key().await {
-            Err(e) => e.to_string(),
-            Ok(info) => panic!("derived index {} without durable storage", info.index),
-        };
+    /// A channel of this test's own. The process-wide one is shared with every
+    /// other test in the binary, so asserting on it makes the value received
+    /// depend on what else happens to publish concurrently.
+    fn private_channel() -> (broadcast::Sender<u32>, TradeKeyIndexStream) {
+        let (tx, rx) = broadcast::channel(TRADE_KEY_INDEX_CHANNEL_CAPACITY);
+        (tx, TradeKeyIndexStream { rx })
+    }
+
+    #[test]
+    fn deriving_without_durable_storage_is_refused() {
+        // Asserted as a pure decision, not through `derive_trade_key`: that
+        // would depend on the process-wide APP_DB still being uninitialised,
+        // and other tests in this binary initialise it.
+        let err = require_durable_storage::<crate::db::sqlite::SqliteStorage>(None)
+            .unwrap_err()
+            .to_string();
 
         assert!(
             err.starts_with("StorageUnavailable:"),
@@ -556,10 +614,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_consumed_index_reaches_the_stream() {
-        let mut stream = on_trade_key_index_changed();
+    async fn a_store_being_present_satisfies_the_precondition() {
+        let db = temp_store("precondition").await;
 
-        publish_trade_key_index(7);
+        assert!(require_durable_storage(Some(&db)).is_ok());
+    }
+
+    #[tokio::test]
+    async fn a_consumed_index_reaches_the_stream() {
+        let (tx, mut stream) = private_channel();
+
+        publish_index(&tx, 7);
 
         assert_eq!(stream.next().await.unwrap(), 7);
     }
@@ -567,25 +632,16 @@ mod tests {
     #[tokio::test]
     async fn reconciliation_publishes_only_when_the_database_is_ahead() {
         let stored = stored_identity("abc", 22);
-        let mut stream = on_trade_key_index_changed();
+        let (tx, mut stream) = private_channel();
 
         // Secure storage behind the database: Dart must learn the real value.
-        assert_eq!(
-            reconcile_and_publish_trade_key_index(20, Some(&stored), "abc"),
-            22
-        );
+        assert_eq!(reconcile_and_publish_to(&tx, 20, Some(&stored), "abc"), 22);
         assert_eq!(stream.next().await.unwrap(), 22);
 
         // Already in sync, and a counter belonging to another mnemonic: no
         // publication, so Dart never rewrites a value it already holds.
-        assert_eq!(
-            reconcile_and_publish_trade_key_index(22, Some(&stored), "abc"),
-            22
-        );
-        assert_eq!(
-            reconcile_and_publish_trade_key_index(30, Some(&stored), "other"),
-            30
-        );
+        assert_eq!(reconcile_and_publish_to(&tx, 22, Some(&stored), "abc"), 22);
+        assert_eq!(reconcile_and_publish_to(&tx, 30, Some(&stored), "other"), 30);
         assert!(
             stream.rx.try_recv().is_err(),
             "nothing further should have been published"
@@ -628,21 +684,15 @@ mod tests {
             .unwrap();
         assert_eq!(info.trade_key_index, 20);
 
-        // A real store, but a throwaway one: derivation now requires durable
-        // storage, and the global singleton must stay uninitialised so the
-        // memory-only case remains testable in this same process.
-        let db_path = std::env::temp_dir().join(format!(
-            "mostro_identity_lifecycle_{}.db",
-            std::process::id()
-        ));
-        let db = crate::db::sqlite::SqliteStorage::open(db_path.to_str().unwrap())
-            .await
-            .unwrap();
+        // A real store, but a throwaway one, and a channel of this test's own:
+        // neither the global singleton nor the shared channel is touched, so
+        // this cannot make other tests in the binary flaky (or be made flaky
+        // by them).
+        let db = temp_store("lifecycle").await;
+        let (tx, mut published) = private_channel();
 
-        let mut published = on_trade_key_index_changed();
-
-        let first = derive_trade_key_with(&db).await.unwrap();
-        let second = derive_trade_key_with(&db).await.unwrap();
+        let first = derive_trade_key_with(Some(&db), &tx).await.unwrap();
+        let second = derive_trade_key_with(Some(&db), &tx).await.unwrap();
         assert_eq!(first.index, 21);
         assert_eq!(second.index, 22);
         assert_ne!(first.public_key, second.public_key);

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -28,6 +28,7 @@
 use crate::api::bond::*;
 use crate::api::disputes::*;
 use crate::api::escrow::*;
+use crate::api::identity::*;
 use crate::api::logging::*;
 use crate::api::messages::*;
 use crate::api::nostr::*;
@@ -47,7 +48,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -612460854;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1417387575;
 
 // Section: executor
 
@@ -1168,6 +1169,63 @@ fn wire__crate__api__settings__SettingsStream_next_impl(
                         let mut api_that_guard = api_that_guard.unwrap();
                         let output_ok =
                             crate::api::settings::SettingsStream::next(&mut *api_that_guard)
+                                .await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__identity__TradeKeyIndexStream_next_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "TradeKeyIndexStream_next",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<TradeKeyIndexStream>,
+            >>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || async move {
+                        let mut api_that_guard = None;
+                        let decode_indices_ =
+                            flutter_rust_bridge::for_generated::lockable_compute_decode_order(
+                                vec![flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                    &api_that, 0, true,
+                                )],
+                            );
+                        for i in decode_indices_ {
+                            match i {
+                                0 => {
+                                    api_that_guard =
+                                        Some(api_that.lockable_decode_async_ref_mut().await)
+                                }
+                                _ => unreachable!(),
+                            }
+                        }
+                        let mut api_that_guard = api_that_guard.unwrap();
+                        let output_ok =
+                            crate::api::identity::TradeKeyIndexStream::next(&mut *api_that_guard)
                                 .await?;
                         Ok(output_ok)
                     })()
@@ -3327,6 +3385,39 @@ fn wire__crate__api__settings__on_settings_changed_impl(
         },
     )
 }
+fn wire__crate__api__identity__on_trade_key_index_changed_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "on_trade_key_index_changed",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, ()>((move || {
+                    let output_ok =
+                        Result::<_, ()>::Ok(crate::api::identity::on_trade_key_index_changed())?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__messages__on_unread_count_changed_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -4397,6 +4488,9 @@ flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
     flutter_rust_bridge::for_generated::RustAutoOpaqueInner<SettingsStream>
 );
 flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
+    flutter_rust_bridge::for_generated::RustAutoOpaqueInner<TradeKeyIndexStream>
+);
+flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
     flutter_rust_bridge::for_generated::RustAutoOpaqueInner<UnreadCountStream>
 );
 flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
@@ -4528,6 +4622,16 @@ impl SseDecode for SettingsStream {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut inner = <RustOpaqueMoi<
             flutter_rust_bridge::for_generated::RustAutoOpaqueInner<SettingsStream>,
+        >>::sse_decode(deserializer);
+        return flutter_rust_bridge::for_generated::rust_auto_opaque_decode_owned(inner);
+    }
+}
+
+impl SseDecode for TradeKeyIndexStream {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <RustOpaqueMoi<
+            flutter_rust_bridge::for_generated::RustAutoOpaqueInner<TradeKeyIndexStream>,
         >>::sse_decode(deserializer);
         return flutter_rust_bridge::for_generated::rust_auto_opaque_decode_owned(inner);
     }
@@ -4669,6 +4773,16 @@ impl SseDecode
 
 impl SseDecode
     for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<SettingsStream>>
+{
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <usize>::sse_decode(deserializer);
+        return decode_rust_opaque_moi(inner);
+    }
+}
+
+impl SseDecode
+    for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<TradeKeyIndexStream>>
 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -5944,221 +6058,233 @@ fn pde_ffi_dispatcher_primary_impl(
         20 => {
             wire__crate__api__settings__SettingsStream_next_impl(port, ptr, rust_vec_len, data_len)
         }
-        21 => wire__crate__api__messages__UnreadCountStream_next_impl(
+        21 => wire__crate__api__identity__TradeKeyIndexStream_next_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        22 => {
+        22 => wire__crate__api__messages__UnreadCountStream_next_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        23 => {
             wire__crate__api__nwc__WalletStatusStream_next_impl(port, ptr, rust_vec_len, data_len)
         }
-        23 => wire__crate__api__nostr__add_relay_impl(port, ptr, rust_vec_len, data_len),
-        24 => wire__crate__api__orders__cancel_order_impl(port, ptr, rust_vec_len, data_len),
-        25 => wire__crate__api__logging__clear_logs_impl(port, ptr, rust_vec_len, data_len),
-        26 => wire__crate__api__nwc__connect_wallet_impl(port, ptr, rust_vec_len, data_len),
-        27 => wire__crate__api__identity__create_identity_impl(port, ptr, rust_vec_len, data_len),
-        28 => wire__crate__api__orders__create_order_impl(port, ptr, rust_vec_len, data_len),
-        29 => wire__crate__api__identity__delete_identity_impl(port, ptr, rust_vec_len, data_len),
-        30 => wire__crate__api__identity__derive_trade_key_impl(port, ptr, rust_vec_len, data_len),
-        31 => wire__crate__api__nwc__disconnect_wallet_impl(port, ptr, rust_vec_len, data_len),
-        32 => {
+        24 => wire__crate__api__nostr__add_relay_impl(port, ptr, rust_vec_len, data_len),
+        25 => wire__crate__api__orders__cancel_order_impl(port, ptr, rust_vec_len, data_len),
+        26 => wire__crate__api__logging__clear_logs_impl(port, ptr, rust_vec_len, data_len),
+        27 => wire__crate__api__nwc__connect_wallet_impl(port, ptr, rust_vec_len, data_len),
+        28 => wire__crate__api__identity__create_identity_impl(port, ptr, rust_vec_len, data_len),
+        29 => wire__crate__api__orders__create_order_impl(port, ptr, rust_vec_len, data_len),
+        30 => wire__crate__api__identity__delete_identity_impl(port, ptr, rust_vec_len, data_len),
+        31 => wire__crate__api__identity__derive_trade_key_impl(port, ptr, rust_vec_len, data_len),
+        32 => wire__crate__api__nwc__disconnect_wallet_impl(port, ptr, rust_vec_len, data_len),
+        33 => {
             wire__crate__api__messages__download_attachment_impl(port, ptr, rust_vec_len, data_len)
         }
-        33 => wire__crate__api__identity__export_encrypted_backup_impl(
+        34 => wire__crate__api__identity__export_encrypted_backup_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        34 => wire__crate__api__nostr__fetch_mostro_instance_tags_impl(
+        35 => wire__crate__api__nostr__fetch_mostro_instance_tags_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        35 => wire__crate__api__nostr__flush_message_queue_impl(port, ptr, rust_vec_len, data_len),
-        36 => wire__crate__api__get_app_version_impl(port, ptr, rust_vec_len, data_len),
-        37 => wire__crate__api__messages__get_attachment_status_impl(
+        36 => wire__crate__api__nostr__flush_message_queue_impl(port, ptr, rust_vec_len, data_len),
+        37 => wire__crate__api__get_app_version_impl(port, ptr, rust_vec_len, data_len),
+        38 => wire__crate__api__messages__get_attachment_status_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        38 => wire__crate__api__nwc__get_balance_impl(port, ptr, rust_vec_len, data_len),
-        39 => wire__crate__api__nostr__get_connection_state_impl(port, ptr, rust_vec_len, data_len),
-        40 => wire__crate__api__disputes__get_dispute_impl(port, ptr, rust_vec_len, data_len),
-        41 => wire__crate__api__escrow__get_escrow_mode_impl(port, ptr, rust_vec_len, data_len),
-        42 => wire__crate__api__identity__get_identity_impl(port, ptr, rust_vec_len, data_len),
-        43 => wire__crate__api__messages__get_messages_impl(port, ptr, rust_vec_len, data_len),
-        44 => wire__crate__api__settings__get_mostro_pubkey_impl(port, ptr, rust_vec_len, data_len),
-        45 => wire__crate__api__identity__get_nym_identity_impl(port, ptr, rust_vec_len, data_len),
-        46 => wire__crate__api__orders__get_order_impl(port, ptr, rust_vec_len, data_len),
-        47 => wire__crate__api__orders__get_orders_impl(port, ptr, rust_vec_len, data_len),
-        48 => {
+        39 => wire__crate__api__nwc__get_balance_impl(port, ptr, rust_vec_len, data_len),
+        40 => wire__crate__api__nostr__get_connection_state_impl(port, ptr, rust_vec_len, data_len),
+        41 => wire__crate__api__disputes__get_dispute_impl(port, ptr, rust_vec_len, data_len),
+        42 => wire__crate__api__escrow__get_escrow_mode_impl(port, ptr, rust_vec_len, data_len),
+        43 => wire__crate__api__identity__get_identity_impl(port, ptr, rust_vec_len, data_len),
+        44 => wire__crate__api__messages__get_messages_impl(port, ptr, rust_vec_len, data_len),
+        45 => wire__crate__api__settings__get_mostro_pubkey_impl(port, ptr, rust_vec_len, data_len),
+        46 => wire__crate__api__identity__get_nym_identity_impl(port, ptr, rust_vec_len, data_len),
+        47 => wire__crate__api__orders__get_order_impl(port, ptr, rust_vec_len, data_len),
+        48 => wire__crate__api__orders__get_orders_impl(port, ptr, rust_vec_len, data_len),
+        49 => {
             wire__crate__api__reputation__get_privacy_mode_impl(port, ptr, rust_vec_len, data_len)
         }
-        49 => wire__crate__api__reputation__get_rating_for_trade_impl(
+        50 => wire__crate__api__reputation__get_rating_for_trade_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        50 => wire__crate__api__nostr__get_relays_impl(port, ptr, rust_vec_len, data_len),
-        51 => wire__crate__api__settings__get_settings_impl(port, ptr, rust_vec_len, data_len),
-        52 => wire__crate__api__identity__get_trade_key_impl(port, ptr, rust_vec_len, data_len),
-        53 => wire__crate__api__orders__get_trade_role_impl(port, ptr, rust_vec_len, data_len),
-        54 => wire__crate__api__messages__get_unread_count_impl(port, ptr, rust_vec_len, data_len),
-        55 => wire__crate__api__nwc__get_wallet_impl(port, ptr, rust_vec_len, data_len),
-        56 => wire__crate__api__disputes__handle_admin_canceled_impl(
+        51 => wire__crate__api__nostr__get_relays_impl(port, ptr, rust_vec_len, data_len),
+        52 => wire__crate__api__settings__get_settings_impl(port, ptr, rust_vec_len, data_len),
+        53 => wire__crate__api__identity__get_trade_key_impl(port, ptr, rust_vec_len, data_len),
+        54 => wire__crate__api__orders__get_trade_role_impl(port, ptr, rust_vec_len, data_len),
+        55 => wire__crate__api__messages__get_unread_count_impl(port, ptr, rust_vec_len, data_len),
+        56 => wire__crate__api__nwc__get_wallet_impl(port, ptr, rust_vec_len, data_len),
+        57 => wire__crate__api__disputes__handle_admin_canceled_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        57 => {
+        58 => {
             wire__crate__api__disputes__handle_admin_settled_impl(port, ptr, rust_vec_len, data_len)
         }
-        58 => wire__crate__api__disputes__handle_admin_took_dispute_impl(
+        59 => wire__crate__api__disputes__handle_admin_took_dispute_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        59 => wire__crate__api__reputation__handle_rating_received_impl(
+        60 => wire__crate__api__reputation__handle_rating_received_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        60 => {
+        61 => {
             wire__crate__api__identity__import_from_mnemonic_impl(port, ptr, rust_vec_len, data_len)
         }
-        61 => wire__crate__api__identity__import_from_nsec_impl(port, ptr, rust_vec_len, data_len),
-        62 => wire__crate__api__init_db_impl(port, ptr, rust_vec_len, data_len),
-        63 => wire__crate__api__nostr__initialize_impl(port, ptr, rust_vec_len, data_len),
-        64 => wire__crate__api__logging__install_log_bridge_impl(port, ptr, rust_vec_len, data_len),
-        65 => wire__crate__api__orders__list_trades_impl(port, ptr, rust_vec_len, data_len),
-        66 => wire__crate__api__identity__load_identity_from_mnemonic_impl(
+        62 => wire__crate__api__identity__import_from_nsec_impl(port, ptr, rust_vec_len, data_len),
+        63 => wire__crate__api__init_db_impl(port, ptr, rust_vec_len, data_len),
+        64 => wire__crate__api__nostr__initialize_impl(port, ptr, rust_vec_len, data_len),
+        65 => wire__crate__api__logging__install_log_bridge_impl(port, ptr, rust_vec_len, data_len),
+        66 => wire__crate__api__orders__list_trades_impl(port, ptr, rust_vec_len, data_len),
+        67 => wire__crate__api__identity__load_identity_from_mnemonic_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        67 => wire__crate__api__nwc__make_invoice_impl(port, ptr, rust_vec_len, data_len),
-        68 => wire__crate__api__messages__mark_as_read_impl(port, ptr, rust_vec_len, data_len),
-        69 => wire__crate__api__messages__on_attachment_progress_impl(
+        68 => wire__crate__api__nwc__make_invoice_impl(port, ptr, rust_vec_len, data_len),
+        69 => wire__crate__api__messages__mark_as_read_impl(port, ptr, rust_vec_len, data_len),
+        70 => wire__crate__api__messages__on_attachment_progress_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        70 => wire__crate__api__bond__on_bond_slashed_impl(port, ptr, rust_vec_len, data_len),
-        71 => wire__crate__api__nostr__on_connection_state_changed_impl(
+        71 => wire__crate__api__bond__on_bond_slashed_impl(port, ptr, rust_vec_len, data_len),
+        72 => wire__crate__api__nostr__on_connection_state_changed_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        72 => {
+        73 => {
             wire__crate__api__disputes__on_dispute_updated_impl(port, ptr, rust_vec_len, data_len)
         }
-        73 => {
+        74 => {
             wire__crate__api__escrow__on_escrow_mode_changed_impl(port, ptr, rust_vec_len, data_len)
         }
-        74 => wire__crate__api__logging__on_log_entry_impl(port, ptr, rust_vec_len, data_len),
-        75 => wire__crate__api__messages__on_new_message_impl(port, ptr, rust_vec_len, data_len),
-        76 => wire__crate__api__orders__on_orders_updated_impl(port, ptr, rust_vec_len, data_len),
-        77 => {
+        75 => wire__crate__api__logging__on_log_entry_impl(port, ptr, rust_vec_len, data_len),
+        76 => wire__crate__api__messages__on_new_message_impl(port, ptr, rust_vec_len, data_len),
+        77 => wire__crate__api__orders__on_orders_updated_impl(port, ptr, rust_vec_len, data_len),
+        78 => {
             wire__crate__api__reputation__on_rating_received_impl(port, ptr, rust_vec_len, data_len)
         }
-        78 => {
+        79 => {
             wire__crate__api__nostr__on_relay_status_changed_impl(port, ptr, rust_vec_len, data_len)
         }
-        79 => {
+        80 => {
             wire__crate__api__settings__on_settings_changed_impl(port, ptr, rust_vec_len, data_len)
         }
-        80 => wire__crate__api__messages__on_unread_count_changed_impl(
+        81 => wire__crate__api__identity__on_trade_key_index_changed_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        81 => {
+        82 => wire__crate__api__messages__on_unread_count_changed_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        83 => {
             wire__crate__api__nwc__on_wallet_status_changed_impl(port, ptr, rust_vec_len, data_len)
         }
-        82 => wire__crate__api__disputes__open_dispute_impl(port, ptr, rust_vec_len, data_len),
-        83 => {
+        84 => wire__crate__api__disputes__open_dispute_impl(port, ptr, rust_vec_len, data_len),
+        85 => {
             wire__crate__api__orders__order_filters_default_impl(port, ptr, rust_vec_len, data_len)
         }
-        84 => wire__crate__api__nwc__pay_invoice_impl(port, ptr, rust_vec_len, data_len),
-        85 => wire__crate__api__logging__recent_logs_impl(port, ptr, rust_vec_len, data_len),
-        86 => wire__crate__api__settings__rehydrate_active_mostro_node_impl(
+        86 => wire__crate__api__nwc__pay_invoice_impl(port, ptr, rust_vec_len, data_len),
+        87 => wire__crate__api__logging__recent_logs_impl(port, ptr, rust_vec_len, data_len),
+        88 => wire__crate__api__settings__rehydrate_active_mostro_node_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        87 => wire__crate__api__escrow__rehydrate_escrow_overrides_impl(
+        89 => wire__crate__api__escrow__rehydrate_escrow_overrides_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        88 => wire__crate__api__orders__release_order_impl(port, ptr, rust_vec_len, data_len),
-        89 => wire__crate__api__nostr__remove_relay_impl(port, ptr, rust_vec_len, data_len),
-        90 => wire__crate__api__orders__restart_orders_subscription_impl(
+        90 => wire__crate__api__orders__release_order_impl(port, ptr, rust_vec_len, data_len),
+        91 => wire__crate__api__nostr__remove_relay_impl(port, ptr, rust_vec_len, data_len),
+        92 => wire__crate__api__orders__restart_orders_subscription_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        91 => wire__crate__api__orders__send_fiat_sent_impl(port, ptr, rust_vec_len, data_len),
-        92 => wire__crate__api__messages__send_file_impl(port, ptr, rust_vec_len, data_len),
-        93 => wire__crate__api__orders__send_invoice_impl(port, ptr, rust_vec_len, data_len),
-        94 => wire__crate__api__messages__send_message_impl(port, ptr, rust_vec_len, data_len),
-        95 => wire__crate__api__settings__set_active_mostro_node_impl(
+        93 => wire__crate__api__orders__send_fiat_sent_impl(port, ptr, rust_vec_len, data_len),
+        94 => wire__crate__api__messages__send_file_impl(port, ptr, rust_vec_len, data_len),
+        95 => wire__crate__api__orders__send_invoice_impl(port, ptr, rust_vec_len, data_len),
+        96 => wire__crate__api__messages__send_message_impl(port, ptr, rust_vec_len, data_len),
+        97 => wire__crate__api__settings__set_active_mostro_node_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        96 => wire__crate__api__escrow__set_cashu_mint_url_override_impl(
+        98 => wire__crate__api__escrow__set_cashu_mint_url_override_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        97 => wire__crate__api__settings__set_default_fiat_code_impl(
+        99 => wire__crate__api__settings__set_default_fiat_code_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        98 => wire__crate__api__settings__set_default_lightning_address_impl(
+        100 => wire__crate__api__settings__set_default_lightning_address_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        99 => wire__crate__api__escrow__set_escrow_mode_override_impl(
+        101 => wire__crate__api__escrow__set_escrow_mode_override_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        100 => wire__crate__api__settings__set_language_impl(port, ptr, rust_vec_len, data_len),
-        101 => {
+        102 => wire__crate__api__settings__set_language_impl(port, ptr, rust_vec_len, data_len),
+        103 => {
             wire__crate__api__settings__set_logging_enabled_impl(port, ptr, rust_vec_len, data_len)
         }
-        102 => {
+        104 => {
             wire__crate__api__reputation__set_privacy_mode_impl(port, ptr, rust_vec_len, data_len)
         }
-        103 => wire__crate__api__settings__set_theme_impl(port, ptr, rust_vec_len, data_len),
-        104 => wire__crate__api__disputes__submit_evidence_impl(port, ptr, rust_vec_len, data_len),
-        105 => wire__crate__api__reputation__submit_rating_impl(port, ptr, rust_vec_len, data_len),
-        106 => wire__crate__api__orders__subscribe_orders_impl(port, ptr, rust_vec_len, data_len),
-        107 => wire__crate__api__orders__take_order_impl(port, ptr, rust_vec_len, data_len),
+        105 => wire__crate__api__settings__set_theme_impl(port, ptr, rust_vec_len, data_len),
+        106 => wire__crate__api__disputes__submit_evidence_impl(port, ptr, rust_vec_len, data_len),
+        107 => wire__crate__api__reputation__submit_rating_impl(port, ptr, rust_vec_len, data_len),
+        108 => wire__crate__api__orders__subscribe_orders_impl(port, ptr, rust_vec_len, data_len),
+        109 => wire__crate__api__orders__take_order_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -6363,6 +6489,24 @@ impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for FrbWrapper<
 
 impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<SettingsStream>> for SettingsStream {
     fn into_into_dart(self) -> FrbWrapper<SettingsStream> {
+        self.into()
+    }
+}
+
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<TradeKeyIndexStream> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        flutter_rust_bridge::for_generated::rust_auto_opaque_encode::<_, MoiArc<_>>(self.0)
+            .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<TradeKeyIndexStream>
+{
+}
+
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<TradeKeyIndexStream>> for TradeKeyIndexStream {
+    fn into_into_dart(self) -> FrbWrapper<TradeKeyIndexStream> {
         self.into()
     }
 }
@@ -7454,6 +7598,13 @@ impl SseEncode for SettingsStream {
     }
 }
 
+impl SseEncode for TradeKeyIndexStream {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<TradeKeyIndexStream>>>::sse_encode(flutter_rust_bridge::for_generated::rust_auto_opaque_encode::<_, MoiArc<_>>(self), serializer);
+    }
+}
+
 impl SseEncode for UnreadCountStream {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -7595,6 +7746,17 @@ impl SseEncode
 
 impl SseEncode
     for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<SettingsStream>>
+{
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        let (ptr, size) = self.sse_encode_raw();
+        <usize>::sse_encode(ptr, serializer);
+        <i32>::sse_encode(size, serializer);
+    }
+}
+
+impl SseEncode
+    for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<TradeKeyIndexStream>>
 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -8673,6 +8835,7 @@ mod io {
     use crate::api::bond::*;
     use crate::api::disputes::*;
     use crate::api::escrow::*;
+    use crate::api::identity::*;
     use crate::api::logging::*;
     use crate::api::messages::*;
     use crate::api::nostr::*;
@@ -8859,6 +9022,20 @@ mod io {
     }
 
     #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_mostro_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTradeKeyIndexStream(
+        ptr: *const std::ffi::c_void,
+    ) {
+        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<TradeKeyIndexStream>>::increment_strong_count(ptr as _);
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_mostro_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTradeKeyIndexStream(
+        ptr: *const std::ffi::c_void,
+    ) {
+        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<TradeKeyIndexStream>>::decrement_strong_count(ptr as _);
+    }
+
+    #[unsafe(no_mangle)]
     pub extern "C" fn frbgen_mostro_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUnreadCountStream(
         ptr: *const std::ffi::c_void,
     ) {
@@ -8901,6 +9078,7 @@ mod web {
     use crate::api::bond::*;
     use crate::api::disputes::*;
     use crate::api::escrow::*;
+    use crate::api::identity::*;
     use crate::api::logging::*;
     use crate::api::messages::*;
     use crate::api::nostr::*;
@@ -9086,6 +9264,20 @@ mod web {
         ptr: *const std::ffi::c_void,
     ) {
         MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<SettingsStream>>::decrement_strong_count(ptr as _);
+    }
+
+    #[wasm_bindgen]
+    pub fn rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTradeKeyIndexStream(
+        ptr: *const std::ffi::c_void,
+    ) {
+        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<TradeKeyIndexStream>>::increment_strong_count(ptr as _);
+    }
+
+    #[wasm_bindgen]
+    pub fn rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTradeKeyIndexStream(
+        ptr: *const std::ffi::c_void,
+    ) {
+        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<TradeKeyIndexStream>>::decrement_strong_count(ptr as _);
     }
 
     #[wasm_bindgen]

--- a/test/core/services/identity_trade_key_index_test.dart
+++ b/test/core/services/identity_trade_key_index_test.dart
@@ -1,0 +1,56 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro/core/services/identity_service.dart';
+
+void main() {
+  test('main() subscribes to the index stream before loading the identity', () {
+    // Loading the identity publishes the reconciled counter when the database
+    // is ahead of secure storage, and the Tokio broadcast channel drops a
+    // value with no receiver — so subscribing after identity init silently
+    // loses exactly the catch-up this mechanism exists for. Nothing at runtime
+    // fails when the order is wrong, hence this static guard.
+    final source = File('lib/main.dart').readAsStringSync();
+
+    final subscribe = source.indexOf('onTradeKeyIndexChanged');
+    final identityInit = source.indexOf('IdentityService.initialize');
+
+    expect(subscribe, greaterThan(-1), reason: 'subscription call not found');
+    expect(identityInit, greaterThan(-1), reason: 'identity init not found');
+    expect(
+      subscribe,
+      lessThan(identityInit),
+      reason: 'subscribe to onTradeKeyIndexChanged before IdentityService.initialize',
+    );
+  });
+
+  group('nextStoredTradeKeyIndex', () {
+    test('writes the incoming index when nothing is stored yet', () {
+      // Arrange / Act
+      final next = IdentityService.nextStoredTradeKeyIndex(null, 21);
+
+      // Assert
+      expect(next, 21);
+    });
+
+    test('writes the incoming index when it is ahead of the stored one', () {
+      expect(IdentityService.nextStoredTradeKeyIndex('21', 22), 22);
+    });
+
+    test('skips the write when the stored index already matches', () {
+      // Avoids rewriting secure storage on every reconciliation.
+      expect(IdentityService.nextStoredTradeKeyIndex('22', 22), isNull);
+    });
+
+    test('never moves the counter backwards', () {
+      // A lower value would re-derive keys the daemon already registered,
+      // which it rejects with InvalidTradeIndex.
+      expect(IdentityService.nextStoredTradeKeyIndex('30', 22), isNull);
+    });
+
+    test('treats an unparsable stored value as nothing known', () {
+      expect(IdentityService.nextStoredTradeKeyIndex('', 5), 5);
+      expect(IdentityService.nextStoredTradeKeyIndex('corrupt', 5), 5);
+    });
+  });
+}


### PR DESCRIPTION
Closes #249.

## Problem

The trade-key counter was meant to have two durable homes — Rust's `identity` row in `mostro.db` and Flutter's secure storage — reconciled on load by taking the higher of the two. In practice only the database copy was ever written: `_kTradeKeyIndex` was set to `'0'` at create/import/regenerate and never updated after a derivation, so the value Flutter passed in was always `0` and `reconcile_trade_key_index` always resolved to the database's.

Losing that file therefore rewound the counter to 0, and the next create/take re-derived an index the daemon had already registered — answered with `CantDo(InvalidTradeIndex)`.

Second facet from the issue: `derive_trade_key` persisted under `if let Some(db)`, so in memory-only mode it handed out indices with **no durable record at all** — the exact corruption the rest of that function exists to prevent.

## Change

**Durability (Rust → Dart).** Every consumed index is published on a broadcast stream, `on_trade_key_index_changed()`, after it is durable in the database. Flutter subscribes once at startup and mirrors each value into secure storage via `IdentityService.saveTradeKeyIndex`. Writes are monotonic: a value at or below the stored one is skipped, so the counter can never move backwards.

Identity load is also a publication point — when the database knows a higher counter than secure storage passed in, the reconciled value is published, so a lagging copy catches up without waiting for the next derivation. That is what fixes an already-affected installation.

`main()` subscribes **before** `IdentityService.initialize()`. A Tokio broadcast channel drops values with no receiver, so subscribing afterwards silently loses exactly that catch-up. Nothing fails at runtime when the order is wrong, so a static test guards it (same approach as `test/web/pages_bundle_test.dart`).

**Memory-only mode.** `derive_trade_key` now fails with a stable `StorageUnavailable:` marker instead of deriving without a record. Dart maps it to a localized message in the create- and take-order screens (new `storageUnavailable` string in en/es/fr/de/it). Consequence, deliberately: orders cannot be created or taken while the database is unavailable — explicit, instead of quietly consuming indices.

## Test plan

- [x] `cargo test` — 197 passing. New: derivation without durable storage is refused; a consumed index reaches the stream; reconciliation publishes only when the database is ahead, and never for another mnemonic's counter. The lifecycle test now derives against a throwaway SQLite store through a `derive_trade_key_with` seam — the global DB singleton stays uninitialised so the memory-only case remains testable in the same process — and asserts both indices are published and persisted.
- [x] `cargo clippy --all-targets` — no new warnings
- [x] `flutter test` — 190 passing. New: the monotonic write decision (nothing stored / ahead / equal / behind / unparsable) and the subscription-order guard.
- [x] `flutter analyze` — no issues
- [x] Release Linux build, two consecutive launches: the first mirrors the database's index (`2`) into secure storage, the second is silent because the two now agree.

## Not in scope

The third direction listed in #249 — probing the daemon for the highest consumed index to recover an identity with no local counter at all — is a protocol-level feature and is deliberately left out.