### PR TITLE
feat(pow): honor pow_first_contact when mining first-contact events

### DIFF
--- a/rust/src/api/nostr.rs
+++ b/rust/src/api/nostr.rs
@@ -227,15 +227,17 @@ pub(crate) async fn fetch_and_set_node_capabilities() {
     use crate::mostro::escrow_mode;
 
     let mostro_pubkey_hex = crate::config::active_mostro_pubkey();
-    match fetch_mostro_instance_tags(mostro_pubkey_hex).await {
+    match fetch_mostro_instance_tags(mostro_pubkey_hex.clone()).await {
         Ok(Some(tags)) => {
             // Both difficulties: `pow` for every event, `pow_first_contact`
             // for the first event of a trade. An absent first-contact tag is
             // recorded as unknown rather than as `pow`, and both land in one
-            // atomic snapshot so an in-flight wrap can never mix generations
-            // — see mostro::pow.
+            // snapshot tagged with the node they came from, so an in-flight
+            // first-contact wrap can neither mix generations nor mine at a
+            // previous node's (or the startup default's) difficulty — see
+            // mostro::pow.
             let (difficulty, first_contact) = crate::mostro::pow::parse_pow_tags(&tags);
-            crate::mostro::pow::set_pows(difficulty, first_contact);
+            crate::mostro::pow::set_pows(&mostro_pubkey_hex, difficulty, first_contact);
 
             // Today's daemons publish no escrow tags at all, so this resolves
             // to Unknown — which keeps every Cashu path shut. See escrow_mode.
@@ -244,7 +246,7 @@ pub(crate) async fn fetch_and_set_node_capabilities() {
         }
         Ok(None) => {
             log::warn!("[nostr] no Kind 38385 event found — PoW defaults to 0");
-            crate::mostro::pow::set_pows(0, None);
+            crate::mostro::pow::set_pows(&mostro_pubkey_hex, 0, None);
             // Nothing was advertised: stay Unknown rather than assume
             // Lightning, and leave Cashu closed.
             escrow_mode::clear();

--- a/rust/src/api/nostr.rs
+++ b/rust/src/api/nostr.rs
@@ -231,10 +231,11 @@ pub(crate) async fn fetch_and_set_node_capabilities() {
         Ok(Some(tags)) => {
             // Both difficulties: `pow` for every event, `pow_first_contact`
             // for the first event of a trade. An absent first-contact tag is
-            // recorded as unknown rather than as `pow` — see mostro::pow.
+            // recorded as unknown rather than as `pow`, and both land in one
+            // atomic snapshot so an in-flight wrap can never mix generations
+            // — see mostro::pow.
             let (difficulty, first_contact) = crate::mostro::pow::parse_pow_tags(&tags);
-            crate::mostro::pow::set_pow(difficulty);
-            crate::mostro::pow::set_first_contact_pow(first_contact);
+            crate::mostro::pow::set_pows(difficulty, first_contact);
 
             // Today's daemons publish no escrow tags at all, so this resolves
             // to Unknown — which keeps every Cashu path shut. See escrow_mode.
@@ -243,8 +244,7 @@ pub(crate) async fn fetch_and_set_node_capabilities() {
         }
         Ok(None) => {
             log::warn!("[nostr] no Kind 38385 event found — PoW defaults to 0");
-            crate::mostro::pow::set_pow(0);
-            crate::mostro::pow::set_first_contact_pow(None);
+            crate::mostro::pow::set_pows(0, None);
             // Nothing was advertised: stay Unknown rather than assume
             // Lightning, and leave Cashu closed.
             escrow_mode::clear();

--- a/rust/src/api/nostr.rs
+++ b/rust/src/api/nostr.rs
@@ -229,20 +229,12 @@ pub(crate) async fn fetch_and_set_node_capabilities() {
     let mostro_pubkey_hex = crate::config::active_mostro_pubkey();
     match fetch_mostro_instance_tags(mostro_pubkey_hex).await {
         Ok(Some(tags)) => {
-            let pow_tag = tags
-                .iter()
-                .find(|t| t.first().map(|s| s.as_str()) == Some("pow"));
-            let difficulty = match pow_tag.and_then(|t| t.get(1)) {
-                Some(v) => match v.parse::<u8>() {
-                    Ok(d) => d,
-                    Err(_) => {
-                        log::warn!("[nostr] malformed pow tag value: {v:?} — defaulting to 0");
-                        0
-                    }
-                },
-                None => 0,
-            };
+            // Both difficulties: `pow` for every event, `pow_first_contact`
+            // for the first event of a trade. An absent first-contact tag is
+            // recorded as unknown rather than as `pow` — see mostro::pow.
+            let (difficulty, first_contact) = crate::mostro::pow::parse_pow_tags(&tags);
             crate::mostro::pow::set_pow(difficulty);
+            crate::mostro::pow::set_first_contact_pow(first_contact);
 
             // Today's daemons publish no escrow tags at all, so this resolves
             // to Unknown — which keeps every Cashu path shut. See escrow_mode.
@@ -252,6 +244,7 @@ pub(crate) async fn fetch_and_set_node_capabilities() {
         Ok(None) => {
             log::warn!("[nostr] no Kind 38385 event found — PoW defaults to 0");
             crate::mostro::pow::set_pow(0);
+            crate::mostro::pow::set_first_contact_pow(None);
             // Nothing was advertised: stay Unknown rather than assume
             // Lightning, and leave Cashu closed.
             escrow_mode::clear();

--- a/rust/src/mostro/actions.rs
+++ b/rust/src/mostro/actions.rs
@@ -415,6 +415,125 @@ pub async fn restore_session(
 mod tests {
     use super::*;
 
+    /// The NIP-13 target difficulty the event was mined at, read from its
+    /// nonce tag (`["nonce", "<nonce>", "<target>"]`), or `None` when the
+    /// event was not mined at all.
+    fn mined_target(json: &str) -> Option<String> {
+        let event = Event::from_json(json).unwrap();
+        event.tags.iter().find_map(|t| {
+            let tag = t.as_slice();
+            (tag.first().map(String::as_str) == Some("nonce"))
+                .then(|| tag.get(2).cloned())
+                .flatten()
+        })
+    }
+
+    fn sample_params() -> NewOrderParams {
+        NewOrderParams {
+            kind: OrderKind::Sell,
+            fiat_amount: Some(100.0),
+            fiat_amount_min: None,
+            fiat_amount_max: None,
+            fiat_code: "USD".to_string(),
+            payment_method: "cashapp".to_string(),
+            premium: 0.0,
+            amount_sats: None,
+        }
+    }
+
+    /// Directed PoW-selection coverage (issue #177): create, take, and restore
+    /// are first-contact events — their visible sender is a trade key the
+    /// daemon does not know yet — so they must mine at `first_contact_pow()`,
+    /// not the base difficulty. Distinct values (1 vs 4) make the nonce tag
+    /// betray which one was selected; both are low enough to mine instantly.
+    #[tokio::test]
+    async fn create_take_and_restore_mine_at_the_first_contact_difficulty() {
+        use std::time::Duration;
+
+        let _pow = crate::mostro::pow::test_support::lock_pow();
+        crate::mostro::pow::set_pows(1, Some(4));
+
+        let identity_keys = Keys::generate();
+        let trade_keys = Keys::generate();
+        let mostro_pubkey = Keys::generate().public_key();
+        let order_id = "94486ae3-4083-4dfe-b543-53fe761025e9";
+
+        // Mining is probabilistic — cap wall time so a regression that stalls
+        // does not hang CI indefinitely.
+        let wraps = crate::rt::time::timeout(Duration::from_secs(60), async {
+            let create = new_order(
+                &identity_keys,
+                &trade_keys,
+                &mostro_pubkey,
+                &sample_params(),
+                3,
+                42,
+            )
+            .await
+            .unwrap();
+            let take = take_sell(
+                &identity_keys,
+                &trade_keys,
+                &mostro_pubkey,
+                order_id,
+                5,
+                None,
+                None,
+                77,
+            )
+            .await
+            .unwrap();
+            let restore = restore_session(&identity_keys, &trade_keys, &mostro_pubkey)
+                .await
+                .unwrap();
+            [("create", create), ("take", take), ("restore", restore)]
+        })
+        .await
+        .expect("first-contact wraps timed out");
+
+        for (name, json) in wraps {
+            assert_eq!(
+                mined_target(&json).as_deref(),
+                Some("4"),
+                "{name} must mine at first_contact_pow(), not the base pow"
+            );
+        }
+    }
+
+    /// The counterpart: an action on an order the daemon already knows the
+    /// trade key for pays only the base `pow`, never `pow_first_contact`.
+    #[tokio::test]
+    async fn generic_actions_mine_at_the_base_difficulty() {
+        use std::time::Duration;
+
+        let _pow = crate::mostro::pow::test_support::lock_pow();
+        crate::mostro::pow::set_pows(1, Some(4));
+
+        let identity_keys = Keys::generate();
+        let trade_keys = Keys::generate();
+        let mostro_pubkey = Keys::generate().public_key();
+
+        let json = crate::rt::time::timeout(
+            Duration::from_secs(60),
+            fiat_sent(
+                &identity_keys,
+                &trade_keys,
+                &mostro_pubkey,
+                "94486ae3-4083-4dfe-b543-53fe761025e9",
+                5,
+            ),
+        )
+        .await
+        .expect("generic wrap timed out")
+        .unwrap();
+
+        assert_eq!(
+            mined_target(&json).as_deref(),
+            Some("1"),
+            "a generic action must mine at get_pow()"
+        );
+    }
+
     /// The outgoing new-order message must carry the caller's request_id —
     /// it is the correlation nonce the daemon echoes in its reply, and
     /// `create_order` relies on it to tell the genuine reply apart from

--- a/rust/src/mostro/actions.rs
+++ b/rust/src/mostro/actions.rs
@@ -76,7 +76,7 @@ pub async fn new_order(
         Action::NewOrder,
         payload,
     );
-    wrap_message(identity_keys, trade_keys, mostro_pubkey, &msg).await
+    wrap_message_first_contact(identity_keys, trade_keys, mostro_pubkey, &msg).await
 }
 
 /// Build and wrap a TakeBuy MostroMessage.
@@ -321,7 +321,7 @@ async fn take_order_impl(
         action,
         payload,
     );
-    wrap_message(identity_keys, trade_keys, mostro_pubkey, &msg).await
+    wrap_message_first_contact(identity_keys, trade_keys, mostro_pubkey, &msg).await
 }
 
 /// Helper for actions that only need an order ID and no additional payload.
@@ -347,7 +347,46 @@ async fn wrap_message(
     mostro_pubkey: &PublicKey,
     msg: &Message,
 ) -> Result<String> {
-    let pow = crate::mostro::pow::get_pow();
+    wrap_message_at(
+        identity_keys,
+        trade_keys,
+        mostro_pubkey,
+        msg,
+        crate::mostro::pow::get_pow(),
+    )
+    .await
+}
+
+/// [`wrap_message`] for a **first-contact** event — one whose visible sender is
+/// a trade key the daemon does not yet associate with an active order or
+/// dispute: creating an order, taking one, or a restore under a fresh trade
+/// key. Those pay `pow_first_contact`, which is never lower than `pow` and is
+/// typically higher; mining such an event at `pow` gets it dropped before the
+/// daemon decrypts anything, with no reply of any kind, so the caller sees only
+/// a timeout (issue #177).
+async fn wrap_message_first_contact(
+    identity_keys: &Keys,
+    trade_keys: &Keys,
+    mostro_pubkey: &PublicKey,
+    msg: &Message,
+) -> Result<String> {
+    wrap_message_at(
+        identity_keys,
+        trade_keys,
+        mostro_pubkey,
+        msg,
+        crate::mostro::pow::first_contact_pow(),
+    )
+    .await
+}
+
+async fn wrap_message_at(
+    identity_keys: &Keys,
+    trade_keys: &Keys,
+    mostro_pubkey: &PublicKey,
+    msg: &Message,
+    pow: u8,
+) -> Result<String> {
     let event =
         gift_wrap::wrap_mostro_message(identity_keys, trade_keys, mostro_pubkey, msg, pow).await?;
     Ok(event.as_json())
@@ -369,7 +408,7 @@ pub async fn restore_session(
     // daemon to look up the user's trades); trade_keys sign the rumor
     // (-> event.sender, the key the daemon replies to). Mirrors new_order.
     let msg = Message::new_restore(None);
-    wrap_message(identity_keys, trade_keys, mostro_pubkey, &msg).await
+    wrap_message_first_contact(identity_keys, trade_keys, mostro_pubkey, &msg).await
 }
 
 #[cfg(test)]

--- a/rust/src/mostro/actions.rs
+++ b/rust/src/mostro/actions.rs
@@ -364,20 +364,20 @@ async fn wrap_message(
 /// typically higher; mining such an event at `pow` gets it dropped before the
 /// daemon decrypts anything, with no reply of any kind, so the caller sees only
 /// a timeout (issue #177).
+///
+/// The difficulty must come from a capability snapshot fetched *from
+/// `mostro_pubkey`*: at startup none exists yet, and right after a node switch
+/// the store still holds the previous node's values. `first_contact_pow_for`
+/// waits for the right generation and fails closed (`PowUnknown`) if it never
+/// arrives, rather than mine at a difficulty that may be silently rejected.
 async fn wrap_message_first_contact(
     identity_keys: &Keys,
     trade_keys: &Keys,
     mostro_pubkey: &PublicKey,
     msg: &Message,
 ) -> Result<String> {
-    wrap_message_at(
-        identity_keys,
-        trade_keys,
-        mostro_pubkey,
-        msg,
-        crate::mostro::pow::first_contact_pow(),
-    )
-    .await
+    let pow = crate::mostro::pow::first_contact_pow_for(&mostro_pubkey.to_hex()).await?;
+    wrap_message_at(identity_keys, trade_keys, mostro_pubkey, msg, pow).await
 }
 
 async fn wrap_message_at(
@@ -450,13 +450,13 @@ mod tests {
     async fn create_take_and_restore_mine_at_the_first_contact_difficulty() {
         use std::time::Duration;
 
-        let _pow = crate::mostro::pow::test_support::lock_pow();
-        crate::mostro::pow::set_pows(1, Some(4));
-
         let identity_keys = Keys::generate();
         let trade_keys = Keys::generate();
         let mostro_pubkey = Keys::generate().public_key();
         let order_id = "94486ae3-4083-4dfe-b543-53fe761025e9";
+
+        let _pow = crate::mostro::pow::test_support::lock_pow();
+        crate::mostro::pow::set_pows(&mostro_pubkey.to_hex(), 1, Some(4));
 
         // Mining is probabilistic — cap wall time so a regression that stalls
         // does not hang CI indefinitely.
@@ -506,12 +506,12 @@ mod tests {
     async fn generic_actions_mine_at_the_base_difficulty() {
         use std::time::Duration;
 
-        let _pow = crate::mostro::pow::test_support::lock_pow();
-        crate::mostro::pow::set_pows(1, Some(4));
-
         let identity_keys = Keys::generate();
         let trade_keys = Keys::generate();
         let mostro_pubkey = Keys::generate().public_key();
+
+        let _pow = crate::mostro::pow::test_support::lock_pow();
+        crate::mostro::pow::set_pows(&mostro_pubkey.to_hex(), 1, Some(4));
 
         let json = crate::rt::time::timeout(
             Duration::from_secs(60),
@@ -543,6 +543,11 @@ mod tests {
         let identity_keys = Keys::generate();
         let trade_keys = Keys::generate();
         let mostro_keys = Keys::generate();
+
+        // First-contact wrapping fails closed until this node's capabilities
+        // are published — a test double for the Kind 38385 fetch.
+        let _pow = crate::mostro::pow::test_support::lock_pow();
+        crate::mostro::pow::set_pows(&mostro_keys.public_key().to_hex(), 0, None);
 
         let params = NewOrderParams {
             kind: OrderKind::Sell,
@@ -588,6 +593,11 @@ mod tests {
         let trade_keys = Keys::generate();
         let mostro_keys = Keys::generate();
         let order_id = "94486ae3-4083-4dfe-b543-53fe761025e9";
+
+        // First-contact wrapping fails closed until this node's capabilities
+        // are published — a test double for the Kind 38385 fetch.
+        let _pow = crate::mostro::pow::test_support::lock_pow();
+        crate::mostro::pow::set_pows(&mostro_keys.public_key().to_hex(), 0, None);
 
         let json = take_sell(
             &identity_keys,
@@ -647,6 +657,12 @@ mod tests {
         let identity_keys = Keys::generate();
         let trade_keys = Keys::generate();
         let mostro_keys = Keys::generate();
+
+        // First-contact wrapping fails closed until this node's capabilities
+        // are published — a test double for the Kind 38385 fetch.
+        let _pow = crate::mostro::pow::test_support::lock_pow();
+        crate::mostro::pow::set_pows(&mostro_keys.public_key().to_hex(), 0, None);
+
         let json = restore_session(&identity_keys, &trade_keys, &mostro_keys.public_key())
             .await
             .unwrap();

--- a/rust/src/mostro/pow.rs
+++ b/rust/src/mostro/pow.rs
@@ -1,10 +1,33 @@
-/// Global NIP-13 Proof of Work difficulty required by the connected Mostro.
+/// NIP-13 Proof of Work difficulties required by the connected Mostro.
 ///
-/// Set when the relay pool goes online by parsing the `pow` tag from
-/// the daemon's Kind 38385 event.  Read by `gift_wrap::wrap` before signing.
-use std::sync::atomic::{AtomicU8, Ordering};
+/// Both are published in the daemon's Kind 38385 event and set when the relay
+/// pool goes online:
+///
+/// * `pow` — required of **every** event the client sends.
+/// * `pow_first_contact` — required when the visible sender is a trade key the
+///   node does not yet associate with an active order or dispute: creating an
+///   order, taking one, or a restore under a fresh trade key. Never lower than
+///   `pow`, typically higher.
+///
+/// An under-powered event is dropped before the daemon decrypts anything, with
+/// no `cant-do` and no error of any kind — mining against `pow` when the node
+/// charges `pow_first_contact` makes order creation silently do nothing
+/// (issue #177, <https://mostro.network/protocol/transport_migration.html>).
+///
+/// **An absent `pow_first_contact` tag means unknown, not zero and not `pow`.**
+/// Daemons that enforce a first-contact difficulty but predate the tag exist,
+/// so [`get_first_contact_pow`] returns `None` rather than a number and
+/// [`first_contact_pow`] falls back to at least `pow`.
+use std::sync::atomic::{AtomicU16, AtomicU8, Ordering};
 
 static POW_DIFFICULTY: AtomicU8 = AtomicU8::new(0);
+
+const FIRST_CONTACT_ABSENT: u16 = u16::MAX;
+
+/// `pow_first_contact`, or [`FIRST_CONTACT_ABSENT`] when the node published no
+/// such tag. A `u16` only so the "absent" state has a value a `u8` difficulty
+/// can never occupy.
+static POW_FIRST_CONTACT: AtomicU16 = AtomicU16::new(FIRST_CONTACT_ABSENT);
 
 /// Store the required PoW difficulty for outgoing events.
 pub fn set_pow(difficulty: u8) {
@@ -12,7 +35,144 @@ pub fn set_pow(difficulty: u8) {
     log::info!("[pow] difficulty set to {difficulty}");
 }
 
+/// Store the first-contact difficulty, or `None` when the node published none.
+pub fn set_first_contact_pow(difficulty: Option<u8>) {
+    match difficulty {
+        Some(d) => {
+            POW_FIRST_CONTACT.store(u16::from(d), Ordering::Relaxed);
+            log::info!("[pow] first-contact difficulty set to {d}");
+        }
+        None => {
+            POW_FIRST_CONTACT.store(FIRST_CONTACT_ABSENT, Ordering::Relaxed);
+            log::info!(
+                "[pow] node published no pow_first_contact — first-contact difficulty unknown"
+            );
+        }
+    }
+}
+
 /// Current PoW difficulty.  Returns 0 when no PoW is required.
 pub fn get_pow() -> u8 {
     POW_DIFFICULTY.load(Ordering::Relaxed)
+}
+
+/// Advertised first-contact difficulty, or `None` when the node published no
+/// `pow_first_contact` tag — which means *unknown*, not zero.
+pub fn get_first_contact_pow() -> Option<u8> {
+    match POW_FIRST_CONTACT.load(Ordering::Relaxed) {
+        FIRST_CONTACT_ABSENT => None,
+        d => Some(d as u8),
+    }
+}
+
+/// Difficulty to mine a first-contact event at. See [`resolve_first_contact`].
+pub fn first_contact_pow() -> u8 {
+    resolve_first_contact(get_pow(), get_first_contact_pow())
+}
+
+/// The first-contact difficulty implied by [`pow`](get_pow) and an optional
+/// `pow_first_contact`:
+///
+/// * published → that value, but never below `pow` (the protocol states it is
+///   never lower; a node advertising otherwise is clamped rather than trusted).
+/// * absent → `pow`, the documented floor for an unknown first-contact
+///   difficulty. That may still be too low, which no client can detect from the
+///   event alone: silence is the gate's only feedback.
+pub fn resolve_first_contact(pow: u8, first_contact: Option<u8>) -> u8 {
+    match first_contact {
+        Some(d) => d.max(pow),
+        None => pow,
+    }
+}
+
+/// Read both PoW difficulties out of a Kind 38385 tag list.
+///
+/// A malformed value is reported and treated as if the tag were absent, which
+/// for `pow` means 0 and for `pow_first_contact` means unknown.
+pub fn parse_pow_tags(tags: &[Vec<String>]) -> (u8, Option<u8>) {
+    (
+        parse_difficulty(tags, "pow").unwrap_or(0),
+        parse_difficulty(tags, "pow_first_contact"),
+    )
+}
+
+fn parse_difficulty(tags: &[Vec<String>], name: &str) -> Option<u8> {
+    let value = tags
+        .iter()
+        .find(|t| t.first().map(|s| s.as_str()) == Some(name))?
+        .get(1)?;
+
+    match value.parse::<u8>() {
+        Ok(d) => Some(d),
+        Err(_) => {
+            log::warn!("[pow] malformed {name} tag value: {value:?} — treating as absent");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tag(name: &str, value: &str) -> Vec<String> {
+        vec![name.to_string(), value.to_string()]
+    }
+
+    #[test]
+    fn an_absent_first_contact_tag_falls_back_to_pow() {
+        // Not 0: the tag being absent means the difficulty is unknown, and
+        // mining below `pow` would be dropped for certain.
+        assert_eq!(resolve_first_contact(6, None), 6);
+        assert_eq!(resolve_first_contact(0, None), 0);
+    }
+
+    #[test]
+    fn a_published_first_contact_difficulty_is_used() {
+        assert_eq!(resolve_first_contact(6, Some(12)), 12);
+    }
+
+    #[test]
+    fn a_first_contact_difficulty_below_pow_is_clamped() {
+        // The protocol states it is never lower than `pow`; a node saying
+        // otherwise gets clamped rather than trusted, since `pow` applies to
+        // every event including this one.
+        assert_eq!(resolve_first_contact(6, Some(2)), 6);
+    }
+
+    #[test]
+    fn both_difficulties_are_read_from_the_tag_list() {
+        let tags = vec![
+            tag("mostro_version", "0.18.0"),
+            tag("pow", "6"),
+            tag("pow_first_contact", "12"),
+        ];
+
+        assert_eq!(parse_pow_tags(&tags), (6, Some(12)));
+    }
+
+    #[test]
+    fn a_node_publishing_only_pow_leaves_first_contact_unknown() {
+        // What the daemon at 0.18.0 actually advertises today.
+        let tags = vec![tag("pow", "6"), tag("protocol_version", "1")];
+
+        assert_eq!(parse_pow_tags(&tags), (6, None));
+    }
+
+    #[test]
+    fn malformed_values_are_treated_as_absent() {
+        let tags = vec![tag("pow", "many"), tag("pow_first_contact", "-1")];
+
+        assert_eq!(parse_pow_tags(&tags), (0, None));
+    }
+
+    #[test]
+    fn a_valueless_tag_is_treated_as_absent() {
+        let tags = vec![
+            vec!["pow".to_string()],
+            vec!["pow_first_contact".to_string()],
+        ];
+
+        assert_eq!(parse_pow_tags(&tags), (0, None));
+    }
 }

--- a/rust/src/mostro/pow.rs
+++ b/rust/src/mostro/pow.rs
@@ -18,56 +18,66 @@
 /// Daemons that enforce a first-contact difficulty but predate the tag exist,
 /// so [`get_first_contact_pow`] returns `None` rather than a number and
 /// [`first_contact_pow`] falls back to at least `pow`.
-use std::sync::atomic::{AtomicU16, AtomicU8, Ordering};
-
-static POW_DIFFICULTY: AtomicU8 = AtomicU8::new(0);
+use std::sync::atomic::{AtomicU32, Ordering};
 
 const FIRST_CONTACT_ABSENT: u16 = u16::MAX;
 
-/// `pow_first_contact`, or [`FIRST_CONTACT_ABSENT`] when the node published no
-/// such tag. A `u16` only so the "absent" state has a value a `u8` difficulty
-/// can never occupy.
-static POW_FIRST_CONTACT: AtomicU16 = AtomicU16::new(FIRST_CONTACT_ABSENT);
+/// Both difficulties packed into one word — bits 0–7 hold `pow`, bits 8–23
+/// hold `pow_first_contact` as a `u16` whose [`FIRST_CONTACT_ABSENT`] value a
+/// `u8` difficulty can never occupy. One word, one store, one load: a reader
+/// can never observe `pow` from one capability refresh and
+/// `pow_first_contact` from another — e.g. mine a first-contact event at the
+/// old first-contact value while a refresh to a stricter node is mid-flight.
+static POW_SNAPSHOT: AtomicU32 = AtomicU32::new(encode(0, None));
 
-/// Store the required PoW difficulty for outgoing events.
-pub fn set_pow(difficulty: u8) {
-    POW_DIFFICULTY.store(difficulty, Ordering::Relaxed);
-    log::info!("[pow] difficulty set to {difficulty}");
+const fn encode(pow: u8, first_contact: Option<u8>) -> u32 {
+    let fc = match first_contact {
+        Some(d) => d as u16,
+        None => FIRST_CONTACT_ABSENT,
+    };
+    ((fc as u32) << 8) | pow as u32
 }
 
-/// Store the first-contact difficulty, or `None` when the node published none.
-pub fn set_first_contact_pow(difficulty: Option<u8>) {
-    match difficulty {
-        Some(d) => {
-            POW_FIRST_CONTACT.store(u16::from(d), Ordering::Relaxed);
-            log::info!("[pow] first-contact difficulty set to {d}");
-        }
-        None => {
-            POW_FIRST_CONTACT.store(FIRST_CONTACT_ABSENT, Ordering::Relaxed);
-            log::info!(
-                "[pow] node published no pow_first_contact — first-contact difficulty unknown"
-            );
-        }
+const fn decode(snapshot: u32) -> (u8, Option<u8>) {
+    let pow = (snapshot & 0xFF) as u8;
+    match (snapshot >> 8) as u16 {
+        FIRST_CONTACT_ABSENT => (pow, None),
+        d => (pow, Some(d as u8)),
+    }
+}
+
+/// Store both PoW difficulties as one atomic snapshot: `pow` for every
+/// outgoing event, and `pow_first_contact` (`None` when the node published no
+/// such tag). A single setter on purpose — publishing them separately would
+/// let a concurrent wrap mine against one fresh and one stale value.
+pub fn set_pows(pow: u8, first_contact: Option<u8>) {
+    POW_SNAPSHOT.store(encode(pow, first_contact), Ordering::Relaxed);
+    match first_contact {
+        Some(d) => log::info!("[pow] difficulty set to {pow}, first-contact to {d}"),
+        None => log::info!(
+            "[pow] difficulty set to {pow}; node published no pow_first_contact — \
+             first-contact difficulty unknown"
+        ),
     }
 }
 
 /// Current PoW difficulty.  Returns 0 when no PoW is required.
 pub fn get_pow() -> u8 {
-    POW_DIFFICULTY.load(Ordering::Relaxed)
+    decode(POW_SNAPSHOT.load(Ordering::Relaxed)).0
 }
 
 /// Advertised first-contact difficulty, or `None` when the node published no
 /// `pow_first_contact` tag — which means *unknown*, not zero.
 pub fn get_first_contact_pow() -> Option<u8> {
-    match POW_FIRST_CONTACT.load(Ordering::Relaxed) {
-        FIRST_CONTACT_ABSENT => None,
-        d => Some(d as u8),
-    }
+    decode(POW_SNAPSHOT.load(Ordering::Relaxed)).1
 }
 
-/// Difficulty to mine a first-contact event at. See [`resolve_first_contact`].
+/// Difficulty to mine a first-contact event at. Both inputs come from a single
+/// atomic load, so they always belong to the same capability refresh. See
+/// [`resolve_first_contact`].
 pub fn first_contact_pow() -> u8 {
-    resolve_first_contact(get_pow(), get_first_contact_pow())
+    let (pow, first_contact) = decode(POW_SNAPSHOT.load(Ordering::Relaxed));
+    resolve_first_contact(pow, first_contact)
 }
 
 /// The first-contact difficulty implied by [`pow`](get_pow) and an optional
@@ -111,6 +121,28 @@ fn parse_difficulty(tags: &[Vec<String>], name: &str) -> Option<u8> {
     }
 }
 
+/// Serializes tests that touch the process-global PoW snapshot — they live in
+/// this module and in `mostro::actions` — and restores the "nothing
+/// advertised" default on drop so no test leaks a difficulty into another.
+#[cfg(test)]
+pub(crate) mod test_support {
+    use std::sync::{Mutex, MutexGuard, PoisonError};
+
+    static LOCK: Mutex<()> = Mutex::new(());
+
+    pub(crate) struct PowGuard(#[allow(dead_code)] MutexGuard<'static, ()>);
+
+    impl Drop for PowGuard {
+        fn drop(&mut self) {
+            super::set_pows(0, None);
+        }
+    }
+
+    pub(crate) fn lock_pow() -> PowGuard {
+        PowGuard(LOCK.lock().unwrap_or_else(PoisonError::into_inner))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -138,6 +170,37 @@ mod tests {
         // otherwise gets clamped rather than trusted, since `pow` applies to
         // every event including this one.
         assert_eq!(resolve_first_contact(6, Some(2)), 6);
+    }
+
+    #[test]
+    fn the_snapshot_roundtrips_every_boundary_value() {
+        for (pow, fc) in [
+            (0, None),
+            (255, None),
+            (0, Some(0)),
+            (255, Some(255)),
+            (6, Some(12)),
+        ] {
+            assert_eq!(decode(encode(pow, fc)), (pow, fc));
+        }
+    }
+
+    /// Regression for the refresh race (PR #251 review): both difficulties are
+    /// published as one snapshot, so the absent → advertised transition can
+    /// never be observed half-applied by `first_contact_pow`.
+    #[test]
+    fn a_refresh_publishes_both_difficulties_together() {
+        let _guard = test_support::lock_pow();
+
+        set_pows(6, None);
+        assert_eq!(get_pow(), 6);
+        assert_eq!(get_first_contact_pow(), None);
+        assert_eq!(first_contact_pow(), 6);
+
+        set_pows(6, Some(12));
+        assert_eq!(get_pow(), 6);
+        assert_eq!(get_first_contact_pow(), Some(12));
+        assert_eq!(first_contact_pow(), 12);
     }
 
     #[test]

--- a/rust/src/mostro/pow.rs
+++ b/rust/src/mostro/pow.rs
@@ -16,68 +16,112 @@
 ///
 /// **An absent `pow_first_contact` tag means unknown, not zero and not `pow`.**
 /// Daemons that enforce a first-contact difficulty but predate the tag exist,
-/// so [`get_first_contact_pow`] returns `None` rather than a number and
-/// [`first_contact_pow`] falls back to at least `pow`.
-use std::sync::atomic::{AtomicU32, Ordering};
+/// so the tag parses to `None` rather than a number and
+/// [`first_contact_pow_for`] falls back to at least `pow`.
+use std::sync::LazyLock;
 
-const FIRST_CONTACT_ABSENT: u16 = u16::MAX;
+use anyhow::{anyhow, Result};
+use tokio::sync::watch;
 
-/// Both difficulties packed into one word — bits 0–7 hold `pow`, bits 8–23
-/// hold `pow_first_contact` as a `u16` whose [`FIRST_CONTACT_ABSENT`] value a
-/// `u8` difficulty can never occupy. One word, one store, one load: a reader
-/// can never observe `pow` from one capability refresh and
-/// `pow_first_contact` from another — e.g. mine a first-contact event at the
-/// old first-contact value while a refresh to a stricter node is mid-flight.
-static POW_SNAPSHOT: AtomicU32 = AtomicU32::new(encode(0, None));
+use crate::rt::time::Duration;
 
-const fn encode(pow: u8, first_contact: Option<u8>) -> u32 {
-    let fc = match first_contact {
-        Some(d) => d as u16,
-        None => FIRST_CONTACT_ABSENT,
-    };
-    ((fc as u32) << 8) | pow as u32
+/// How long a first-contact wrap waits for the destination node's capability
+/// fetch before failing closed. The fetch itself is bounded by a 10s relay
+/// query, so a snapshot that has not arrived by then is not coming.
+const CAPABILITY_WAIT: Duration = Duration::from_secs(10);
+
+/// One capability generation: both difficulties plus the node (hex pubkey)
+/// they were fetched from. Published as a single value so a reader can never
+/// observe `pow` from one refresh and `pow_first_contact` from another — and,
+/// as important, so a reader can tell *whose* difficulties these are: at
+/// startup nothing has been fetched yet, and right after a node switch the
+/// stored generation still belongs to the previous node.
+#[derive(Clone, Debug, PartialEq)]
+struct Capabilities {
+    node: String,
+    pow: u8,
+    first_contact: Option<u8>,
 }
 
-const fn decode(snapshot: u32) -> (u8, Option<u8>) {
-    let pow = (snapshot & 0xFF) as u8;
-    match (snapshot >> 8) as u16 {
-        FIRST_CONTACT_ABSENT => (pow, None),
-        d => (pow, Some(d as u8)),
-    }
-}
+/// `None` until the first successful capability fetch. A `watch` channel so a
+/// first-contact wrap can await the generation it needs instead of reading
+/// whatever happens to be stored.
+static CAPS: LazyLock<watch::Sender<Option<Capabilities>>> =
+    LazyLock::new(|| watch::channel(None).0);
 
-/// Store both PoW difficulties as one atomic snapshot: `pow` for every
-/// outgoing event, and `pow_first_contact` (`None` when the node published no
-/// such tag). A single setter on purpose — publishing them separately would
-/// let a concurrent wrap mine against one fresh and one stale value.
-pub fn set_pows(pow: u8, first_contact: Option<u8>) {
-    POW_SNAPSHOT.store(encode(pow, first_contact), Ordering::Relaxed);
+/// Store both PoW difficulties fetched from `node` (hex pubkey) as one
+/// snapshot: `pow` for every outgoing event, and `pow_first_contact` (`None`
+/// when the node published no such tag). A single setter on purpose —
+/// publishing the values separately would let a concurrent wrap mine against
+/// one fresh and one stale value.
+pub fn set_pows(node: &str, pow: u8, first_contact: Option<u8>) {
+    CAPS.send_replace(Some(Capabilities {
+        node: node.to_string(),
+        pow,
+        first_contact,
+    }));
     match first_contact {
-        Some(d) => log::info!("[pow] difficulty set to {pow}, first-contact to {d}"),
+        Some(d) => log::info!("[pow] node {node}: difficulty set to {pow}, first-contact to {d}"),
         None => log::info!(
-            "[pow] difficulty set to {pow}; node published no pow_first_contact — \
+            "[pow] node {node}: difficulty set to {pow}; no pow_first_contact published — \
              first-contact difficulty unknown"
         ),
     }
 }
 
 /// Current PoW difficulty.  Returns 0 when no PoW is required.
+///
+/// Deliberately node-agnostic, unlike [`first_contact_pow_for`]: the events
+/// mined at this difficulty act on orders the daemon already knows, which can
+/// only exist after at least one successful capability fetch, and blocking
+/// every mid-trade send on a re-fetch would hurt more than a briefly stale
+/// difficulty does.
 pub fn get_pow() -> u8 {
-    decode(POW_SNAPSHOT.load(Ordering::Relaxed)).0
+    CAPS.borrow().as_ref().map_or(0, |c| c.pow)
 }
 
-/// Advertised first-contact difficulty, or `None` when the node published no
-/// `pow_first_contact` tag — which means *unknown*, not zero.
-pub fn get_first_contact_pow() -> Option<u8> {
-    decode(POW_SNAPSHOT.load(Ordering::Relaxed)).1
+/// Difficulty to mine a first-contact event for `node` (hex pubkey) at,
+/// resolved per [`resolve_first_contact`] — but only from a capability
+/// snapshot that was actually fetched *from that node*.
+///
+/// Until such a snapshot exists this waits (capability fetches run
+/// asynchronously when the relay pool comes online and after a node switch),
+/// and after [`CAPABILITY_WAIT`] it fails closed with a `PowUnknown` error
+/// rather than guess: at startup the store holds nothing, and right after a
+/// node switch it still holds the previous node's — possibly lower —
+/// difficulties, and an under-mined first-contact event is dropped silently
+/// (issue #177), which is strictly worse than an explicit error the user can
+/// retry.
+pub async fn first_contact_pow_for(node: &str) -> Result<u8> {
+    first_contact_pow_within(node, CAPABILITY_WAIT).await
 }
 
-/// Difficulty to mine a first-contact event at. Both inputs come from a single
-/// atomic load, so they always belong to the same capability refresh. See
-/// [`resolve_first_contact`].
-pub fn first_contact_pow() -> u8 {
-    let (pow, first_contact) = decode(POW_SNAPSHOT.load(Ordering::Relaxed));
-    resolve_first_contact(pow, first_contact)
+/// [`first_contact_pow_for`] with an explicit wait bound, so tests can cover
+/// the fail-closed path without a 10-second stall.
+async fn first_contact_pow_within(node: &str, wait: Duration) -> Result<u8> {
+    let mut rx = CAPS.subscribe();
+    crate::rt::time::timeout(wait, async {
+        loop {
+            // Scoped so the watch borrow is released before awaiting.
+            let ready = rx
+                .borrow_and_update()
+                .as_ref()
+                .filter(|c| c.node == node)
+                .map(|c| resolve_first_contact(c.pow, c.first_contact));
+            if let Some(pow) = ready {
+                return pow;
+            }
+            if rx.changed().await.is_err() {
+                // The sender is a static and never drops; park until the
+                // timeout fires rather than spin.
+                std::future::pending::<()>().await;
+            }
+        }
+    })
+    .await
+    .map_err(|_| {
+        anyhow!("PowUnknown: capabilities for node {node} not fetched yet — refusing to mine a first-contact event at a difficulty that may be too low")
+    })
 }
 
 /// The first-contact difficulty implied by [`pow`](get_pow) and an optional
@@ -134,7 +178,7 @@ pub(crate) mod test_support {
 
     impl Drop for PowGuard {
         fn drop(&mut self) {
-            super::set_pows(0, None);
+            super::CAPS.send_replace(None);
         }
     }
 
@@ -172,35 +216,65 @@ mod tests {
         assert_eq!(resolve_first_contact(6, Some(2)), 6);
     }
 
-    #[test]
-    fn the_snapshot_roundtrips_every_boundary_value() {
-        for (pow, fc) in [
-            (0, None),
-            (255, None),
-            (0, Some(0)),
-            (255, Some(255)),
-            (6, Some(12)),
-        ] {
-            assert_eq!(decode(encode(pow, fc)), (pow, fc));
-        }
-    }
-
     /// Regression for the refresh race (PR #251 review): both difficulties are
     /// published as one snapshot, so the absent → advertised transition can
-    /// never be observed half-applied by `first_contact_pow`.
-    #[test]
-    fn a_refresh_publishes_both_difficulties_together() {
+    /// never be observed half-applied by a first-contact wrap.
+    #[tokio::test]
+    async fn a_refresh_publishes_both_difficulties_together() {
         let _guard = test_support::lock_pow();
 
-        set_pows(6, None);
+        set_pows("node-a", 6, None);
         assert_eq!(get_pow(), 6);
-        assert_eq!(get_first_contact_pow(), None);
-        assert_eq!(first_contact_pow(), 6);
+        assert_eq!(first_contact_pow_within("node-a", SHORT).await.unwrap(), 6);
 
-        set_pows(6, Some(12));
+        set_pows("node-a", 6, Some(12));
         assert_eq!(get_pow(), 6);
-        assert_eq!(get_first_contact_pow(), Some(12));
-        assert_eq!(first_contact_pow(), 12);
+        assert_eq!(first_contact_pow_within("node-a", SHORT).await.unwrap(), 12);
+    }
+
+    /// A short bound for waits the test expects to succeed immediately or to
+    /// fail closed without stalling the suite.
+    const SHORT: Duration = Duration::from_millis(50);
+
+    /// Regression for ermeme's P1 on PR #251, startup window: before any
+    /// capability fetch has completed there is no snapshot, and a
+    /// first-contact wrap must fail closed instead of mining at 0.
+    #[tokio::test]
+    async fn before_any_fetch_first_contact_fails_closed() {
+        let _guard = test_support::lock_pow();
+
+        let err = first_contact_pow_within("node-a", SHORT).await.unwrap_err();
+        assert!(err.to_string().starts_with("PowUnknown"), "got: {err}");
+    }
+
+    /// Regression for ermeme's P1 on PR #251, node-switch window: the previous
+    /// node's snapshot must never satisfy a first-contact wrap for the new
+    /// node, no matter how fresh it is.
+    #[tokio::test]
+    async fn a_previous_nodes_snapshot_never_serves_the_new_node() {
+        let _guard = test_support::lock_pow();
+
+        set_pows("node-a", 1, Some(2));
+        let err = first_contact_pow_within("node-b", SHORT).await.unwrap_err();
+        assert!(err.to_string().starts_with("PowUnknown"), "got: {err}");
+    }
+
+    /// The wait side of the gate: a wrap that arrives while the capability
+    /// fetch is still in flight blocks until the fetch lands, then mines at
+    /// the fetched difficulty — no error, no under-mining.
+    #[tokio::test]
+    async fn a_delayed_capability_fetch_unblocks_the_wait() {
+        let _guard = test_support::lock_pow();
+
+        crate::rt::spawn(async {
+            crate::rt::time::sleep(Duration::from_millis(20)).await;
+            set_pows("node-a", 6, Some(12));
+        });
+
+        let pow = first_contact_pow_within("node-a", Duration::from_secs(5))
+            .await
+            .unwrap();
+        assert_eq!(pow, 12);
     }
 
     #[test]

--- a/specs/005-transport-v2-migration/spec.md
+++ b/specs/005-transport-v2-migration/spec.md
@@ -69,6 +69,22 @@ delivery and decryption are unchanged.
 - **FR-005**: Outgoing v2 events MUST carry no NIP-40 expiration tag (`expiration:
   None`), mirroring the reference client; the daemon fills its own.
 - **FR-006**: Full-privacy mode MUST behave as today (identity key = trade key).
+- **FR-007**: Outgoing v2 events MUST be mined (NIP-13) to the difficulty the
+  connected node advertises in its Kind 38385 event: `pow` for every event, and
+  `pow_first_contact` for **first-contact** events — ones whose visible sender is
+  a trade key the node does not yet associate with an active order or dispute:
+  creating an order, taking one, or a restore under a fresh trade key. Selection
+  rules (issue #177):
+  - An absent `pow_first_contact` tag means *unknown* — not zero and not `pow`;
+    first-contact events then fall back to mining at `pow`.
+  - A published `pow_first_contact` lower than `pow` MUST be clamped up to `pow`
+    (the protocol states it is never lower; a node advertising otherwise is
+    clamped rather than trusted).
+  - Both difficulties MUST be refreshed together from the same Kind 38385 fetch
+    and published to senders as a single atomic snapshot, so a wrap in flight
+    during a refresh can never mix values from two generations.
+  - An under-powered event is dropped before the node decrypts anything, with no
+    `cant-do` and no reply of any kind — the caller sees only a timeout.
 
 ## Out of Scope
 

--- a/specs/005-transport-v2-migration/spec.md
+++ b/specs/005-transport-v2-migration/spec.md
@@ -81,8 +81,14 @@ delivery and decryption are unchanged.
     (the protocol states it is never lower; a node advertising otherwise is
     clamped rather than trusted).
   - Both difficulties MUST be refreshed together from the same Kind 38385 fetch
-    and published to senders as a single atomic snapshot, so a wrap in flight
-    during a refresh can never mix values from two generations.
+    and published to senders as a single snapshot, tagged with the node it was
+    fetched from, so a wrap in flight during a refresh can never mix values
+    from two generations.
+  - First-contact events MUST only be mined against a snapshot fetched from the
+    node they are addressed to: before the first fetch completes (startup) and
+    right after a node switch no such snapshot exists, and the sender MUST wait
+    for the fetch and fail closed (an explicit, retryable error) rather than
+    mine at a default or at the previous node's difficulty.
   - An under-powered event is dropped before the node decrypts anything, with no
     `cant-do` and no reply of any kind — the caller sees only a timeout.
 


### PR DESCRIPTION
Closes #177.

## Problem

The app read only the `pow` tag from the daemon's Kind 38385 event and applied that value to every outgoing event. A node charging a higher `pow_first_contact` therefore received under-powered create-order, take-order and restore events — and [the gate runs before the daemon decrypts anything](https://mostro.network/protocol/transport_migration.html#proof-of-work-and-the-first-contact-gate), so there is no `cant-do` and no error of any kind. The event is dropped and the client sees only a timeout (`NoDaemonResponse`).

## Change

`mostro::pow` now tracks both difficulties:

| Event | Difficulty |
| --- | --- |
| New order, take order, restore under a fresh trade key | `pow_first_contact`, clamped to never fall below `pow` |
| Anything inside an already-active order (fiat-sent, release, cancel, dispute, rate, add-invoice) | `pow` |

That split follows the protocol's definition: first contact is an event whose visible sender is a trade key the node does not yet associate with an active order or dispute. `restore_session` is included because it deliberately signs the rumor with a fresh trade key.

**An absent `pow_first_contact` tag is recorded as unknown** — not as `pow`, not as 0. The protocol is explicit that daemons enforcing a first-contact difficulty while predating the tag exist, and that assuming `pow` there is exactly the mistake that produces the silent drop. The fallback mines at `pow`, the documented floor.

## Verified against the live node

The daemon at `82fa8cb9…be88390` (mostro 0.18.0) currently advertises:

```
["pow","6"]            ← present
                       ← no pow_first_contact tag
["protocol_version","1"]
```

So this PR makes the app record that node's first-contact difficulty as *unknown* and mine at 6, instead of silently assuming 6 is enough. One of the tests pins exactly that tag shape.

## Test plan

- [x] `cargo test` — 205 passing. Parsing and the difficulty rules are pure functions, so they are tested without touching the process-wide PoW state: both tags present, only `pow` (the 0.18.0 shape above), a first-contact value below `pow` (clamped), malformed values, and a tag with no value.
- [x] `cargo clippy --all-targets` — no new warnings
- [x] `cargo check --locked --target wasm32-unknown-unknown` — passes

## Deliberately not in this PR

1. **Escalate-on-silence.** For an absent tag the protocol prescribes retrying a *freshly built* event at doubled difficulty up to a cap, since silence is the gate's only feedback. It belongs in the create/take wait loop rather than here, and it cannot be validated against the reference node until (2) lands.
2. **Transport selection.** That node advertises `protocol_version = "1"` (gift wrap, kind `1059`) while the app always sends kind `14` and only ever unwraps kind `14` replies. No amount of PoW gets an order created against it. Being tracked as separate work — it touches every daemon message in both directions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added distinct proof-of-work mining targets for first-contact interactions.
  * First-contact actions (create, take, restore) now automatically mine using the first-contact difficulty when available.
  * Capability announcements now publish both general and first-contact proof-of-work requirements together with consistent fallback behavior.

* **Bug Fixes**
  * Improved handling of missing or malformed proof-of-work settings and prevented mismatched difficulty updates.

* **Documentation**
  * Updated the transport v2 migration spec with FR-007 for outgoing protocol-v2 event mining rules and under-powered event handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->