### PR TITLE
feat(disputes): move the dispute chat onto the kind-14 envelope

### DIFF
--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -207,7 +207,12 @@ Future<ChatRoomState?> tradeInfoToChatRoom(
   // Fetch persisted messages to populate last-message preview.
   List<rust_types.ChatMessage> msgs;
   try {
-    msgs = await messages_api.getMessages(tradeId: trade.order.id);
+    // Peer messages only: the room preview and unread badge describe the
+    // buyer<->seller conversation, not the dispute channel that shares the
+    // order key (PR #254 review).
+    msgs = (await messages_api.getMessages(tradeId: trade.order.id))
+        .where((m) => m.messageType == rust_types.MessageType.peer)
+        .toList();
   } catch (_) {
     msgs = const [];
   }
@@ -273,5 +278,8 @@ final incomingMessageProvider =
 /// updates via [incomingMessageProvider].
 final messageHistoryProvider =
     FutureProvider.autoDispose.family<List<rust_types.ChatMessage>, String>(
-  (ref, tradeId) => messages_api.getMessages(tradeId: tradeId),
+  // Peer messages only — this feeds the peer chat room (PR #254 review).
+  (ref, tradeId) async => (await messages_api.getMessages(tradeId: tradeId))
+      .where((m) => m.messageType == rust_types.MessageType.peer)
+      .toList(),
 );

--- a/lib/features/chat/screens/chat_room_screen.dart
+++ b/lib/features/chat/screens/chat_room_screen.dart
@@ -78,6 +78,11 @@ class _ChatRoomScreenState extends ConsumerState<ChatRoomScreen> {
         // Deduplication uses the same id check as _onIncomingMessage so the
         // invariant is identical in both paths.
         for (final msg in msgs) {
+          // This room is the buyer<->seller conversation only: solver
+          // messages from a dispute share the order key in the store but
+          // must never surface here — replying would go to the counterparty,
+          // not the solver (PR #254 review).
+          if (msg.messageType != rust_types.MessageType.peer) continue;
           if (!_messages.any((m) => m.id == msg.id)) {
             _messages.add(msg);
           }
@@ -142,6 +147,9 @@ class _ChatRoomScreenState extends ConsumerState<ChatRoomScreen> {
   // ── Incoming stream ───────────────────────────────────────────────────────
 
   void _onIncomingMessage(rust_types.ChatMessage msg) {
+    // Dispute-channel traffic never belongs in the peer room (see
+    // _loadHistory).
+    if (msg.messageType != rust_types.MessageType.peer) return;
     if (_messages.any((m) => m.id == msg.id)) return; // deduplicate
     setState(() => _messages.add(msg));
     _scrollToBottom();

--- a/rust/src/api/disputes.rs
+++ b/rust/src/api/disputes.rs
@@ -203,29 +203,22 @@ pub async fn submit_evidence(trade_id: String, text: String) -> Result<()> {
         .await
         .ok_or_else(|| anyhow!("TradeNotFound: no trade key for {trade_id}"))?;
 
-    let sender_keys = crate::api::identity::get_active_trade_keys(trade_index).await?;
+    // Same envelope as the peer chat, keyed to the solver instead of the
+    // counterparty: inner kind 1 signed by our trade key, NIP-44 under K_conv,
+    // inside a kind 14 signed with K_sign and p-tagged to pub(K_conv). No gift
+    // wrap and no ephemeral key — see
+    // <https://mostro.network/protocol/dispute_chat.html>.
+    //
+    // The text travels as the message itself rather than a hand-rolled
+    // {"type":"evidence"} JSON: this is a conversation with the solver, and
+    // that shape had no reader on the other side of the envelope.
+    let ctx = crate::api::messages::admin_chat_context(trade_index, &admin_pubkey).await?;
+    let inner = crate::api::messages::publish_chat_payload_for(&ctx, &text).await?;
 
-    // Build the evidence payload.
-    let payload = serde_json::json!({
-        "type": "evidence",
-        "trade_id": trade_id,
-        "text": text,
-    })
-    .to_string();
-
-    // Wrap and send as NIP-59 Kind-14 DM to the admin.
-    let event_json = crate::nostr::gift_wrap::wrap(
-        &sender_keys,
-        &admin_pubkey,
-        &payload,
-        nostr_sdk::Kind::from(14u16),
-    )
-    .await
-    .map_err(|e| anyhow!("gift wrap failed: {e}"))?;
-
-    crate::api::orders::publish_event(&event_json)
-        .await
-        .map_err(|e| anyhow!("publish failed: {e}"))?;
+    // Record it locally so the dispute conversation has history, exactly as a
+    // peer message does. Keyed by the inner event id, so our own echo arriving
+    // from a relay dedups against this record instead of duplicating it.
+    crate::api::messages::store_outgoing_admin_message(&trade_id, &ctx, &text, &inner).await;
 
     log::info!("[disputes] evidence submitted for trade={trade_id}");
     Ok(())
@@ -286,36 +279,47 @@ pub async fn handle_admin_took_dispute(trade_id: String, admin_pubkey: String) -
     derive_admin_shared_key(&trade_id, &admin_pubkey_for_key).await
 }
 
-/// Derive the admin shared key for `trade_id` and store it in the session.
+/// Derive the dispute-chat keys for `trade_id` and start listening.
 ///
-/// This key allows the user to decrypt admin messages in the dispute chat (the
-/// admin encrypts to the trade pubkey, not the identity key).
+/// Both sides ECDH their trade key against the solver's pubkey and split the
+/// secret with HKDF exactly as the peer chat does, so `derive_chat_keys` is
+/// reused unchanged — the only difference is whose pubkey goes in
+/// (<https://mostro.network/protocol/dispute_chat.html>).
 ///
-/// Best-effort: if no trade key or session exists this logs a warning but does
-/// not fail — the dispute record has already been updated, and losing the
-/// derivation must not lose the admin pubkey with it.
+/// Best-effort: if no trade key exists yet this logs a warning but does not
+/// fail. The dispute record and the solver pubkey are already stored, so a
+/// later reconnect can start the listener; losing the derivation must not lose
+/// the pubkey with it.
 async fn derive_admin_shared_key(trade_id: &str, admin_pubkey_hex: &str) -> Result<()> {
     let trade_id = trade_id.to_string();
-    let admin_pubkey_for_key = admin_pubkey_hex.to_string();
+    let admin_pubkey_hex = admin_pubkey_hex.to_string();
 
-    let derive_result: Result<()> = async {
+    let start_result: Result<()> = async {
         let trade_index = crate::api::orders::trade_key_for_order(&trade_id)
             .await
             .ok_or_else(|| anyhow!("no trade key for trade {trade_id}"))?;
         let trade_keys = crate::api::identity::get_active_trade_keys(trade_index).await?;
-        let admin_pk = nostr_sdk::PublicKey::from_hex(&admin_pubkey_for_key)
+        let admin_pk = nostr_sdk::PublicKey::from_hex(&admin_pubkey_hex)
             .map_err(|e| anyhow!("invalid admin pubkey: {e}"))?;
-        let shared_key = crate::crypto::ecdh::derive_nip04_shared_key(&trade_keys, &admin_pk)?;
-        crate::mostro::session::session_manager()
-            .set_admin_shared_key(&trade_id, shared_key)
-            .await?;
-        log::info!("[disputes] adminSharedKey derived for trade={trade_id}");
+        let (conv, sign) = crate::crypto::chat_keys::derive_chat_keys(&trade_keys, &admin_pk)?;
+
+        // Own task, like the peer chat: the guard inside is keyed per channel,
+        // so this never collides with the peer conversation of the same order.
+        crate::rt::spawn(crate::api::messages::subscribe_incoming_chat(
+            crate::api::messages::ChatChannel::Dispute,
+            trade_id.clone(),
+            trade_keys,
+            admin_pk,
+            conv,
+            sign,
+        ));
+        log::info!("[disputes] dispute chat listening for trade={trade_id}");
         Ok(())
     }
     .await;
 
-    if let Err(e) = derive_result {
-        log::warn!("[disputes] could not derive adminSharedKey for trade={trade_id}: {e}");
+    if let Err(e) = start_result {
+        log::warn!("[disputes] could not start dispute chat for trade={trade_id}: {e}");
     }
 
     Ok(())

--- a/rust/src/api/disputes.rs
+++ b/rust/src/api/disputes.rs
@@ -47,6 +47,10 @@ impl DisputeStore {
         self.disputes.read().await.get(trade_id).cloned()
     }
 
+    async fn all(&self) -> Vec<Dispute> {
+        self.disputes.read().await.values().cloned().collect()
+    }
+
     /// Atomically update a dispute under the write lock.
     ///
     /// `f` receives a mutable reference to the dispute and should return
@@ -215,6 +219,40 @@ pub async fn submit_evidence(trade_id: String, text: String) -> Result<()> {
     let ctx = crate::api::messages::admin_chat_context(trade_index, &admin_pubkey).await?;
     let inner = crate::api::messages::publish_chat_payload_for(&ctx, &text).await?;
 
+    // Interop dual-write (PR #254 review): the current solver client
+    // (mostrix) still reads only NIP-59 gift wrap — its envelope migration is
+    // tracked in mostrix#102. Until the deprecation date the evidence also
+    // goes out in the pre-migration shape it understands, gift-wrapped
+    // straight to the solver. Best-effort: the envelope copy above is the
+    // durable one, and this copy disappears with the dual-read window.
+    if crate::rt::unix_now() < crate::api::messages::LEGACY_CHAT_DEPRECATION_TS {
+        let legacy_send: Result<()> = async {
+            let sender_keys = crate::api::identity::get_active_trade_keys(trade_index).await?;
+            let payload = serde_json::json!({
+                "type": "evidence",
+                "trade_id": trade_id,
+                "text": text,
+            })
+            .to_string();
+            let event_json = crate::nostr::gift_wrap::wrap(
+                &sender_keys,
+                &admin_pubkey,
+                &payload,
+                nostr_sdk::Kind::from(14u16),
+            )
+            .await
+            .map_err(|e| anyhow!("legacy wrap failed: {e}"))?;
+            crate::api::orders::publish_event(&event_json)
+                .await
+                .map_err(|e| anyhow!("legacy publish failed: {e}"))?;
+            Ok(())
+        }
+        .await;
+        if let Err(e) = legacy_send {
+            log::warn!("[disputes] legacy evidence copy not sent trade={trade_id}: {e}");
+        }
+    }
+
     // Record it locally so the dispute conversation has history, exactly as a
     // peer message does. Keyed by the inner event id, so our own echo arriving
     // from a relay dedups against this record instead of duplicating it.
@@ -263,6 +301,17 @@ pub async fn handle_admin_took_dispute(trade_id: String, admin_pubkey: String) -
 
     dispute_store()
         .update_conditional(&trade_id, move |dispute| {
+            // Idempotent same-solver replay (PR #254 review): the record is
+            // committed InReview before key derivation and listener startup,
+            // both of which can fail transiently (keys not hydrated yet,
+            // relay pool offline). A replayed assignment for the SAME solver
+            // is the retry path for exactly that window, so it must fall
+            // through to re-derive and re-arm instead of being rejected.
+            if dispute.status == DisputeStatus::InReview
+                && dispute.admin_pubkey.as_deref() == Some(admin_pubkey.as_str())
+            {
+                return Ok(());
+            }
             if dispute.status != DisputeStatus::Open {
                 return Err(anyhow!(
                     "InvalidState: dispute is not open (current: {:?})",
@@ -323,6 +372,26 @@ async fn derive_admin_shared_key(trade_id: &str, admin_pubkey_hex: &str) -> Resu
     }
 
     Ok(())
+}
+
+/// Re-arm the dispute-chat listener of every in-review dispute with a known
+/// solver. Called when the relay pool comes (back) online, mirroring
+/// `resubscribe_active_chats` for the peer channel (PR #254 review): listener
+/// startup is best-effort at assignment time and can fail while keys or
+/// connectivity are not there yet, and without a rearm path solver replies
+/// would stay invisible for the rest of the process. Idempotent — the
+/// per-channel single-owner guard makes a spawn for an already-listening
+/// dispute a no-op.
+pub(crate) async fn resubscribe_active_dispute_chats() {
+    for dispute in dispute_store().all().await {
+        if dispute.status != DisputeStatus::InReview {
+            continue;
+        }
+        let Some(admin) = dispute.admin_pubkey.clone() else {
+            continue;
+        };
+        let _ = derive_admin_shared_key(&dispute.trade_id, &admin).await;
+    }
 }
 
 /// Handle an incoming `adminSettled` event (admin resolved in buyer's favour).
@@ -459,6 +528,29 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.to_string().contains("DisputeAlreadyOpen"));
+    }
+
+    /// PR #254 review (ermeme): the record commits InReview before key
+    /// derivation and listener startup, which can fail transiently. A
+    /// replayed assignment for the same solver is the retry path and must
+    /// succeed instead of being rejected as InvalidState.
+    #[tokio::test]
+    async fn a_same_solver_assignment_replay_is_idempotent() {
+        let trade_id = format!("t-{}", uuid::Uuid::new_v4());
+        let admin_pk = "0000000000000000000000000000000000000000000000000000000000000005";
+        seed_dispute(&trade_id, None).await;
+
+        handle_admin_took_dispute(trade_id.clone(), admin_pk.to_string())
+            .await
+            .unwrap();
+        // The replay (daemon resend / reconnect backfill) must be accepted.
+        handle_admin_took_dispute(trade_id.clone(), admin_pk.to_string())
+            .await
+            .expect("same-solver replay must be an idempotent retry");
+
+        let d = get_dispute(trade_id).await.unwrap().unwrap();
+        assert_eq!(d.status, DisputeStatus::InReview);
+        assert_eq!(d.admin_pubkey.as_deref(), Some(admin_pk));
     }
 
     #[tokio::test]

--- a/rust/src/api/messages.rs
+++ b/rust/src/api/messages.rs
@@ -228,7 +228,7 @@ fn message_store() -> &'static MessageStore {
 // ── Public API ────────────────────────────────────────────────────────────────
 
 /// The chat-key material for one conversation, derived from the session.
-struct ChatContext {
+pub(crate) struct ChatContext {
     trade_keys: nostr_sdk::Keys,
     /// `K_conv` — NIP-44 encryption; `pub(K_conv)` is the `p` tag.
     conv: nostr_sdk::Keys,
@@ -258,6 +258,49 @@ async fn chat_context(trade_key_index: u32, peer_hex: &str) -> Result<ChatContex
 ///
 /// Returns the signed inner event on success — its id and timestamp are the
 /// message's durable identity (shared with the recipient's replay dedup).
+/// [`chat_context`] for the dispute channel: the shared secret is with the
+/// solver's pubkey from `admin-took-dispute` instead of the counterparty's
+/// trade key. Derivation is identical — that is what the spec prescribes.
+pub(crate) async fn admin_chat_context(
+    trade_key_index: u32,
+    admin_pubkey: &nostr_sdk::PublicKey,
+) -> Result<ChatContext> {
+    chat_context(trade_key_index, &admin_pubkey.to_hex()).await
+}
+
+/// Publish over an already-built context. Exposed for the dispute channel,
+/// which owns its own send path but must not reimplement the envelope.
+pub(crate) async fn publish_chat_payload_for(
+    ctx: &ChatContext,
+    payload: &str,
+) -> Result<nostr_sdk::Event> {
+    publish_chat_payload(ctx, payload).await
+}
+
+/// Record a message we just sent to the solver, mirroring what `send_message`
+/// stores for the peer chat: identified by the inner event id so the relay
+/// echo dedups against it, and never unread (we wrote it).
+pub(crate) async fn store_outgoing_admin_message(
+    trade_id: &str,
+    ctx: &ChatContext,
+    content: &str,
+    inner: &nostr_sdk::Event,
+) {
+    let msg = ChatMessage {
+        id: inner.id.to_hex(),
+        trade_id: trade_id.to_string(),
+        sender_pubkey: ctx.trade_keys.public_key().to_hex(),
+        content: content.to_string(),
+        message_type: MessageType::Admin,
+        is_mine: true,
+        is_read: true,
+        has_attachment: false,
+        attachment: None,
+        created_at: inner.created_at.as_secs() as i64,
+    };
+    let _ = message_store().add_message(msg).await;
+}
+
 async fn publish_chat_payload(ctx: &ChatContext, payload: &str) -> Result<nostr_sdk::Event> {
     let (outer, inner) =
         crate::nostr::gift_wrap::mostro_wrap(&ctx.trade_keys, &ctx.conv, &ctx.sign, payload)
@@ -785,8 +828,53 @@ const LEGACY_CHAT_DEPRECATION_TS: i64 = 1_798_675_200;
 /// Subscription id for the chat envelope of one order — explicit so every
 /// exit path can unsubscribe and a lingering relay subscription never
 /// outlives its task.
-fn chat_subscription_id(order_id: &str) -> nostr_sdk::SubscriptionId {
-    nostr_sdk::SubscriptionId::new(format!("mostro-chat-{order_id}"))
+fn chat_subscription_id(channel: ChatChannel, order_id: &str) -> nostr_sdk::SubscriptionId {
+    nostr_sdk::SubscriptionId::new(format!("mostro-chat-{}{order_id}", channel.id_prefix()))
+}
+
+/// Which conversation an envelope subscription serves.
+///
+/// Both use the identical envelope and key derivation — the difference is who
+/// the shared secret is with, and therefore which key pair `derive_chat_keys`
+/// produces (<https://mostro.network/protocol/dispute_chat.html>).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum ChatChannel {
+    /// Buyer ↔ seller, keyed to the counterparty's trade key.
+    Peer,
+    /// Party ↔ solver, keyed to the admin pubkey from `admin-took-dispute`.
+    /// Each party has its own independent conversation with the admin.
+    Dispute,
+}
+
+impl ChatChannel {
+    /// Distinguishes the two conversations of one order everywhere they are
+    /// tracked by id: subscription ids and the single-owner guard. Without it
+    /// a dispute chat would be mistaken for the peer chat already running for
+    /// that order and silently never start.
+    fn id_prefix(self) -> &'static str {
+        match self {
+            ChatChannel::Peer => "",
+            ChatChannel::Dispute => "dispute-",
+        }
+    }
+
+    fn guard_key(self, order_id: &str) -> String {
+        format!("{}{order_id}", self.id_prefix())
+    }
+
+    fn message_type(self) -> MessageType {
+        match self {
+            ChatChannel::Peer => MessageType::Peer,
+            ChatChannel::Dispute => MessageType::Admin,
+        }
+    }
+
+    /// Whether to also read the pre-migration gift-wrap form. Only the peer
+    /// chat ever had one; the dispute chat moves to the envelope directly, so
+    /// it never subscribes to kind 1059.
+    fn reads_legacy_gift_wrap(self) -> bool {
+        matches!(self, ChatChannel::Peer)
+    }
 }
 
 /// Subscription id for the legacy gift-wrap dual-read of one order.
@@ -947,6 +1035,7 @@ fn parse_chat_payload(payload: &str) -> (String, Option<AttachmentInfo>) {
 /// only ever drops chat events; it cannot touch the order state machine, the
 /// daemon transport, or dispute flows.
 pub(crate) async fn subscribe_incoming_chat(
+    channel: ChatChannel,
     order_id: String,
     trade_keys: nostr_sdk::Keys,
     peer_pubkey: nostr_sdk::PublicKey,
@@ -956,20 +1045,22 @@ pub(crate) async fn subscribe_incoming_chat(
     // Single-owner guard: a second spawn for the same order is a no-op.
     {
         let mut active = active_chats().lock().await;
-        if !active.insert(order_id.clone()) {
+        if !active.insert(channel.guard_key(&order_id)) {
             log::debug!("[messages] chat task already active order={order_id}");
             return;
         }
     }
 
-    run_chat_subscription(&order_id, &trade_keys, &peer_pubkey, &conv, &sign).await;
+    run_chat_subscription(channel, &order_id, &trade_keys, &peer_pubkey, &conv, &sign).await;
 
     // Cleanup on every exit path: release ownership and drop the relay
     // subscriptions so they never outlive the task.
-    active_chats().lock().await.remove(&order_id);
+    active_chats().lock().await.remove(&channel.guard_key(&order_id));
     if let Ok(pool) = crate::api::nostr::get_pool() {
         let client = pool.client();
-        client.unsubscribe(&chat_subscription_id(&order_id)).await;
+        client
+            .unsubscribe(&chat_subscription_id(channel, &order_id))
+            .await;
         client
             .unsubscribe(&legacy_chat_subscription_id(&order_id))
             .await;
@@ -1046,6 +1137,7 @@ impl ChatRxState {
 }
 
 async fn run_chat_subscription(
+    channel: ChatChannel,
     order_id: &str,
     trade_keys: &nostr_sdk::Keys,
     peer_pubkey: &nostr_sdk::PublicKey,
@@ -1068,8 +1160,9 @@ async fn run_chat_subscription(
     // `since` from the persisted cursor: everything older is already stored
     // locally (the cursor only advances on durably stored messages).
     let cursor = load_chat_cursor(order_id).await.unwrap_or(0);
-    let sub_id = chat_subscription_id(order_id);
+    let sub_id = chat_subscription_id(channel, order_id);
     let legacy_sub_id = legacy_chat_subscription_id(order_id);
+    let reads_legacy = channel.reads_legacy_gift_wrap();
 
     let mut filter = nostr_sdk::Filter::new()
         .kind(nostr_sdk::Kind::PrivateDirectMessage)
@@ -1092,7 +1185,7 @@ async fn run_chat_subscription(
     // Dual-read window: also accept the superseded gift-wrap envelope from
     // pre-migration peers, read-only, until the deprecation date. The legacy
     // address is the old NIP-04-style shared pubkey.
-    let legacy_shared: Option<nostr_sdk::Keys> = if unix_now() < LEGACY_CHAT_DEPRECATION_TS {
+    let legacy_shared: Option<nostr_sdk::Keys> = if reads_legacy && unix_now() < LEGACY_CHAT_DEPRECATION_TS {
         // The legacy address doubles as the decryption key: v1 gift-wraps to
         // the NIP-04-style shared pubkey, so the receiver must unwrap with
         // the shared SECRET as its keypair.
@@ -1142,7 +1235,7 @@ async fn run_chat_subscription(
                 ..
             }) => {
                 if subscription_id == sub_id {
-                    handle_chat_event(order_id, &allowed_signers, conv, &sign_pubkey, &my_trade_pubkey, &event, &mut state)
+                    handle_chat_event(channel, order_id, &allowed_signers, conv, &sign_pubkey, &my_trade_pubkey, &event, &mut state)
                         .await;
                 } else if subscription_id == legacy_sub_id {
                     if let Some(shared) = &legacy_shared {
@@ -1184,7 +1277,12 @@ async fn run_chat_subscription(
 
 /// Validate and store one incoming chat-envelope event (see
 /// `subscribe_incoming_chat` for the pipeline description).
+// One more argument than clippy's default: the channel joins parameters this
+// function already threaded, and bundling them into a struct would just move
+// the same values behind a name that adds nothing.
+#[allow(clippy::too_many_arguments)]
 async fn handle_chat_event(
+    channel: ChatChannel,
     order_id: &str,
     allowed_signers: &[nostr_sdk::PublicKey],
     conv: &nostr_sdk::Keys,
@@ -1269,7 +1367,7 @@ async fn handle_chat_event(
         trade_id: order_id.to_string(),
         sender_pubkey: inner.pubkey.to_hex(),
         content,
-        message_type: MessageType::Peer,
+        message_type: channel.message_type(),
         is_mine: is_echo,
         is_read: is_echo,
         has_attachment: attachment.is_some(),
@@ -1453,7 +1551,7 @@ pub(crate) async fn resubscribe_active_chats() {
         };
         log::info!("[messages] resubscribing chat order={order_id}");
         crate::rt::spawn(subscribe_incoming_chat(
-            order_id, trade_keys, peer, conv, sign,
+            ChatChannel::Peer, order_id, trade_keys, peer, conv, sign,
         ));
     }
 }
@@ -1480,6 +1578,47 @@ fn chat_still_relevant(trade: &crate::api::types::TradeInfo) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn the_two_channels_of_one_order_never_collide() {
+        let order = "order-1";
+
+        // Same order, different conversations: the single-owner guard and the
+        // relay subscription id must tell them apart, or starting the dispute
+        // chat would be a no-op because the peer chat already "owns" the order.
+        assert_ne!(
+            ChatChannel::Peer.guard_key(order),
+            ChatChannel::Dispute.guard_key(order)
+        );
+        assert_ne!(
+            chat_subscription_id(ChatChannel::Peer, order),
+            chat_subscription_id(ChatChannel::Dispute, order)
+        );
+    }
+
+    #[test]
+    fn the_peer_channel_keeps_its_wire_identity() {
+        // The peer subscription id is unchanged by the channel refactor: a
+        // different string would orphan subscriptions across an app upgrade.
+        assert_eq!(
+            chat_subscription_id(ChatChannel::Peer, "order-1"),
+            nostr_sdk::SubscriptionId::new("mostro-chat-order-1")
+        );
+    }
+
+    #[test]
+    fn only_the_peer_channel_reads_the_legacy_gift_wrap() {
+        // The dispute chat migrates straight to the envelope, so it has no
+        // pre-migration form to dual-read and never subscribes to kind 1059.
+        assert!(ChatChannel::Peer.reads_legacy_gift_wrap());
+        assert!(!ChatChannel::Dispute.reads_legacy_gift_wrap());
+    }
+
+    #[test]
+    fn each_channel_stores_its_own_message_type() {
+        assert_eq!(ChatChannel::Peer.message_type(), MessageType::Peer);
+        assert_eq!(ChatChannel::Dispute.message_type(), MessageType::Admin);
+    }
 
     #[tokio::test]
     async fn send_and_get_messages() {

--- a/rust/src/api/messages.rs
+++ b/rust/src/api/messages.rs
@@ -60,6 +60,11 @@ struct MessageStore {
     unread_tx: broadcast::Sender<u32>,
     /// Broadcast channel for attachment progress (payload = (message_id, progress 0.0–1.0)).
     attachment_tx: broadcast::Sender<(String, f64)>,
+    /// Ids present in memory whose DB write failed — known for replay dedup,
+    /// but NOT durable: the `since` cursor must never advance past them, or
+    /// a restart loses the message with no relay copy left to refetch
+    /// (PR #254 review).
+    non_durable: Arc<RwLock<std::collections::HashSet<String>>>,
 }
 
 impl MessageStore {
@@ -69,6 +74,7 @@ impl MessageStore {
         let (attachment_tx, _) = broadcast::channel(64);
         Self {
             messages: Arc::new(RwLock::new(HashMap::new())),
+            non_durable: Arc::new(RwLock::new(std::collections::HashSet::new())),
             hydrated: Arc::new(RwLock::new(std::collections::HashSet::new())),
             new_message_tx,
             unread_tx,
@@ -134,6 +140,13 @@ impl MessageStore {
             },
             None => true,
         };
+        // Keep memory-only ids distinct from durably committed ones — the
+        // receive path consults this before advancing the cursor.
+        if stored {
+            self.non_durable.write().await.remove(&msg.id);
+        } else {
+            self.non_durable.write().await.insert(msg.id.clone());
+        }
         let _ = self.new_message_tx.send(msg.clone());
         let unread = self.unread_count_inner().await;
         let _ = self.unread_tx.send(unread);
@@ -161,6 +174,35 @@ impl MessageStore {
                 .await
                 .map_err(|e| anyhow!("dedup lookup failed: {e}")),
             None => Ok(false),
+        }
+    }
+
+    /// `true` when the already-known `id` is durably stored, retrying the DB
+    /// write for a memory-only copy first. Callers gate cursor advancement on
+    /// this: an id whose write failed must keep the cursor put so the relay
+    /// copy is refetched after a restart (PR #254 review).
+    async fn ensure_durable(&self, trade_id: &str, id: &str) -> bool {
+        if !self.non_durable.read().await.contains(id) {
+            return true;
+        }
+        let copy = {
+            let store = self.messages.read().await;
+            store
+                .get(trade_id)
+                .and_then(|msgs| msgs.iter().find(|m| m.id == id).cloned())
+        };
+        let (Some(db), Some(msg)) = (crate::db::app_db::db(), copy) else {
+            return false;
+        };
+        match db.save_message(&msg).await {
+            Ok(()) => {
+                self.non_durable.write().await.remove(id);
+                true
+            }
+            Err(e) => {
+                log::warn!("[messages] persist retry failed id={id}: {e}");
+                false
+            }
         }
     }
 
@@ -823,7 +865,7 @@ const MAX_STORED_BYTES_PER_TRADE: usize = 5 * 1024 * 1024;
 /// the new envelope. After the deadline the legacy subscription is simply
 /// not created. Trades in flight at the cutover keep working: the legacy
 /// path only reads, never writes.
-const LEGACY_CHAT_DEPRECATION_TS: i64 = 1_798_675_200;
+pub(crate) const LEGACY_CHAT_DEPRECATION_TS: i64 = 1_798_675_200;
 
 /// Subscription id for the chat envelope of one order — explicit so every
 /// exit path can unsubscribe and a lingering relay subscription never
@@ -869,17 +911,38 @@ impl ChatChannel {
         }
     }
 
-    /// Whether to also read the pre-migration gift-wrap form. Only the peer
-    /// chat ever had one; the dispute chat moves to the envelope directly, so
-    /// it never subscribes to kind 1059.
+    /// Durable `since`-cursor key for this channel of `order_id`.
+    ///
+    /// Channel-scoped (PR #254 review): the peer and dispute subscriptions
+    /// are independent event streams, and a shared cursor would let either
+    /// advance past backlog the other has not seen — e.g. a solver with a
+    /// slightly slower clock dating a reply before the peer cursor, which
+    /// the dispute filter would then never fetch. The peer key keeps its
+    /// historical shape so existing installs do not refetch their backlog.
+    fn cursor_key(self, order_id: &str) -> String {
+        crate::db::settings_keys::chat_cursor(&format!("{}{order_id}", self.id_prefix()))
+    }
+
+    /// Whether to also read the pre-migration gift-wrap form until
+    /// [`LEGACY_CHAT_DEPRECATION_TS`]. Both channels do: the peer chat for
+    /// pre-migration counterparties (#246), and the dispute chat because the
+    /// current solver client still speaks only gift wrap
+    /// (mostrix#102 tracks its migration) — without the dual-read its
+    /// replies would be invisible (PR #254 review).
     fn reads_legacy_gift_wrap(self) -> bool {
-        matches!(self, ChatChannel::Peer)
+        true
     }
 }
 
-/// Subscription id for the legacy gift-wrap dual-read of one order.
-fn legacy_chat_subscription_id(order_id: &str) -> nostr_sdk::SubscriptionId {
-    nostr_sdk::SubscriptionId::new(format!("mostro-chat-legacy-{order_id}"))
+/// Subscription id for the legacy gift-wrap dual-read of one channel of one
+/// order. Channel-scoped like the primary id: each task owns and cleans up
+/// exactly its own subscriptions, so a dispute listener exiting can never
+/// tear down the peer task's live legacy delivery (PR #254 review).
+fn legacy_chat_subscription_id(channel: ChatChannel, order_id: &str) -> nostr_sdk::SubscriptionId {
+    nostr_sdk::SubscriptionId::new(format!(
+        "mostro-chat-legacy-{}{order_id}",
+        channel.id_prefix()
+    ))
 }
 
 /// Orders with a live chat task. Single-owner guard: `on_peer_pubkey_received`
@@ -952,10 +1015,10 @@ impl TokenBucket {
     }
 }
 
-/// Read the persisted `since` cursor for `order_id`, if any.
-async fn load_chat_cursor(order_id: &str) -> Option<i64> {
+/// Read the persisted `since` cursor for one channel of `order_id`, if any.
+async fn load_chat_cursor(channel: ChatChannel, order_id: &str) -> Option<i64> {
     let db = crate::db::app_db::db()?;
-    db.get_setting(&crate::db::settings_keys::chat_cursor(order_id))
+    db.get_setting(&channel.cursor_key(order_id))
         .await
         .ok()
         .flatten()?
@@ -965,9 +1028,9 @@ async fn load_chat_cursor(order_id: &str) -> Option<i64> {
 
 /// Persist the `since` cursor. Best-effort: on web this is a no-op until
 /// IndexedDB lands (#233), so the backlog bound degrades to per-process.
-async fn store_chat_cursor(order_id: &str, ts: i64) {
+async fn store_chat_cursor(channel: ChatChannel, order_id: &str, ts: i64) {
     if let Some(db) = crate::db::app_db::db() {
-        let key = crate::db::settings_keys::chat_cursor(order_id);
+        let key = channel.cursor_key(order_id);
         if let Err(e) = db.set_setting(&key, &ts.to_string()).await {
             log::warn!("[messages] cursor persist failed order={order_id}: {e}");
         }
@@ -1062,7 +1125,7 @@ pub(crate) async fn subscribe_incoming_chat(
             .unsubscribe(&chat_subscription_id(channel, &order_id))
             .await;
         client
-            .unsubscribe(&legacy_chat_subscription_id(&order_id))
+            .unsubscribe(&legacy_chat_subscription_id(channel, &order_id))
             .await;
     }
     log::debug!("[messages] incoming-chat subscription exiting order={order_id}");
@@ -1070,6 +1133,7 @@ pub(crate) async fn subscribe_incoming_chat(
 
 /// Mutable per-conversation receive state (see `subscribe_incoming_chat`).
 struct ChatRxState {
+    channel: ChatChannel,
     outer_seen: BoundedIdSet,
     bucket: TokenBucket,
     consecutive_rejected: u32,
@@ -1082,8 +1146,9 @@ struct ChatRxState {
 }
 
 impl ChatRxState {
-    fn new(cursor: i64) -> Self {
+    fn new(channel: ChatChannel, cursor: i64) -> Self {
         Self {
+            channel,
             outer_seen: BoundedIdSet::new(OUTER_LRU_CAP),
             bucket: TokenBucket::new(crate::rt::time::Instant::now()),
             consecutive_rejected: 0,
@@ -1131,7 +1196,7 @@ impl ChatRxState {
         let accepted = event_ts.min(unix_now());
         if accepted > self.cursor {
             self.cursor = accepted;
-            store_chat_cursor(order_id, accepted).await;
+            store_chat_cursor(self.channel, order_id, accepted).await;
         }
     }
 }
@@ -1159,9 +1224,9 @@ async fn run_chat_subscription(
 
     // `since` from the persisted cursor: everything older is already stored
     // locally (the cursor only advances on durably stored messages).
-    let cursor = load_chat_cursor(order_id).await.unwrap_or(0);
+    let cursor = load_chat_cursor(channel, order_id).await.unwrap_or(0);
     let sub_id = chat_subscription_id(channel, order_id);
-    let legacy_sub_id = legacy_chat_subscription_id(order_id);
+    let legacy_sub_id = legacy_chat_subscription_id(channel, order_id);
     let reads_legacy = channel.reads_legacy_gift_wrap();
 
     let mut filter = nostr_sdk::Filter::new()
@@ -1186,13 +1251,18 @@ async fn run_chat_subscription(
     // pre-migration peers, read-only, until the deprecation date. The legacy
     // address is the old NIP-04-style shared pubkey.
     let legacy_shared: Option<nostr_sdk::Keys> = if reads_legacy && unix_now() < LEGACY_CHAT_DEPRECATION_TS {
-        // The legacy address doubles as the decryption key: v1 gift-wraps to
-        // the NIP-04-style shared pubkey, so the receiver must unwrap with
-        // the shared SECRET as its keypair.
-        let keys = crate::crypto::ecdh::derive_nip04_shared_key(trade_keys, peer_pubkey)
-            .ok()
-            .and_then(|raw| nostr_sdk::SecretKey::from_slice(&raw).ok())
-            .map(nostr_sdk::Keys::new);
+        // The legacy address doubles as the decryption key. For the peer
+        // chat, v1 gift-wraps to the NIP-04-style shared pubkey, so the
+        // receiver unwraps with the shared SECRET as its keypair. For the
+        // dispute chat, the pre-migration solver (mostrix) gift-wraps
+        // straight to the trade pubkey, so the trade keys unwrap it.
+        let keys = match channel {
+            ChatChannel::Peer => crate::crypto::ecdh::derive_nip04_shared_key(trade_keys, peer_pubkey)
+                .ok()
+                .and_then(|raw| nostr_sdk::SecretKey::from_slice(&raw).ok())
+                .map(nostr_sdk::Keys::new),
+            ChatChannel::Dispute => Some(trade_keys.clone()),
+        };
         match keys {
             None => {
                 log::warn!("[messages] legacy shared key derivation failed order={order_id}");
@@ -1225,7 +1295,7 @@ async fn run_chat_subscription(
         legacy_shared.is_some(),
     );
 
-    let mut state = ChatRxState::new(cursor);
+    let mut state = ChatRxState::new(channel, cursor);
 
     loop {
         match rx.recv().await {
@@ -1240,6 +1310,7 @@ async fn run_chat_subscription(
                 } else if subscription_id == legacy_sub_id {
                     if let Some(shared) = &legacy_shared {
                         handle_legacy_chat_event(
+                            channel,
                             order_id,
                             shared,
                             &my_trade_pubkey,
@@ -1337,11 +1408,16 @@ async fn handle_chat_event(
             return;
         }
         Ok(true) => {
-            // Already durably stored (an echo of our own send, or a replay).
+            // An echo of our own send, or a replay. Only advance the cursor
+            // if the known copy really is durable — a memory-only record
+            // (its DB write failed) gets one retry here, and failing that
+            // the cursor stays put so the relay copy survives a restart.
             log::debug!("[messages] incoming-chat duplicate inner id={inner_id}");
-            state
-                .advance_cursor(order_id, event.created_at.as_secs() as i64)
-                .await;
+            if message_store().ensure_durable(order_id, &inner_id).await {
+                state
+                    .advance_cursor(order_id, event.created_at.as_secs() as i64)
+                    .await;
+            }
             return;
         }
         Ok(false) => {}
@@ -1395,6 +1471,7 @@ async fn handle_chat_event(
 /// pre-migration counterparty is not cut off mid-trade, and disappears at
 /// [`LEGACY_CHAT_DEPRECATION_TS`].
 async fn handle_legacy_chat_event(
+    channel: ChatChannel,
     order_id: &str,
     legacy_shared: &nostr_sdk::Keys,
     my_trade_pubkey: &nostr_sdk::PublicKey,
@@ -1505,7 +1582,7 @@ async fn handle_legacy_chat_event(
         trade_id: order_id.to_string(),
         sender_pubkey: sender_hex.to_string(),
         content,
-        message_type: MessageType::Peer,
+        message_type: channel.message_type(),
         is_mine: is_echo,
         is_read: is_echo,
         has_attachment: attachment.is_some(),
@@ -1610,8 +1687,34 @@ mod tests {
     fn only_the_peer_channel_reads_the_legacy_gift_wrap() {
         // The dispute chat migrates straight to the envelope, so it has no
         // pre-migration form to dual-read and never subscribes to kind 1059.
+        // Both channels dual-read until the deprecation date: the peer chat
+        // for pre-migration counterparties, the dispute chat because the
+        // current solver client (mostrix#102) still writes only gift wrap.
         assert!(ChatChannel::Peer.reads_legacy_gift_wrap());
-        assert!(!ChatChannel::Dispute.reads_legacy_gift_wrap());
+        assert!(ChatChannel::Dispute.reads_legacy_gift_wrap());
+    }
+
+    /// PR #254 review: the peer and dispute streams are independent, so each
+    /// channel owns its own durable cursor (peer keeps the historical key so
+    /// existing installs do not refetch) and its own subscription ids.
+    #[test]
+    fn cursors_and_subscription_ids_are_channel_scoped() {
+        assert_eq!(
+            ChatChannel::Peer.cursor_key("o1"),
+            crate::db::settings_keys::chat_cursor("o1"),
+        );
+        assert_eq!(
+            ChatChannel::Dispute.cursor_key("o1"),
+            crate::db::settings_keys::chat_cursor("dispute-o1"),
+        );
+        assert_ne!(
+            ChatChannel::Peer.cursor_key("o1"),
+            ChatChannel::Dispute.cursor_key("o1"),
+        );
+        assert_ne!(
+            legacy_chat_subscription_id(ChatChannel::Peer, "o1"),
+            legacy_chat_subscription_id(ChatChannel::Dispute, "o1"),
+        );
     }
 
     #[test]
@@ -1894,7 +1997,7 @@ mod tests {
         // Pre-EOSE (catch-up): a backlog far above the burst size is all
         // accepted — dropping stored history would lose it permanently
         // because the cursor advances past it.
-        let mut state = ChatRxState::new(0);
+        let mut state = ChatRxState::new(ChatChannel::Peer, 0);
         assert!(!state.live);
         for _ in 0..(RATE_CAPACITY as u32 * 5) {
             assert!(state.budget_ok("order-x"));
@@ -1971,8 +2074,9 @@ mod tests {
         let event: Event = serde_json::from_str(&event_json).unwrap();
 
         let order_id = uuid::Uuid::new_v4().to_string();
-        let mut state = ChatRxState::new(0);
+        let mut state = ChatRxState::new(ChatChannel::Peer, 0);
         handle_legacy_chat_event(
+            ChatChannel::Peer,
             &order_id,
             &shared_keys,
             &my_keys.public_key(),
@@ -1998,6 +2102,7 @@ mod tests {
         .unwrap();
         let event2: Event = serde_json::from_str(&event_json2).unwrap();
         handle_legacy_chat_event(
+            ChatChannel::Peer,
             &order_id,
             &shared_keys,
             &my_keys.public_key(),
@@ -2019,6 +2124,7 @@ mod tests {
         .unwrap();
         let stranger_event: Event = serde_json::from_str(&stranger_json).unwrap();
         handle_legacy_chat_event(
+            ChatChannel::Peer,
             &order_id,
             &shared_keys,
             &my_keys.public_key(),

--- a/rust/src/api/nostr.rs
+++ b/rust/src/api/nostr.rs
@@ -61,6 +61,11 @@ pub async fn initialize(relays: Option<Vec<String>>) -> Result<()> {
                     // would resubscribe. Idempotent: orders with a live chat
                     // task are skipped by the single-owner guard.
                     crate::api::messages::resubscribe_active_chats().await;
+                    // Same rearm for dispute chats: solver assignments are
+                    // committed before listener startup, which can fail while
+                    // keys or connectivity are missing — coming online is the
+                    // retry point (PR #254 review).
+                    crate::api::disputes::resubscribe_active_dispute_chats().await;
                 }
                 Ok(state) => {
                     log::info!("[nostr] connection state changed: {state:?}");

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -2294,6 +2294,7 @@ async fn on_peer_pubkey_received(order_id: &str, peer_pubkey_hex: &str) {
     let order_id_owned = order_id.to_string();
     crate::rt::spawn(async move {
         crate::api::messages::subscribe_incoming_chat(
+            crate::api::messages::ChatChannel::Peer,
             order_id_owned,
             trade_keys,
             peer_pubkey,

--- a/rust/src/db/mod.rs
+++ b/rust/src/db/mod.rs
@@ -37,6 +37,20 @@ pub mod settings_keys {
     pub fn chat_cursor(order_id: &str) -> String {
         format!("{CHAT_CURSOR_PREFIX}{order_id}")
     }
+
+    /// Per-order solver pubkey (hex) for the dispute chat.
+    pub const DISPUTE_ADMIN_PREFIX: &str = "dispute_admin:";
+
+    /// Build the settings key holding the dispute solver's pubkey for
+    /// `order_id`.
+    ///
+    /// The dispute record itself stays in memory by design — status and
+    /// resolution are re-derivable from daemon events. This pubkey is not: it
+    /// arrives exactly once, in `admin-took-dispute`, and without it the
+    /// dispute chat keys cannot be derived again after a restart.
+    pub fn dispute_admin(order_id: &str) -> String {
+        format!("{DISPUTE_ADMIN_PREFIX}{order_id}")
+    }
 }
 
 /// Storage trait — implemented by both SQLite (native) and IndexedDB (WASM).

--- a/specs/004-mostro-p2p-client/contracts/messages.md
+++ b/specs/004-mostro-p2p-client/contracts/messages.md
@@ -12,8 +12,19 @@ random ephemeral authors made third-party flooding unattributable); it is
 still *read* from pre-migration peers until the dual-read deadline
 (`LEGACY_CHAT_DEPRECATION_TS`, 2026-12-31T00:00:00Z), bounded by the same
 LRU / rate budget / size cap / durable dedup / quota as the new envelope.
-Admin/dispute chat still uses gift wrap. Messages persist locally after
-validation. Supports encrypted file attachments via Blossom servers.
+Admin/dispute chat uses the **same chat envelope**, keyed to the solver's
+pubkey (from `admin-took-dispute`) instead of the counterparty's trade key
+(<https://mostro.network/protocol/dispute_chat.html>). Interop dual-path
+until `LEGACY_CHAT_DEPRECATION_TS`: the current solver client (mostrix)
+still speaks only NIP-59 gift wrap (mostrix#102), so outgoing evidence is
+additionally *written* as a gift wrap to the solver, and solver gift wraps
+addressed to the trade pubkey are still *read*, under the same bounds as
+the peer dual-read. Each channel keeps its **own** durable `since` cursor
+(`chat_cursor:<order>` for peer, `chat_cursor:dispute-<order>` for
+dispute) and its own subscription ids, so the two independent streams can
+never suppress or tear down each other. Messages persist locally after
+validation; the `since` cursor advances only past durably persisted
+messages. Supports encrypted file attachments via Blossom servers.
 
 **Security requirements implemented** (see the protocol spec for the
 normative list):


### PR DESCRIPTION
Second of two PRs. Stacked on #253 — **base it on `main` and re-target once #253 merges**. Closes #138.

## Problem

The dispute channel was the last producer of NIP-59 traffic in the app, and it was half a channel:

- **Outbound**: `submit_evidence` gift-wrapped a hand-rolled `{"type":"evidence", …}` JSON to the admin (`api/disputes.rs:217`).
- **Inbound**: nothing. There was no subscription and no handler, so a solver's reply never reached the app.
- The `admin_shared_key` it derived was a NIP-04-style key written into the session and **never read** by anything.

## Change

The channel now uses the envelope from [dispute_chat.md](https://mostro.network/protocol/dispute_chat.html): inner kind 1 signed by our trade key, NIP-44 under `K_conv`, inside a kind 14 signed with `K_sign` and p-tagged to `pub(K_conv)`. No gift wrap, no ephemeral key, and no pubkey a relay can correlate to either party.

Key derivation is `derive_chat_keys` **unchanged** — the only difference is that the ECDH peer is the solver's pubkey from `admin-took-dispute` instead of the counterparty's trade key, which is exactly what the spec prescribes.

Inbound reuses the existing subscriber, generalized by a `ChatChannel`. Its accepted-signers slice was already `[my trade key, other party]`, the right rule for both channels — the spec makes the admin a legitimate writer here, unlike the peer chat. The channel decides three things:

| | Peer | Dispute |
| --- | --- | --- |
| Guard key / subscription id | `mostro-chat-<order>` | `mostro-chat-dispute-<order>` |
| Stored `MessageType` | `Peer` | `Admin` |
| Dual-reads legacy kind 1059 | yes, until `LEGACY_CHAT_DEPRECATION_TS` | **no** |

The id split matters: the single-owner guard was keyed on the order id alone, so a dispute chat would have been treated as the peer chat already running for that order and silently never started.

The evidence text now travels as the message itself. The old JSON shape had no reader on the other side of the envelope, and this is a conversation with the solver — it belongs in the same history the UI already renders.

## Honest scope note

**NIP-59 is not gone from the app yet.** `gift_wrap::unwrap` still serves the time-boxed legacy read of the *peer* chat until `LEGACY_CHAT_DEPRECATION_TS` (2026-12-31), per #246. What this removes is the last source of *new* NIP-59 traffic.

## Test plan

- [x] `cargo test` — 205 passing. New: the two channels of one order never collide (guard key and subscription id), the peer subscription id is byte-identical to before the refactor (a change would orphan subscriptions across an upgrade), only the peer channel dual-reads gift wrap, and each channel stores its own message type.
- [x] `cargo clippy --all-targets` — 24 warnings, the same baseline as `main`
- [x] `cargo check --locked --target wasm32-unknown-unknown` — passes
- [x] `./scripts/frb-generate.sh` — no diff; bridge surface unchanged

## Follow-up, deliberately not here

Durability of the solver pubkey. The dispute store is in-memory by design, so after a restart the dispute chat does not resubscribe — `resubscribe_active_chats` only rebuilds peer chats. That needs a persisted record and a rehydrate path, which is its own change.