### PR TITLE
fix(deps): pin permission_handler_html to 0.1.3+5

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -80,6 +80,13 @@ dependencies:
   # Required by flutter_rust_bridge generated code
   freezed_annotation: ^2.4.4
 
+dependency_overrides:
+  # permission_handler_html 0.1.4+0 (published 2026-07-31) fails to compile
+  # for web (`'isA' isn't defined for the type 'Object'`), breaking every CI
+  # web build. Pinned to the previous release until upstream ships a fix:
+  # https://github.com/baseflow/flutter-permission-handler/issues/1550
+  permission_handler_html: 0.1.3+5
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
permission_handler_html 0.1.4+0 (published 2026-07-31) fails to compile for web ('isA' isn't defined for the type 'Object'), breaking every CI web build since pubspec.lock is not tracked and CI resolves dependencies fresh on each run. Pin the previous release via dependency_overrides until upstream ships a fix.

Upstream issue: https://github.com/baseflow/flutter-permission-handler/issues/1550

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility by pinning the web permission handling component to a stable version.
  * Helps prevent issues introduced by newer releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->