### PR TITLE
fix(#202): wait for the daemon reply before persisting a dispute

### DIFF
--- a/lib/core/daemon_errors.dart
+++ b/lib/core/daemon_errors.dart
@@ -44,5 +44,10 @@ String localizedDaemonError(
   if (raw.contains('TradeNotDisputable')) {
     return l10n.tradeNotDisputable;
   }
+  // A dispute for this trade already exists, or one is still in flight: the
+  // open is a duplicate either way, and retrying it changes nothing.
+  if (raw.contains('DisputeAlreadyOpen')) {
+    return l10n.disputeAlreadyOpen;
+  }
   return fallback;
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -345,6 +345,7 @@
   "openDisputeFailed": "Streit konnte nicht eröffnet werden. Bitte erneut versuchen.",
   "openDisputeTitle": "Streitfall eröffnen",
   "openDisputeConfirmation": "Möchtest du wirklich einen Streitfall eröffnen? Dies eskaliert den Handel an einen Administrator und kann nicht rückgängig gemacht werden.",
+  "disputeAlreadyOpen": "Für diesen Handel ist bereits ein Streit eröffnet.",
   "tradeNotDisputable": "Ein Streit kann erst eröffnet werden, wenn die Gelder für diesen Handel gesperrt sind.",
   "tradeWaitingInvoiceBuyerInstruction": "Sende deine Lightning-Rechnung, damit der Verkäufer die Gelder sperren kann.",
   "tradeWaitingInvoiceSellerInstruction": "Warte auf die Lightning-Rechnung des Käufers.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -705,6 +705,8 @@
   "@openDisputeTitle": {"description": "Title of the open-dispute confirmation dialog"},
   "openDisputeConfirmation": "Are you sure you want to open a dispute? This escalates the trade to an admin and cannot be undone.",
   "@openDisputeConfirmation": {"description": "Body of the open-dispute confirmation dialog"},
+  "disputeAlreadyOpen": "A dispute for this trade is already open.",
+  "@disputeAlreadyOpen": {"description": "Snackbar shown when a dispute is opened for a trade that already has one, or while a previous attempt is still in flight"},
   "tradeNotDisputable": "A dispute can only be opened once the funds are locked for this trade.",
   "@tradeNotDisputable": {"description": "Snackbar shown when a dispute is attempted before the trade reaches a disputable state"},
   "tradeWaitingInvoiceBuyerInstruction": "Submit your Lightning invoice so the seller can lock the funds.",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -345,6 +345,7 @@
   "openDisputeFailed": "No se pudo abrir la disputa. Por favor, inténtelo de nuevo.",
   "openDisputeTitle": "Abrir disputa",
   "openDisputeConfirmation": "¿Seguro que quieres abrir una disputa? Esto escala la operación a un administrador y no se puede deshacer.",
+  "disputeAlreadyOpen": "Ya hay una disputa abierta para este intercambio.",
   "tradeNotDisputable": "Solo se puede abrir una disputa cuando los fondos ya están bloqueados para este intercambio.",
   "tradeWaitingInvoiceBuyerInstruction": "Envía tu factura Lightning para que el vendedor pueda bloquear los fondos.",
   "tradeWaitingInvoiceSellerInstruction": "Esperando a que el comprador envíe su factura Lightning.",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -345,6 +345,7 @@
   "openDisputeFailed": "Impossible d'ouvrir le litige. Veuillez réessayer.",
   "openDisputeTitle": "Ouvrir un litige",
   "openDisputeConfirmation": "Êtes-vous sûr de vouloir ouvrir un litige ? Cela transmet l'échange à un administrateur et ne peut pas être annulé.",
+  "disputeAlreadyOpen": "Un litige est déjà ouvert pour cet échange.",
   "tradeNotDisputable": "Un litige ne peut être ouvert qu'une fois les fonds bloqués pour cet échange.",
   "tradeWaitingInvoiceBuyerInstruction": "Soumettez votre facture Lightning pour que le vendeur puisse bloquer les fonds.",
   "tradeWaitingInvoiceSellerInstruction": "En attente de la facture Lightning de l'acheteur.",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -345,6 +345,7 @@
   "openDisputeFailed": "Impossibile aprire la disputa. Riprovare.",
   "openDisputeTitle": "Apri contestazione",
   "openDisputeConfirmation": "Sei sicuro di voler aprire una contestazione? Questo inoltra lo scambio a un amministratore e non può essere annullato.",
+  "disputeAlreadyOpen": "Esiste già una disputa aperta per questo scambio.",
   "tradeNotDisputable": "Una disputa può essere aperta solo quando i fondi sono bloccati per questo scambio.",
   "tradeWaitingInvoiceBuyerInstruction": "Invia la tua fattura Lightning per permettere al venditore di bloccare i fondi.",
   "tradeWaitingInvoiceSellerInstruction": "In attesa che il compratore invii la propria fattura Lightning.",

--- a/rust/src/api/disputes.rs
+++ b/rust/src/api/disputes.rs
@@ -85,16 +85,21 @@ impl DisputeStore {
                 // InReview, not ours, no reason, solver known. Claim it
                 // instead of failing: keep the solver and the InReview status
                 // it already learned, restore our initiator metadata.
+                //
+                // The id is part of that metadata (PR #275 review). The
+                // placeholder was minted locally because the peer path never
+                // sees the daemon's id, while an accepted open carries it; the
+                // window this race lives in is now the whole reply wait, so
+                // keeping the placeholder's id would routinely discard the
+                // daemon's.
                 Some(existing)
-                    if existing.status == DisputeStatus::InReview
-                        && !existing.initiated_by_me
-                        && existing.reason.is_none()
-                        && existing.admin_pubkey.is_some()
+                    if is_peer_placeholder(existing)
                         && pending_opens()
                             .lock()
                             .map(|set| set.contains(&dispute.trade_id))
                             .unwrap_or(false) =>
                 {
+                    existing.id = dispute.id;
                     existing.initiated_by_me = true;
                     existing.reason = dispute.reason;
                     existing.clone()
@@ -177,6 +182,21 @@ fn dispute_store() -> &'static DisputeStore {
     DISPUTE_STORE.get_or_init(DisputeStore::new)
 }
 
+/// Whether `dispute` is the record `handle_admin_took_dispute` writes when it
+/// is the first thing this side hears about the dispute: InReview, not ours,
+/// no reason, solver known, and an id minted locally because the peer path
+/// never sees the daemon's.
+///
+/// Both paths that learn a dispute is in fact ours — the post-acceptance
+/// insert and the late-acceptance reconciliation — test for exactly this shape
+/// before claiming it, so the predicate lives in one place.
+fn is_peer_placeholder(dispute: &Dispute) -> bool {
+    dispute.status == DisputeStatus::InReview
+        && !dispute.initiated_by_me
+        && dispute.reason.is_none()
+        && dispute.admin_pubkey.is_some()
+}
+
 // ── Helper ────────────────────────────────────────────────────────────────────
 
 use crate::rt::unix_now;
@@ -197,13 +217,18 @@ fn status_allows_dispute(status: &crate::api::types::OrderStatus) -> bool {
 
 /// Initiate a dispute on an active trade.
 ///
-/// Sends a `Dispute` action to the Mostro daemon over transport v2 and
-/// creates a local `Dispute` record.
+/// Sends a `Dispute` action to the Mostro daemon over transport v2, waits for
+/// its reply, and creates the local `Dispute` record **only** once the daemon
+/// has accepted it. A publish is not an acceptance: the daemon rejects a
+/// dispute the trade is not eligible for with `CantDo`, and persisting on
+/// publish left that rejection unreconciled — the dispute stayed locally Open
+/// forever (#202).
 ///
 /// **Preconditions**: Trade MUST be disputable (funds in escrow). No existing
 /// open dispute for this trade.
 ///
-/// **Errors**: `TradeNotDisputable`, `DisputeAlreadyOpen`, `ProtocolError`.
+/// **Errors**: `TradeNotDisputable`, `DisputeAlreadyOpen`, `ProtocolError`,
+/// `NoDaemonResponse`, plus daemon `CantDo` reasons passed through.
 pub async fn open_dispute(trade_id: String, reason: Option<String>) -> Result<Dispute> {
     if trade_id.trim().is_empty() {
         bail!("TradeNotDisputable: trade_id must not be empty");
@@ -227,20 +252,37 @@ pub async fn open_dispute(trade_id: String, reason: Option<String>) -> Result<Di
     // Mark this process's concrete in-flight open attempt: only while the
     // marker is held may the post-publish insert claim an admin-took
     // placeholder as ours. Dropped on every exit path.
-    pending_opens()
+    //
+    // Claiming it is also what makes the open single-flight (PR #275 review).
+    // The entry check above cannot see a concurrent attempt — neither has
+    // persisted anything yet — and both would derive the same trade key, so
+    // the second registration would replace the first one's pending record and
+    // strand its waiter on a NoDaemonResponse the daemon never caused.
+    let fresh = pending_opens()
         .lock()
         .expect("pending_opens poisoned")
         .insert(trade_id.clone());
+    if !fresh {
+        bail!("DisputeAlreadyOpen: an open_dispute for trade {trade_id} is already in flight");
+    }
     let _pending = PendingOpenGuard(trade_id.clone());
 
     // Dispatch Action::Dispute to Mostro BEFORE creating the local record so
-    // that a failed publish does not leave an un-retryable "open" slot in the
-    // dispute store.  Only on a successful publish do we persist the dispute.
+    // that a request the daemon never accepted does not leave an un-retryable
+    // "open" slot in the dispute store.
     let trade_index = crate::api::orders::trade_key_for_order(&trade_id)
         .await
         .ok_or_else(|| anyhow!("TradeNotDisputable: no trade key for trade {trade_id}"))?;
 
-    let event_json: String = async {
+    // Correlation nonce for this request. The daemon echoes it in its reply —
+    // DisputeInitiatedByYou on acceptance, CantDo on rejection — and only a
+    // reply carrying it may resolve the wait below.
+    let request_id: u64 = {
+        use rand::RngCore;
+        rand::rngs::OsRng.next_u64().max(1) // 0 is indistinguishable from "unset"
+    };
+
+    let (trade_pk_hex, event_json) = async {
         let sender_keys =
             crate::api::identity::get_active_trade_keys(trade_index).await?;
         let identity_keys =
@@ -248,27 +290,75 @@ pub async fn open_dispute(trade_id: String, reason: Option<String>) -> Result<Di
         let mostro_pubkey =
             nostr_sdk::PublicKey::from_hex(&crate::config::active_mostro_pubkey())
                 .map_err(|e| anyhow!("invalid mostro pubkey: {e}"))?;
-        crate::mostro::actions::dispute(
+        let event_json = crate::mostro::actions::dispute(
             &identity_keys,
             &sender_keys,
             &mostro_pubkey,
             &trade_id,
             trade_index,
+            request_id,
         )
-        .await
+        .await?;
+        Ok::<_, anyhow::Error>((sender_keys.public_key().to_hex(), event_json))
     }
     .await
     .map_err(|e| anyhow!("ProtocolError: could not build Dispute message: {e}"))?;
 
-    crate::api::orders::publish_event(&event_json)
-        .await
-        .map_err(|e| anyhow!("ProtocolError: publish failed: {e}"))?;
+    // Register the pending record BEFORE publishing so the reply cannot race
+    // the bookkeeping. The trade key is already subscribed — the trade is
+    // active — so no new subscription is needed here.
+    let reply_rx = crate::mostro::pending::register_dispute_request(
+        trade_pk_hex.clone(),
+        request_id,
+        trade_index,
+    );
 
-    log::info!("[disputes] Dispute dispatched for trade={trade_id}");
+    if let Err(e) = crate::api::orders::publish_event(&event_json).await {
+        crate::mostro::pending::remove_pending_request(&trade_pk_hex, request_id);
+        return Err(anyhow!("ProtocolError: publish failed: {e}"));
+    }
 
-    // Publish succeeded — persist the dispute record.
+    log::info!("[disputes] Dispute dispatched for trade={trade_id} — waiting for daemon");
+
+    // Timeout detaches only the waiter: the record survives so a genuine late
+    // reply is still recognized as this attempt's, and a stale replay still is
+    // not.
+    let reply = crate::rt::time::timeout(std::time::Duration::from_secs(10), reply_rx).await;
+    if !matches!(reply, Ok(Ok(_))) {
+        crate::mostro::pending::detach_request_waiter(&trade_pk_hex, request_id);
+    }
+
+    use crate::mostro::pending::{DaemonReply, Wake};
+    let dispute_id = match reply {
+        Ok(Ok(Wake { reply: DaemonReply::DisputeAccepted { dispute_id }, .. })) => dispute_id,
+        Ok(Ok(Wake { reply: DaemonReply::Rejected { reason, message }, .. })) => {
+            log::warn!("[disputes] open_dispute rejected for trade={trade_id}: {reason}");
+            bail!("{message}");
+        }
+        Ok(Ok(_)) => bail!("ProtocolError: unexpected daemon reply to Dispute"),
+        // The daemon answers a rejected dispute with CantDo, but only for
+        // MostroCantDo causes: a duplicate dispute or a DB failure is an
+        // internal error it merely logs (mostro src/app.rs, manage_errors),
+        // so silence is a real outcome here and not only a lost event.
+        _ => {
+            log::warn!("[disputes] open_dispute: no daemon response within 10s for trade={trade_id}");
+            bail!("NoDaemonResponse");
+        }
+    };
+
+    // The daemon accepted it — persist the dispute under the id it assigned,
+    // which is what the solver and the daemon's Kind 38386 dispute event refer
+    // to. An acceptance without that id is malformed and fails closed (PR #275
+    // review): `Dispute.id` is contractually the daemon's, and a locally minted
+    // one would be indistinguishable from it while being wrong. A conforming
+    // daemon always sends it (mostro src/app/dispute.rs,
+    // notify_dispute_to_users).
+    let Some(dispute_id) = dispute_id else {
+        bail!("ProtocolError: daemon accepted the dispute without a dispute id");
+    };
+
     let dispute = Dispute {
-        id: uuid::Uuid::new_v4().to_string(),
+        id: dispute_id,
         trade_id: trade_id.clone(),
         status: DisputeStatus::Open,
         initiated_by_me: true,
@@ -337,6 +427,76 @@ pub async fn submit_evidence(trade_id: String, text: String) -> Result<()> {
 
     log::info!("[disputes] evidence submitted for trade={trade_id}");
     Ok(())
+}
+
+/// Record a dispute the daemon accepted after `open_dispute` had already
+/// stopped waiting for the reply.
+///
+/// The acceptance is genuine — the daemon opened the dispute, told the
+/// counterparty, and published its Kind 38386 event — so the reply's status
+/// update moves the trade to `Dispute` either way. Dropping the record while
+/// letting that through would leave a disputed trade with no dispute to open
+/// and no way to reach the solver, which is the same split state this whole
+/// change set exists to remove (PR #275 review). The caller saw
+/// `NoDaemonResponse`, so the record lands unread.
+///
+/// The dispute's reason went with the timed-out call and is not recoverable
+/// here.
+///
+/// A solver can be assigned inside the same window, so the record may already
+/// exist as the peer-style placeholder — and then it is ours after all
+/// (PR #275 review): it is claimed exactly as the post-acceptance insert
+/// claims it, keeping the solver and InReview it learned while taking the
+/// daemon's id and the initiator flag. The claim needs no in-flight marker
+/// here the way that path does; a `DisputeInitiatedByYou` correlated to our
+/// own nonce is itself the proof the dispute is ours. Any other existing
+/// record — a retry that succeeded, a resolved dispute — is left untouched.
+///
+/// Fails closed on an acceptance carrying no dispute id, for the same reason
+/// `open_dispute` does: the record would claim a daemon id it does not have.
+pub(crate) async fn record_late_acceptance(trade_id: &str, dispute_id: Option<String>) {
+    let Some(id) = dispute_id else {
+        log::warn!(
+            "[disputes] late acceptance for trade={trade_id} carried no dispute id — not recorded"
+        );
+        return;
+    };
+    let trade_id_for_new = trade_id.to_string();
+    let id_for_claim = id.clone();
+
+    let result = dispute_store()
+        .upsert_or_update(
+            trade_id,
+            || Dispute {
+                id,
+                trade_id: trade_id_for_new,
+                status: DisputeStatus::Open,
+                initiated_by_me: true,
+                reason: None,
+                admin_pubkey: None,
+                resolution: None,
+                opened_at: unix_now(),
+                resolved_at: None,
+                is_read: false,
+            },
+            move |existing| {
+                if is_peer_placeholder(existing) {
+                    existing.id = id_for_claim;
+                    existing.initiated_by_me = true;
+                }
+                Ok(())
+            },
+        )
+        .await;
+
+    match result {
+        Ok(()) => log::info!(
+            "[disputes] reconciled late daemon acceptance for trade={trade_id}"
+        ),
+        Err(e) => log::warn!(
+            "[disputes] could not reconcile late acceptance for trade={trade_id}: {e}"
+        ),
+    }
 }
 
 /// Get dispute details for a trade.
@@ -594,6 +754,23 @@ mod tests {
         }
     }
 
+    /// PR #275 review: a second open for the same trade while the first is
+    /// still awaiting the daemon must be refused. Both would derive the same
+    /// trade key, so letting it through would replace the first attempt's
+    /// pending record and strand its waiter.
+    #[tokio::test]
+    async fn a_second_open_is_refused_while_one_is_in_flight() {
+        let trade_id = format!("t-{}", uuid::Uuid::new_v4());
+        pending_opens().lock().unwrap().insert(trade_id.clone());
+        let _pending = PendingOpenGuard(trade_id.clone());
+
+        let err = open_dispute(trade_id, None).await.unwrap_err();
+        assert!(
+            err.to_string().contains("already in flight"),
+            "expected the in-flight guard to reject it, got: {err}"
+        );
+    }
+
     #[tokio::test]
     async fn open_dispute_requires_trade_key() {
         // open_dispute now dispatches to Mostro before persisting; without a
@@ -694,9 +871,11 @@ mod tests {
         pending_opens().lock().unwrap().insert(trade_id.clone());
         let _pending = PendingOpenGuard(trade_id.clone());
 
-        // Exactly what open_dispute persists after a successful publish.
+        // Exactly what open_dispute persists after the daemon accepts: the id
+        // is the daemon's, the placeholder's was minted locally.
+        let daemon_dispute_id = uuid::Uuid::new_v4().to_string();
         let own = Dispute {
-            id: uuid::Uuid::new_v4().to_string(),
+            id: daemon_dispute_id.clone(),
             trade_id: trade_id.clone(),
             status: DisputeStatus::Open,
             initiated_by_me: true,
@@ -720,6 +899,89 @@ mod tests {
             "the solver assignment must survive the claim"
         );
         assert_eq!(stored.admin_pubkey.as_deref(), Some(admin_pk));
+        // PR #275 review: the claim must not discard the daemon's id.
+        assert_eq!(
+            stored.id, daemon_dispute_id,
+            "the claimed placeholder must adopt the daemon's dispute id"
+        );
+    }
+
+    /// PR #275 review: the daemon's acceptance can land after `open_dispute`
+    /// gave up. The status arm that follows moves the trade to Dispute either
+    /// way, so the record must exist — otherwise the trade shows as disputed
+    /// with no dispute to open and no solver to reach.
+    #[tokio::test]
+    async fn a_late_acceptance_is_reconciled_into_a_record() {
+        let trade_id = format!("t-{}", uuid::Uuid::new_v4());
+        let daemon_dispute_id = uuid::Uuid::new_v4().to_string();
+
+        assert!(get_dispute(trade_id.clone()).await.unwrap().is_none());
+
+        record_late_acceptance(&trade_id, Some(daemon_dispute_id.clone())).await;
+
+        let d = get_dispute(trade_id).await.unwrap().expect("record created");
+        assert_eq!(d.id, daemon_dispute_id, "the daemon's id must be adopted");
+        assert_eq!(d.status, DisputeStatus::Open);
+        assert!(d.initiated_by_me, "we did open it, late reply or not");
+        assert!(!d.is_read, "the caller was told it failed — this is news");
+    }
+
+    /// PR #275 review: `Dispute.id` is contractually the daemon's, so an
+    /// acceptance that carries no dispute id is malformed and must persist
+    /// nothing rather than mint a local id indistinguishable from a real one.
+    #[tokio::test]
+    async fn a_late_acceptance_without_a_daemon_id_records_nothing() {
+        let trade_id = format!("t-{}", uuid::Uuid::new_v4());
+
+        record_late_acceptance(&trade_id, None).await;
+
+        assert!(
+            get_dispute(trade_id).await.unwrap().is_none(),
+            "a malformed acceptance must not create a record"
+        );
+    }
+
+    /// PR #275 review round 2: `open_dispute` times out, a solver is assigned
+    /// inside the same window — writing the peer-style placeholder — and only
+    /// then does the correlated acceptance arrive. The placeholder is ours
+    /// after all, so the reconciliation must claim it: the daemon's id and the
+    /// initiator flag replace the locally minted ones, and the solver and
+    /// InReview it already learned survive.
+    #[tokio::test]
+    async fn a_late_acceptance_claims_the_admin_took_placeholder() {
+        let trade_id = format!("t-{}", uuid::Uuid::new_v4());
+        let admin_pk = "000000000000000000000000000000000000000000000000000000000000000a";
+        let daemon_dispute_id = uuid::Uuid::new_v4().to_string();
+
+        handle_admin_took_dispute(trade_id.clone(), admin_pk.to_string())
+            .await
+            .unwrap();
+        let placeholder_id = get_dispute(trade_id.clone()).await.unwrap().unwrap().id;
+
+        record_late_acceptance(&trade_id, Some(daemon_dispute_id.clone())).await;
+
+        let d = get_dispute(trade_id).await.unwrap().unwrap();
+        assert_ne!(d.id, placeholder_id, "the local id must not survive");
+        assert_eq!(d.id, daemon_dispute_id, "the daemon's id must be adopted");
+        assert!(d.initiated_by_me, "the acceptance proves the dispute is ours");
+        assert_eq!(d.status, DisputeStatus::InReview, "the assignment survives");
+        assert_eq!(d.admin_pubkey.as_deref(), Some(admin_pk));
+    }
+
+    /// Only the placeholder shape is claimable. A record that is already ours
+    /// — a retry that succeeded while the first attempt's reply was still in
+    /// flight — must survive the late reply untouched.
+    #[tokio::test]
+    async fn a_late_acceptance_leaves_a_successful_retry_alone() {
+        let trade_id = format!("t-{}", uuid::Uuid::new_v4());
+        let before = seed_dispute(&trade_id, Some("no payment".to_string())).await;
+
+        record_late_acceptance(&trade_id, Some(uuid::Uuid::new_v4().to_string())).await;
+
+        let after = get_dispute(trade_id).await.unwrap().unwrap();
+        assert_eq!(after.id, before.id, "the retry's record owns the trade");
+        assert_eq!(after.reason.as_deref(), Some("no payment"));
+        assert_eq!(after.status, DisputeStatus::Open);
     }
 
     /// PR #253 race, direction 2: the initiator's record already exists when

--- a/rust/src/api/disputes.rs
+++ b/rust/src/api/disputes.rs
@@ -314,7 +314,9 @@ pub async fn open_dispute(trade_id: String, reason: Option<String>) -> Result<Di
     );
 
     if let Err(e) = crate::api::orders::publish_event(&event_json).await {
-        crate::mostro::pending::remove_pending_request(&trade_pk_hex, request_id);
+        // Roll back only this attempt: if it is a retry, the timed-out attempt
+        // it took the key from is still answerable and must stay so.
+        crate::mostro::pending::roll_back_dispute_request(&trade_pk_hex, request_id);
         return Err(anyhow!("ProtocolError: publish failed: {e}"));
     }
 

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -21,7 +21,7 @@ use crate::mostro::pending::{
     pending_local_uuid_for, pending_requests, purge_pending_request, remove_pending_request,
     take_matching_add_invoice, take_matching_dispute, take_matching_request,
     take_matching_restore, take_matching_take, take_pending_create_by_content_key, DaemonReply,
-    PendingRequest, PendingRequestKind, Wake,
+    DisputeMatch, PendingRequest, PendingRequestKind, Wake,
 };
 use crate::nostr::order_events::parse_order_event;
 
@@ -1574,8 +1574,8 @@ async fn dispatch_mostro_message(
         // addresses it to the counterparty's trade key, which has no pending
         // record of ours (mostro src/app/dispute.rs, notify_dispute_to_users).
         if kind.action == Action::DisputeInitiatedByYou {
-            if let Some(pending) = take_matching_dispute(trade_pubkey_hex, kind.request_id) {
-                if let Some(tx) = pending.tx {
+            match take_matching_dispute(trade_pubkey_hex, kind.request_id) {
+                Some(DisputeMatch::Waiting(tx)) => {
                     crate::api::logging::blog_info("daemon-msg", format!(
                         "DisputeInitiatedByYou: accepted waiting open_dispute for trade={}",
                         &trade_pubkey_hex[..8]
@@ -1583,13 +1583,14 @@ async fn dispatch_mostro_message(
                     let _ = tx.send(Wake::from(DaemonReply::DisputeAccepted {
                         dispute_id: dispute_id_from_payload(kind.payload.as_ref()),
                     }));
-                } else {
-                    // Genuine acceptance after the 10s timeout: the caller
-                    // already returned NoDaemonResponse and persisted no
-                    // dispute. Record it now — the status arm below moves the
-                    // trade to Dispute regardless, and a disputed trade with
-                    // no dispute record has no solver to reach (PR #275
-                    // review).
+                }
+                // Genuine acceptance after the 10s timeout — of this attempt or
+                // of an earlier one a retry superseded. The caller already
+                // returned NoDaemonResponse and persisted no dispute. Record it
+                // now: the status arm below moves the trade to Dispute
+                // regardless, and a disputed trade with no dispute record has no
+                // solver to reach (PR #275 review).
+                Some(DisputeMatch::Late) => {
                     crate::api::logging::blog_warn("daemon-msg", format!(
                         "DisputeInitiatedByYou: late acceptance for timed-out open_dispute on trade={}",
                         &trade_pubkey_hex[..8]
@@ -1602,6 +1603,7 @@ async fn dispatch_mostro_message(
                         .await;
                     }
                 }
+                None => {}
             }
         }
     }
@@ -4098,9 +4100,10 @@ mod tests {
 
         assert!(take_matching_dispute(dispute_key, None).is_none());
         assert!(take_matching_dispute(dispute_key, Some(99)).is_none());
-        let pending = take_matching_dispute(dispute_key, Some(72)).expect("must match");
-        assert!(matches!(pending.kind, PendingRequestKind::Dispute));
-        assert_eq!(pending.trade_index, 5);
+        assert!(matches!(
+            take_matching_dispute(dispute_key, Some(72)),
+            Some(DisputeMatch::Waiting(_))
+        ));
         assert!(!pending_requests().lock().unwrap().contains_key(dispute_key));
 
         pending_requests().lock().unwrap().remove(take_key);
@@ -4119,7 +4122,7 @@ mod tests {
         let pending = take_matching_restore(key)
             .or_else(|| take_matching_request(key, Some(73)))
             .expect("the rejection must find the dispute record");
-        assert!(matches!(pending.kind, PendingRequestKind::Dispute));
+        assert!(matches!(pending.kind, PendingRequestKind::Dispute { .. }));
 
         let sent = pending
             .tx

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -19,9 +19,9 @@ use crate::mostro::status::{
 use crate::mostro::pending::{
     classify_take_reply, detach_request_waiter, may_reconcile_stored_id, order_content_key,
     pending_local_uuid_for, pending_requests, purge_pending_request, remove_pending_request,
-    take_matching_add_invoice, take_matching_request, take_matching_restore,
-    take_matching_take, take_pending_create_by_content_key, DaemonReply, PendingRequest,
-    PendingRequestKind, Wake,
+    take_matching_add_invoice, take_matching_dispute, take_matching_request,
+    take_matching_restore, take_matching_take, take_pending_create_by_content_key, DaemonReply,
+    PendingRequest, PendingRequestKind, Wake,
 };
 use crate::nostr::order_events::parse_order_event;
 
@@ -1562,6 +1562,48 @@ async fn dispatch_mostro_message(
                 ));
             }
         }
+
+        // A dispute's only success reply is DisputeInitiatedByYou, so the arm
+        // gates on that action as well as on the nonce — anything else leaves
+        // the record for the genuine reply rather than unblocking the caller
+        // on a message that is not an acceptance. Falls through like an
+        // add-invoice: the reply is also the status update that moves the
+        // order to Dispute.
+        //
+        // DisputeInitiatedByPeer echoes the same nonce but the daemon
+        // addresses it to the counterparty's trade key, which has no pending
+        // record of ours (mostro src/app/dispute.rs, notify_dispute_to_users).
+        if kind.action == Action::DisputeInitiatedByYou {
+            if let Some(pending) = take_matching_dispute(trade_pubkey_hex, kind.request_id) {
+                if let Some(tx) = pending.tx {
+                    crate::api::logging::blog_info("daemon-msg", format!(
+                        "DisputeInitiatedByYou: accepted waiting open_dispute for trade={}",
+                        &trade_pubkey_hex[..8]
+                    ));
+                    let _ = tx.send(Wake::from(DaemonReply::DisputeAccepted {
+                        dispute_id: dispute_id_from_payload(kind.payload.as_ref()),
+                    }));
+                } else {
+                    // Genuine acceptance after the 10s timeout: the caller
+                    // already returned NoDaemonResponse and persisted no
+                    // dispute. Record it now — the status arm below moves the
+                    // trade to Dispute regardless, and a disputed trade with
+                    // no dispute record has no solver to reach (PR #275
+                    // review).
+                    crate::api::logging::blog_warn("daemon-msg", format!(
+                        "DisputeInitiatedByYou: late acceptance for timed-out open_dispute on trade={}",
+                        &trade_pubkey_hex[..8]
+                    ));
+                    if let Some(order_id) = kind.id.map(|id| id.to_string()) {
+                        crate::api::disputes::record_late_acceptance(
+                            &order_id,
+                            dispute_id_from_payload(kind.payload.as_ref()),
+                        )
+                        .await;
+                    }
+                }
+            }
+        }
     }
 
     match &kind.action {
@@ -3100,6 +3142,17 @@ async fn bridge_fingerprint_trade_index(order_id: &str, trade_idx: u32) {
     }
 }
 
+/// The daemon's dispute UUID out of a `Dispute` payload.
+fn dispute_id_from_payload(
+    payload: Option<&mostro_core::message::Payload>,
+) -> Option<String> {
+    use mostro_core::message::Payload;
+    match payload {
+        Some(Payload::Dispute(id, _)) => Some(id.to_string()),
+        _ => None,
+    }
+}
+
 /// Parse a Kind 38383 event and upsert it into the order book, applying
 /// maker-order reconciliation (is_mine detection, local→daemon id bridging,
 /// trade-status sync).
@@ -3703,6 +3756,7 @@ pub async fn restore_session() -> Result<mostro_core::message::RestoreSessionInf
 mod tests {
     use super::*;
     use crate::api::types::TradeRole;
+    use crate::mostro::pending::register_dispute_request;
     use crate::mostro::session::session_manager;
 
     #[test]
@@ -3811,6 +3865,23 @@ mod tests {
             recovered_max_trade_index(&restore_info(vec![-1], vec![huge])),
             None
         );
+    }
+
+    #[test]
+    fn the_daemon_dispute_id_is_read_from_a_dispute_payload() {
+        use mostro_core::message::Payload;
+
+        let id = uuid::Uuid::new_v4();
+        assert_eq!(
+            dispute_id_from_payload(Some(&Payload::Dispute(id, None))).as_deref(),
+            Some(id.to_string().as_str())
+        );
+
+        // An acceptance carrying no dispute payload leaves the id unknown
+        // rather than inventing one — the acceptance is malformed and
+        // open_dispute fails closed on it.
+        assert_eq!(dispute_id_from_payload(None), None);
+        assert_eq!(dispute_id_from_payload(Some(&Payload::Amount(42))), None);
     }
 
     fn insert_pending_create(key: &str, request_id: u64) -> tokio::sync::oneshot::Receiver<Wake> {
@@ -4010,6 +4081,59 @@ mod tests {
         assert!(!pending_requests().lock().unwrap().contains_key(ai_key));
 
         pending_requests().lock().unwrap().remove(take_key);
+    }
+
+    /// `take_matching_dispute` mirrors the take rules for its own kind: only
+    /// Dispute records, only with the exact nonce.
+    #[tokio::test]
+    async fn take_matching_dispute_only_consumes_dispute_records() {
+        let take_key = "test-dispute-take-pubkey";
+        let dispute_key = "test-dispute-dispute-pubkey";
+        let _rx_t = insert_pending_take(take_key, 71);
+        let _rx_d = register_dispute_request(dispute_key.to_string(), 72, 5);
+
+        // A Take record is never consumed here, even with its exact nonce.
+        assert!(take_matching_dispute(take_key, Some(71)).is_none());
+        assert!(pending_requests().lock().unwrap().contains_key(take_key));
+
+        assert!(take_matching_dispute(dispute_key, None).is_none());
+        assert!(take_matching_dispute(dispute_key, Some(99)).is_none());
+        let pending = take_matching_dispute(dispute_key, Some(72)).expect("must match");
+        assert!(matches!(pending.kind, PendingRequestKind::Dispute));
+        assert_eq!(pending.trade_index, 5);
+        assert!(!pending_requests().lock().unwrap().contains_key(dispute_key));
+
+        pending_requests().lock().unwrap().remove(take_key);
+    }
+
+    /// #202: the CantDo arm resolves whatever request the nonce identifies, so
+    /// a registered dispute is rejected through the same path as any other
+    /// request. Before the dispute registered one, its rejection matched no
+    /// pending request and was dropped — leaving a local dispute Open forever.
+    #[tokio::test]
+    async fn a_cantdo_rejection_reaches_the_waiting_open_dispute() {
+        let key = "test-dispute-cantdo-pubkey";
+        let mut rx = register_dispute_request(key.to_string(), 73, 6);
+
+        // Exactly what the Action::CantDo arm does to find its caller.
+        let pending = take_matching_restore(key)
+            .or_else(|| take_matching_request(key, Some(73)))
+            .expect("the rejection must find the dispute record");
+        assert!(matches!(pending.kind, PendingRequestKind::Dispute));
+
+        let sent = pending
+            .tx
+            .expect("the waiter is still attached")
+            .send(Wake::from(DaemonReply::Rejected {
+                reason: "NotAllowedByStatus".to_string(),
+                message: "rejected".to_string(),
+            }));
+        assert!(sent.is_ok(), "the caller must still be listening");
+
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(Wake { reply: DaemonReply::Rejected { .. }, .. })
+        ));
     }
 
     /// Same-key overlap (send_invoice reuses the take's trade key): a newer

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -4109,34 +4109,134 @@ mod tests {
         pending_requests().lock().unwrap().remove(take_key);
     }
 
-    /// #202: the CantDo arm resolves whatever request the nonce identifies, so
-    /// a registered dispute is rejected through the same path as any other
-    /// request. Before the dispute registered one, its rejection matched no
-    /// pending request and was dropped — leaving a local dispute Open forever.
+    /// Builds the `UnwrappedMessage` for a daemon reply to an open-dispute,
+    /// signed-by-sender semantics included, for driving the real dispatcher.
+    /// `Action::CantDo` is a `Message::CantDo` on the wire, every other reply
+    /// a `Message::Dispute` — the arms are reached through the dispatcher, not
+    /// re-implemented in the test.
+    fn dispute_reply_message(
+        order_uuid: uuid::Uuid,
+        request_id: u64,
+        trade_index: u32,
+        action: mostro_core::message::Action,
+        payload: Option<mostro_core::message::Payload>,
+    ) -> mostro_core::nip59::UnwrappedMessage {
+        use mostro_core::message::{Action, Message};
+
+        let message = match action {
+            Action::CantDo => Message::cant_do(Some(order_uuid), Some(request_id), payload),
+            other => Message::new_dispute(
+                Some(order_uuid),
+                Some(request_id),
+                Some(trade_index as i64),
+                other,
+                payload,
+            ),
+        };
+        let sender =
+            nostr_sdk::PublicKey::from_hex(&active_mostro_pubkey()).expect("valid mostro pubkey");
+        mostro_core::nip59::UnwrappedMessage {
+            message,
+            signature: None,
+            sender,
+            identity: sender,
+            created_at: nostr_sdk::Timestamp::from(0u64),
+        }
+    }
+
+    /// The acceptance, through the real dispatcher: its `DisputeInitiatedByYou`
+    /// arm must wake the caller with the daemon's dispute id AND still fall
+    /// through to the status arm that moves the trade to Dispute. The matcher's
+    /// own test sees neither half — only this one pins the fall-through the
+    /// arm's comment claims.
+    #[tokio::test]
+    async fn a_dispute_acceptance_wakes_the_caller_and_moves_the_trade() {
+        use crate::api::types::OrderStatus;
+        use mostro_core::message::{Action, Payload};
+
+        let order_uuid = uuid::Uuid::new_v4();
+        let order_id = order_uuid.to_string();
+        let key = "test-dispute-accepted-pubkey";
+        let dispute_uuid = uuid::Uuid::new_v4();
+
+        // A disputable trade, bound to the generation the reply arrives on.
+        let mut info = dummy_order_info(&order_id);
+        info.status = OrderStatus::Active;
+        order_book().upsert_order(info).await;
+        store_trade_key_index(&order_id, 8).await;
+
+        let mut rx = register_dispute_request(key.to_string(), 74, 8);
+
+        dispatch_mostro_message(
+            dispute_reply_message(
+                order_uuid,
+                74,
+                8,
+                Action::DisputeInitiatedByYou,
+                Some(Payload::Dispute(dispute_uuid, None)),
+            ),
+            "test-dispute-accepted",
+            key,
+            8,
+        )
+        .await;
+
+        // The waiting open_dispute gets the daemon's id — the one the solver
+        // and the Kind 38386 event refer to — not a locally minted one.
+        match rx.try_recv() {
+            Ok(Wake { reply: DaemonReply::DisputeAccepted { dispute_id }, .. }) => {
+                assert_eq!(dispute_id, Some(dispute_uuid.to_string()));
+            }
+            _ => panic!("the acceptance must reach the waiting open_dispute"),
+        }
+        assert!(!pending_requests().lock().unwrap().contains_key(key));
+
+        assert_eq!(
+            order_book()
+                .get_order(&order_id)
+                .await
+                .expect("order still cached")
+                .status,
+            OrderStatus::Dispute,
+            "the acceptance is also the status update"
+        );
+    }
+
+    /// #202 itself, driven through the arm that was dropping it: the CantDo arm
+    /// resolves whatever request the nonce identifies, so a registered dispute
+    /// is rejected through the same path as any other request. Before the
+    /// dispute registered one, its rejection matched no pending request and was
+    /// dropped — leaving a local dispute Open forever.
     #[tokio::test]
     async fn a_cantdo_rejection_reaches_the_waiting_open_dispute() {
+        use mostro_core::error::CantDoReason;
+        use mostro_core::message::{Action, Payload};
+
+        let order_uuid = uuid::Uuid::new_v4();
         let key = "test-dispute-cantdo-pubkey";
         let mut rx = register_dispute_request(key.to_string(), 73, 6);
 
-        // Exactly what the Action::CantDo arm does to find its caller.
-        let pending = take_matching_restore(key)
-            .or_else(|| take_matching_request(key, Some(73)))
-            .expect("the rejection must find the dispute record");
-        assert!(matches!(pending.kind, PendingRequestKind::Dispute { .. }));
+        dispatch_mostro_message(
+            dispute_reply_message(
+                order_uuid,
+                73,
+                6,
+                Action::CantDo,
+                Some(Payload::CantDo(Some(CantDoReason::NotAllowedByStatus))),
+            ),
+            "test-dispute-cantdo",
+            key,
+            6,
+        )
+        .await;
 
-        let sent = pending
-            .tx
-            .expect("the waiter is still attached")
-            .send(Wake::from(DaemonReply::Rejected {
-                reason: "NotAllowedByStatus".to_string(),
-                message: "rejected".to_string(),
-            }));
-        assert!(sent.is_ok(), "the caller must still be listening");
-
-        assert!(matches!(
-            rx.try_recv(),
-            Ok(Wake { reply: DaemonReply::Rejected { .. }, .. })
-        ));
+        match rx.try_recv() {
+            Ok(Wake { reply: DaemonReply::Rejected { reason, .. }, .. }) => {
+                assert_eq!(reason, "NotAllowedByStatus");
+            }
+            _ => panic!("the rejection must reach the waiting open_dispute"),
+        }
+        assert!(!pending_requests().lock().unwrap().contains_key(key));
     }
 
     /// Same-key overlap (send_invoice reuses the take's trade key): a newer

--- a/rust/src/mostro/actions.rs
+++ b/rust/src/mostro/actions.rs
@@ -196,22 +196,29 @@ pub async fn cancel(
 }
 
 /// Build and wrap a Dispute MostroMessage.
+///
+/// `request_id` is the correlation nonce the daemon echoes in its reply
+/// (`DisputeInitiatedByYou` or `CantDo`); `open_dispute` relies on it to tell
+/// the genuine reply apart from stale relay-replayed events. This is why the
+/// message is built here instead of through `simple_action`, which sends no
+/// nonce.
 pub async fn dispute(
     identity_keys: &Keys,
     trade_keys: &Keys,
     mostro_pubkey: &PublicKey,
     order_id: &str,
     trade_index: u32,
+    request_id: u64,
 ) -> Result<String> {
-    simple_action(
-        identity_keys,
-        trade_keys,
-        mostro_pubkey,
-        order_id,
-        trade_index,
+    let id = Uuid::parse_str(order_id)?;
+    let msg = Message::new_order(
+        Some(id),
+        Some(request_id),
+        Some(trade_index as i64),
         Action::Dispute,
-    )
-    .await
+        None,
+    );
+    wrap_message(identity_keys, trade_keys, mostro_pubkey, &msg).await
 }
 
 /// Build and wrap a RateUser MostroMessage.

--- a/rust/src/mostro/actions.rs
+++ b/rust/src/mostro/actions.rs
@@ -673,6 +673,55 @@ mod tests {
         assert!(matches!(kind.payload, Some(Payload::Amount(100))));
     }
 
+    /// The outgoing Dispute message must carry the caller's request_id: it is
+    /// the nonce the daemon echoes in `DisputeInitiatedByYou` and in `CantDo`,
+    /// and `open_dispute` persists nothing without a reply carrying it. A
+    /// serialization regression here would otherwise show up only as a 10 s
+    /// `NoDaemonResponse` (PR #275 review).
+    #[tokio::test]
+    async fn dispute_carries_request_id_order_id_and_no_payload() {
+        let identity_keys = Keys::generate();
+        let trade_keys = Keys::generate();
+        let mostro_keys = Keys::generate();
+        let order_id = "94486ae3-4083-4dfe-b543-53fe761025e9";
+
+        // First-contact wrapping fails closed until this node's capabilities
+        // are published — a test double for the Kind 38385 fetch.
+        let _pow = crate::mostro::pow::test_support::lock_pow();
+        crate::mostro::pow::set_pows(&mostro_keys.public_key().to_hex(), 0, None);
+        crate::mostro::protocol_version::set_protocol_version(
+            &mostro_keys.public_key().to_hex(),
+            Some(2),
+        );
+
+        let json = dispute(
+            &identity_keys,
+            &trade_keys,
+            &mostro_keys.public_key(),
+            order_id,
+            9,
+            4242,
+        )
+        .await
+        .unwrap();
+
+        let event = Event::from_json(&json).unwrap();
+        let unwrapped = transport::unwrap_mostro_message(&mostro_keys, &event)
+            .await
+            .unwrap()
+            .expect("message must decrypt for the recipient");
+
+        let kind = unwrapped.message.get_inner_message_kind();
+        assert_eq!(kind.request_id, Some(4242));
+        assert_eq!(kind.trade_index, Some(9));
+        assert_eq!(kind.id.map(|u| u.to_string()).as_deref(), Some(order_id));
+        assert!(matches!(kind.action, Action::Dispute));
+        assert!(kind.payload.is_none(), "Dispute payload must be None");
+        // The rumor is authored by the trade key: that is the pubkey the daemon
+        // addresses its reply to, and the key open_dispute correlates on.
+        assert_eq!(unwrapped.sender, trade_keys.public_key());
+    }
+
     /// #215 handshake contract: a RestoreSession carries no payload (the daemon
     /// rejects anything else in `MessageKind::verify`), its action is
     /// `RestoreSession`, and the rumor is authored by the trade key — the

--- a/rust/src/mostro/pending.rs
+++ b/rust/src/mostro/pending.rs
@@ -108,14 +108,18 @@ pub(crate) enum PendingRequestKind {
         /// purpose so a genuine late acceptance still reconciles, and a retry
         /// must not undo that: a reply echoing one of these is still ours,
         /// even though this record now owns the key (PR #275 review).
+        ///
+        /// The list is not capped. Every entry is still answerable — the
+        /// daemon may accept any attempt it received — and dropping one turns
+        /// its acceptance back into a bare status update, the disputed trade
+        /// with no dispute record this whole change set exists to remove. The
+        /// list only grows through user-driven retries, each gated by a 10 s
+        /// timeout, and the whole record is purged when the trade's
+        /// subscription ends, so eight bytes per retry is not worth trading
+        /// that correctness for.
         superseded: Vec<u64>,
     },
 }
-
-/// How many superseded open-dispute nonces one trade key keeps. Every entry is
-/// a retry the user drove after a 10 s timeout, so the bound is generous; it
-/// exists only so a pathological retry loop cannot grow the record without end.
-const MAX_SUPERSEDED_DISPUTE_NONCES: usize = 8;
 
 /// What a `DisputeInitiatedByYou` turned out to be for this trade key.
 pub(crate) enum DisputeMatch {
@@ -386,10 +390,6 @@ pub(crate) fn register_dispute_request(
                 ..
             }) => {
                 superseded.push(replaced);
-                let overflow = superseded
-                    .len()
-                    .saturating_sub(MAX_SUPERSEDED_DISPUTE_NONCES);
-                superseded.drain(..overflow);
                 superseded
             }
             _ => Vec::new(),
@@ -1158,12 +1158,16 @@ mod tests {
         assert!(!pending_requests().lock().unwrap().contains_key(key));
     }
 
-    /// The superseded list is bounded: a retry loop cannot grow one record
-    /// without end, and the oldest nonces are the ones dropped.
+    /// No retry count makes an attempt uncorrelatable. A capped list would
+    /// drop the oldest nonce, and the daemon's acceptance for that attempt
+    /// would then match nothing and fall through as a bare status update —
+    /// exactly the disputed-trade-without-a-dispute-record split state this
+    /// change set removes (PR #275 review). So every superseded nonce is
+    /// retained, and the oldest one still reconciles.
     #[tokio::test]
-    async fn superseded_dispute_nonces_are_bounded() {
-        let key = "test-dispute-supersede-bound-pubkey";
-        let total = MAX_SUPERSEDED_DISPUTE_NONCES as u64 + 3;
+    async fn every_superseded_dispute_nonce_stays_answerable() {
+        let key = "test-dispute-supersede-retention-pubkey";
+        let total = 12u64;
         for nonce in 1..=total {
             let _rx = register_dispute_request(key.to_string(), nonce, 1);
             detach_request_waiter(key, nonce);
@@ -1174,12 +1178,22 @@ mod tests {
             let PendingRequestKind::Dispute { superseded } = &map.get(key).unwrap().kind else {
                 panic!("must be a dispute record");
             };
-            assert_eq!(superseded.len(), MAX_SUPERSEDED_DISPUTE_NONCES);
-            assert_eq!(
-                superseded.first(),
-                Some(&(total - MAX_SUPERSEDED_DISPUTE_NONCES as u64))
-            );
+            assert_eq!(superseded.len() as u64, total - 1);
+            assert_eq!(superseded.first(), Some(&1));
             assert_eq!(superseded.last(), Some(&(total - 1)));
+        }
+
+        // The very first attempt, superseded eleven times over, is still ours.
+        assert!(matches!(
+            take_matching_dispute(key, Some(1)),
+            Some(DisputeMatch::Late)
+        ));
+        // The live record survives it, waiter attached, as for any other
+        // superseded match.
+        {
+            let map = pending_requests().lock().unwrap();
+            let entry = map.get(key).expect("the live record must survive");
+            assert_eq!(entry.request_id, total);
         }
 
         purge_pending_request(key);

--- a/rust/src/mostro/pending.rs
+++ b/rust/src/mostro/pending.rs
@@ -41,6 +41,11 @@ pub(crate) enum DaemonReply {
     /// update processed by the per-action arms; the caller only needs the
     /// unblock, so no data travels with it.
     Acknowledged,
+    /// Daemon accepted the dispute and assigned it a UUID. That id — not a
+    /// locally minted one — is what the solver and the daemon's Kind 38386
+    /// dispute event refer to, so it travels with the reply. `None` when the
+    /// acceptance carried no dispute payload.
+    DisputeAccepted { dispute_id: Option<String> },
     /// Daemon rejected the request with a CantDo reason.
     Rejected { reason: String, message: String },
     /// Daemon replied to a RestoreSession with the user's active trades and
@@ -96,6 +101,8 @@ pub(crate) enum PendingRequestKind {
     /// by trade pubkey, not request_id (the RestoreSession message carries
     /// no request_id — see mostro-core Message::new_restore).
     Restore,
+    /// An open-dispute awaiting the daemon's `DisputeInitiatedByYou`.
+    Dispute,
 }
 
 /// Everything one outgoing daemon request needs tracked until its reply is
@@ -297,6 +304,53 @@ pub(crate) fn take_matching_add_invoice(
         }
         _ => None,
     }
+}
+
+/// Remove and return the pending request for `trade_pubkey_hex` only when it
+/// is a `Dispute` and `got` echoes its nonce. Like an add-invoice, the
+/// consumed message is also a status update, so it still flows through the
+/// per-action arms (see `dispatch_mostro_message`).
+pub(crate) fn take_matching_dispute(
+    trade_pubkey_hex: &str,
+    got: Option<u64>,
+) -> Option<PendingRequest> {
+    let mut map = pending_requests().lock().ok()?;
+    match map.get(trade_pubkey_hex) {
+        Some(p)
+            if request_id_matches(p.request_id, got)
+                && matches!(p.kind, PendingRequestKind::Dispute) =>
+        {
+            map.remove(trade_pubkey_hex)
+        }
+        _ => None,
+    }
+}
+
+/// Register an open-dispute as the pending request for `trade_pubkey_hex` and
+/// return the channel its reply arrives on.
+///
+/// Lives here because the pending map and its nonce gate are this module's;
+/// `disputes::open_dispute` drives the publish and the wait, and cleans up
+/// through [`remove_pending_request`] (publish failed) or
+/// [`detach_request_waiter`] (timed out).
+pub(crate) fn register_dispute_request(
+    trade_pubkey_hex: String,
+    request_id: u64,
+    trade_index: u32,
+) -> tokio::sync::oneshot::Receiver<Wake> {
+    let (tx, rx) = tokio::sync::oneshot::channel::<Wake>();
+    if let Ok(mut map) = pending_requests().lock() {
+        map.insert(
+            trade_pubkey_hex,
+            PendingRequest {
+                request_id,
+                trade_index,
+                kind: PendingRequestKind::Dispute,
+                tx: Some(tx),
+            },
+        );
+    }
+    rx
 }
 
 /// Classify the daemon's first reply to a take into a [`DaemonReply`].

--- a/rust/src/mostro/pending.rs
+++ b/rust/src/mostro/pending.rs
@@ -112,11 +112,16 @@ pub(crate) enum PendingRequestKind {
         /// The list is not capped. Every entry is still answerable — the
         /// daemon may accept any attempt it received — and dropping one turns
         /// its acceptance back into a bare status update, the disputed trade
-        /// with no dispute record this whole change set exists to remove. The
-        /// list only grows through user-driven retries, each gated by a 10 s
-        /// timeout, and the whole record is purged when the trade's
-        /// subscription ends, so eight bytes per retry is not worth trading
-        /// that correctness for.
+        /// with no dispute record this whole change set exists to remove. It
+        /// only grows through user-driven retries, each gated by a 10 s
+        /// timeout, and shrinks as each nonce is reconciled, so eight bytes
+        /// per outstanding attempt is not worth trading that correctness for.
+        ///
+        /// The record's own lifetime is not bounded in the common case:
+        /// [`purge_pending_request`] runs only when a per-trade daemon
+        /// subscription exits, and `open_dispute` starts none — a dispute on
+        /// a trade loaded from the database after a restart is answered over
+        /// the global feed — so the record can live for the whole process.
         superseded: Vec<u64>,
     },
 }
@@ -343,14 +348,17 @@ pub(crate) fn take_matching_dispute(
     got: Option<u64>,
 ) -> Option<DisputeMatch> {
     let mut map = pending_requests().lock().ok()?;
-    let entry = map.get(trade_pubkey_hex)?;
-    let PendingRequestKind::Dispute { superseded } = &entry.kind else {
+    let entry = map.get_mut(trade_pubkey_hex)?;
+    let PendingRequestKind::Dispute { superseded } = &mut entry.kind else {
         return None;
     };
     // An attempt this key's current record replaced: its caller stopped
     // waiting long ago, but the acceptance is real and still ours. Leave the
-    // live record in place — its own reply may yet arrive.
-    if got.is_some_and(|id| superseded.contains(&id)) {
+    // live record in place — its own reply may yet arrive — and drop the
+    // nonce now that it is answered, so the list only ever names attempts
+    // still outstanding.
+    if let Some(answered) = got.and_then(|id| superseded.iter().position(|n| *n == id)) {
+        superseded.remove(answered);
         return Some(DisputeMatch::Late);
     }
     if !request_id_matches(entry.request_id, got) {
@@ -1189,11 +1197,17 @@ mod tests {
             Some(DisputeMatch::Late)
         ));
         // The live record survives it, waiter attached, as for any other
-        // superseded match.
+        // superseded match — and the answered nonce is gone, so the list
+        // never claims an attempt that has already been reconciled.
         {
             let map = pending_requests().lock().unwrap();
             let entry = map.get(key).expect("the live record must survive");
             assert_eq!(entry.request_id, total);
+            let PendingRequestKind::Dispute { superseded } = &entry.kind else {
+                panic!("must be a dispute record");
+            };
+            assert!(!superseded.contains(&1), "the answered nonce must be dropped");
+            assert_eq!(superseded.len() as u64, total - 2);
         }
 
         purge_pending_request(key);

--- a/rust/src/mostro/pending.rs
+++ b/rust/src/mostro/pending.rs
@@ -102,7 +102,31 @@ pub(crate) enum PendingRequestKind {
     /// no request_id — see mostro-core Message::new_restore).
     Restore,
     /// An open-dispute awaiting the daemon's `DisputeInitiatedByYou`.
-    Dispute,
+    Dispute {
+        /// Nonces of earlier open attempts on this same trade key that timed
+        /// out and were then replaced by this one. Their records were kept on
+        /// purpose so a genuine late acceptance still reconciles, and a retry
+        /// must not undo that: a reply echoing one of these is still ours,
+        /// even though this record now owns the key (PR #275 review).
+        superseded: Vec<u64>,
+    },
+}
+
+/// How many superseded open-dispute nonces one trade key keeps. Every entry is
+/// a retry the user drove after a 10 s timeout, so the bound is generous; it
+/// exists only so a pathological retry loop cannot grow the record without end.
+const MAX_SUPERSEDED_DISPUTE_NONCES: usize = 8;
+
+/// What a `DisputeInitiatedByYou` turned out to be for this trade key.
+pub(crate) enum DisputeMatch {
+    /// The reply resolves the live attempt and its caller is still waiting.
+    /// The record is consumed; the acceptance goes down this channel.
+    Waiting(tokio::sync::oneshot::Sender<Wake>),
+    /// The reply is genuinely ours but nobody is listening — the attempt timed
+    /// out. Either the live record, now consumed, or an earlier attempt a retry
+    /// superseded, in which case the retry's record stays registered for its
+    /// own reply. Reconcile it as a late acceptance.
+    Late,
 }
 
 /// Everything one outgoing daemon request needs tracked until its reply is
@@ -313,16 +337,24 @@ pub(crate) fn take_matching_add_invoice(
 pub(crate) fn take_matching_dispute(
     trade_pubkey_hex: &str,
     got: Option<u64>,
-) -> Option<PendingRequest> {
+) -> Option<DisputeMatch> {
     let mut map = pending_requests().lock().ok()?;
-    match map.get(trade_pubkey_hex) {
-        Some(p)
-            if request_id_matches(p.request_id, got)
-                && matches!(p.kind, PendingRequestKind::Dispute) =>
-        {
-            map.remove(trade_pubkey_hex)
-        }
-        _ => None,
+    let entry = map.get(trade_pubkey_hex)?;
+    let PendingRequestKind::Dispute { superseded } = &entry.kind else {
+        return None;
+    };
+    // An attempt this key's current record replaced: its caller stopped
+    // waiting long ago, but the acceptance is real and still ours. Leave the
+    // live record in place — its own reply may yet arrive.
+    if got.is_some_and(|id| superseded.contains(&id)) {
+        return Some(DisputeMatch::Late);
+    }
+    if !request_id_matches(entry.request_id, got) {
+        return None;
+    }
+    match map.remove(trade_pubkey_hex)?.tx {
+        Some(tx) => Some(DisputeMatch::Waiting(tx)),
+        None => Some(DisputeMatch::Late),
     }
 }
 
@@ -331,8 +363,15 @@ pub(crate) fn take_matching_dispute(
 ///
 /// Lives here because the pending map and its nonce gate are this module's;
 /// `disputes::open_dispute` drives the publish and the wait, and cleans up
-/// through [`remove_pending_request`] (publish failed) or
+/// through [`roll_back_dispute_request`] (publish failed) or
 /// [`detach_request_waiter`] (timed out).
+///
+/// A retry after a timeout takes the key over from the attempt it replaces,
+/// but must not erase it: that record was deliberately kept so a genuine late
+/// acceptance still reconciles instead of falling through as a bare status
+/// update (PR #275 review). Its nonce — and whatever it had already inherited —
+/// travels into the new record's `superseded` list, so both attempts stay
+/// answerable while only the newest owns the waiter.
 pub(crate) fn register_dispute_request(
     trade_pubkey_hex: String,
     request_id: u64,
@@ -340,17 +379,62 @@ pub(crate) fn register_dispute_request(
 ) -> tokio::sync::oneshot::Receiver<Wake> {
     let (tx, rx) = tokio::sync::oneshot::channel::<Wake>();
     if let Ok(mut map) = pending_requests().lock() {
+        let superseded = match map.remove(&trade_pubkey_hex) {
+            Some(PendingRequest {
+                request_id: replaced,
+                kind: PendingRequestKind::Dispute { mut superseded },
+                ..
+            }) => {
+                superseded.push(replaced);
+                let overflow = superseded
+                    .len()
+                    .saturating_sub(MAX_SUPERSEDED_DISPUTE_NONCES);
+                superseded.drain(..overflow);
+                superseded
+            }
+            _ => Vec::new(),
+        };
         map.insert(
             trade_pubkey_hex,
             PendingRequest {
                 request_id,
                 trade_index,
-                kind: PendingRequestKind::Dispute,
+                kind: PendingRequestKind::Dispute { superseded },
                 tx: Some(tx),
             },
         );
     }
     rx
+}
+
+/// Undo an open-dispute registration whose publish failed — the daemon never
+/// saw the attempt, so nothing can answer it.
+///
+/// Unlike [`remove_pending_request`], the record survives when it still carries
+/// superseded nonces: an earlier timed-out attempt on this key is still
+/// answerable, and a retry that never reached the wire must not take it down
+/// with it. The most recent superseded nonce becomes the record's own again,
+/// waiterless, exactly as its own timeout had left it.
+pub(crate) fn roll_back_dispute_request(trade_pubkey_hex: &str, request_id: u64) {
+    let Ok(mut map) = pending_requests().lock() else {
+        return;
+    };
+    let Some(entry) = map.get_mut(trade_pubkey_hex) else {
+        return;
+    };
+    if entry.request_id != request_id {
+        return;
+    }
+    let restored = match &mut entry.kind {
+        PendingRequestKind::Dispute { superseded } => superseded.pop(),
+        _ => None,
+    };
+    if let Some(previous) = restored {
+        entry.request_id = previous;
+        entry.tx = None;
+        return;
+    }
+    map.remove(trade_pubkey_hex);
 }
 
 /// Classify the daemon's first reply to a take into a [`DaemonReply`].
@@ -998,5 +1082,106 @@ mod tests {
 
         // Clean up the leftover non-restore record so we don't leak global state.
         remove_pending_request(&other_key, 9);
+    }
+
+    /// #202 / PR #275: a retry after a timeout takes the trade key over, but
+    /// the attempt it replaces stays answerable. Before this, the retry's
+    /// `register_dispute_request` overwrote the timed-out record outright, so a
+    /// genuine late acceptance for the first attempt matched nothing and fell
+    /// through as a bare status update — a trade moved to Dispute with no
+    /// dispute record, the split state this whole change set exists to remove.
+    #[tokio::test]
+    async fn a_dispute_retry_keeps_the_timed_out_attempt_answerable() {
+        let key = "test-dispute-retry-supersede-pubkey";
+        let _rx_a = register_dispute_request(key.to_string(), 81, 4);
+
+        // A times out: the waiter detaches, the record survives.
+        detach_request_waiter(key, 81);
+
+        // The user retries; B takes the key over.
+        let _rx_b = register_dispute_request(key.to_string(), 82, 4);
+        assert!(matches!(
+            pending_requests().lock().unwrap().get(key).unwrap().kind,
+            PendingRequestKind::Dispute { .. }
+        ));
+
+        // The daemon answers A. It is nobody's live reply, but it is ours...
+        assert!(matches!(
+            take_matching_dispute(key, Some(81)),
+            Some(DisputeMatch::Late)
+        ));
+        // ...and B stays registered with its waiter attached.
+        {
+            let map = pending_requests().lock().unwrap();
+            let entry = map.get(key).expect("the retry's record must survive");
+            assert_eq!(entry.request_id, 82);
+            assert!(entry.tx.is_some());
+        }
+
+        // B's own reply still resolves it normally.
+        assert!(matches!(
+            take_matching_dispute(key, Some(82)),
+            Some(DisputeMatch::Waiting(_))
+        ));
+        assert!(!pending_requests().lock().unwrap().contains_key(key));
+    }
+
+    /// A retry whose publish fails must roll back only itself: the timed-out
+    /// attempt it took the key from is still answerable, and taking the whole
+    /// record down would lose that late acceptance.
+    #[tokio::test]
+    async fn a_failed_dispute_retry_restores_the_attempt_it_replaced() {
+        let key = "test-dispute-rollback-pubkey";
+        let _rx_a = register_dispute_request(key.to_string(), 91, 2);
+        detach_request_waiter(key, 91);
+        let _rx_b = register_dispute_request(key.to_string(), 92, 2);
+
+        // B never reaches the wire.
+        roll_back_dispute_request(key, 92);
+        {
+            let map = pending_requests().lock().unwrap();
+            let entry = map.get(key).expect("A must be restored, not dropped");
+            assert_eq!(entry.request_id, 91);
+            assert!(entry.tx.is_none(), "A had already timed out");
+        }
+
+        // A's late acceptance still reconciles...
+        assert!(matches!(
+            take_matching_dispute(key, Some(91)),
+            Some(DisputeMatch::Late)
+        ));
+        assert!(!pending_requests().lock().unwrap().contains_key(key));
+
+        // ...while a first attempt whose publish fails leaves nothing behind.
+        let _rx_c = register_dispute_request(key.to_string(), 93, 2);
+        roll_back_dispute_request(key, 93);
+        assert!(!pending_requests().lock().unwrap().contains_key(key));
+    }
+
+    /// The superseded list is bounded: a retry loop cannot grow one record
+    /// without end, and the oldest nonces are the ones dropped.
+    #[tokio::test]
+    async fn superseded_dispute_nonces_are_bounded() {
+        let key = "test-dispute-supersede-bound-pubkey";
+        let total = MAX_SUPERSEDED_DISPUTE_NONCES as u64 + 3;
+        for nonce in 1..=total {
+            let _rx = register_dispute_request(key.to_string(), nonce, 1);
+            detach_request_waiter(key, nonce);
+        }
+
+        {
+            let map = pending_requests().lock().unwrap();
+            let PendingRequestKind::Dispute { superseded } = &map.get(key).unwrap().kind else {
+                panic!("must be a dispute record");
+            };
+            assert_eq!(superseded.len(), MAX_SUPERSEDED_DISPUTE_NONCES);
+            assert_eq!(
+                superseded.first(),
+                Some(&(total - MAX_SUPERSEDED_DISPUTE_NONCES as u64))
+            );
+            assert_eq!(superseded.last(), Some(&(total - 1)));
+        }
+
+        purge_pending_request(key);
     }
 }

--- a/specs/004-mostro-p2p-client/contracts/disputes.md
+++ b/specs/004-mostro-p2p-client/contracts/disputes.md
@@ -18,10 +18,56 @@ answers anything earlier with `CantDo`, so the status already held locally is
 checked before publishing. `InProgress` passes: it is the public bucket, i.e. a
 trade whose real state is unknown, and that call belongs to the daemon.
 
-**Side effects**: Sends Dispute action to Mostro daemon via NIP-44 (Kind 14).
-Creates local Dispute record. Updates trade step to `Disputed`.
+The open is **single-flight per trade**: a second call while one is still
+awaiting the daemon is refused. Both would derive the same trade key, so the
+second registration would replace the first one's pending record and strand its
+caller on a timeout the daemon never caused.
 
-**Errors**: `TradeNotDisputable`, `DisputeAlreadyOpen`, `ProtocolError`.
+**Side effects**: Sends the Dispute action to the Mostro daemon via NIP-44
+(Kind 14), carrying a random u64 `request_id` nonce, and waits up to 10 s for
+the reply the daemon echoes it in — `DisputeInitiatedByYou` on acceptance,
+`CantDo` on rejection. Only the correlated acceptance creates the local
+Dispute record; that reply also carries the daemon's dispute UUID, which is
+the id the solver and the daemon's Kind 38386 dispute event refer to, so the
+record is stored under it. The reply doubles as the status update that moves
+the trade to `Disputed` and is processed normally. On rejection or timeout
+**the call persists nothing** — a publish is not an acceptance, and the caller
+surfaces the error instead of showing a dispute that does not exist.
+
+An acceptance **without** that dispute id is malformed and fails closed: it
+persists nothing and reports `ProtocolError`. `Dispute.id` is contractually the
+daemon's, and a locally minted id would be indistinguishable from a real one
+while being wrong. A conforming daemon always sends it, so this is a
+protocol-violation guard rather than a routine path.
+
+An acceptance that arrives **after** the caller timed out is still reconciled:
+the daemon did open the dispute, and its reply moves the trade to `Disputed`
+either way, so the record is created then (unread, and without the reason,
+which went with the timed-out call). Suppressing it would leave a disputed
+trade with no dispute to open and no solver to reach. The same missing-id guard
+applies.
+
+A solver can be assigned inside that same window, in which case the record
+already exists as the peer-style placeholder `admin-took-dispute` writes
+(`InReview`, not ours, no reason, solver known, locally minted id). The
+reconciliation **claims** it — daemon id and initiator flag replace the local
+ones, solver and `InReview` survive — because the correlated acceptance proves
+the dispute is ours. Any other existing record (a retry that succeeded, a
+resolved dispute) is left untouched.
+
+The local status check and the reply correlation are two layers of the same
+concern: the check keeps most rejections off the wire, and the correlation
+reconciles the ones that still come back (issues #203 and #202).
+
+The nonce gate is the dispatcher's, shared with the order requests — see
+[orders.md](orders.md) "Daemon confirmation & request correlation".
+
+Note: the daemon replies `CantDo` only for `MostroCantDo` causes. A duplicate
+dispute or a daemon-side DB failure is an internal error it merely logs, so
+those surface as `NoDaemonResponse` rather than a precise reason.
+
+**Errors**: `TradeNotDisputable`, `DisputeAlreadyOpen`, `ProtocolError`,
+`NoDaemonResponse`, plus daemon `CantDo` reasons passed through as errors.
 
 ---
 

--- a/specs/004-mostro-p2p-client/contracts/disputes.md
+++ b/specs/004-mostro-p2p-client/contracts/disputes.md
@@ -68,8 +68,12 @@ restores the attempt it replaced.
 No retry count changes this: **every** superseded nonce is retained, because
 every one of them is still answerable and dropping one turns its acceptance
 back into that same bare status update. The list only grows through retries the
-user drives, each gated by the 10 s timeout, and the whole record is purged when
-the trade's subscription ends.
+user drives, each gated by the 10 s timeout, and a nonce leaves it as soon as
+its reply is reconciled. Nothing purges the record itself in the common case:
+that only happens when a per-trade daemon subscription exits, and opening a
+dispute starts none — a dispute on a trade loaded from the database after a
+restart is answered over the global feed — so the record can live for the whole
+process.
 
 The local status check and the reply correlation are two layers of the same
 concern: the check keeps most rejections off the wire, and the correlation
@@ -84,6 +88,9 @@ those surface as `NoDaemonResponse` rather than a precise reason.
 
 **Errors**: `TradeNotDisputable`, `DisputeAlreadyOpen`, `ProtocolError`,
 `NoDaemonResponse`, plus daemon `CantDo` reasons passed through as errors.
+`DisputeAlreadyOpen` covers both refusals — a record already exists, or an open
+for this trade is still in flight — and Dart maps the marker to one localized
+message (`localizedDaemonError`).
 
 ---
 

--- a/specs/004-mostro-p2p-client/contracts/disputes.md
+++ b/specs/004-mostro-p2p-client/contracts/disputes.md
@@ -55,6 +55,17 @@ ones, solver and `InReview` survive — because the correlated acceptance proves
 the dispute is ours. Any other existing record (a retry that succeeded, a
 resolved dispute) is left untouched.
 
+Retrying after a timeout does not close that window. The retry derives the same
+trade key and takes the pending record over, but the attempt it replaces stays
+**answerable**: its nonce travels into the new record and a reply echoing it is
+still reconciled as a late acceptance, leaving the retry registered for its own
+reply. Without that, the daemon could accept the first attempt while the client
+had already discarded every way to recognize the answer — the trade would move
+to `Disputed` with no dispute record, the split state this whole change set
+exists to remove. A retry whose publish fails rolls back only itself and
+restores the attempt it replaced. The list of superseded nonces is bounded, so
+a retry loop cannot grow the record without end.
+
 The local status check and the reply correlation are two layers of the same
 concern: the check keeps most rejections off the wire, and the correlation
 reconciles the ones that still come back (issues #203 and #202).

--- a/specs/004-mostro-p2p-client/contracts/disputes.md
+++ b/specs/004-mostro-p2p-client/contracts/disputes.md
@@ -63,8 +63,13 @@ reply. Without that, the daemon could accept the first attempt while the client
 had already discarded every way to recognize the answer — the trade would move
 to `Disputed` with no dispute record, the split state this whole change set
 exists to remove. A retry whose publish fails rolls back only itself and
-restores the attempt it replaced. The list of superseded nonces is bounded, so
-a retry loop cannot grow the record without end.
+restores the attempt it replaced.
+
+No retry count changes this: **every** superseded nonce is retained, because
+every one of them is still answerable and dropping one turns its acceptance
+back into that same bare status update. The list only grows through retries the
+user drives, each gated by the 10 s timeout, and the whole record is purged when
+the trade's subscription ends.
 
 The local status check and the reply correlation are two layers of the same
 concern: the check keeps most rejections off the wire, and the correlation

--- a/specs/004-mostro-p2p-client/contracts/orders.md
+++ b/specs/004-mostro-p2p-client/contracts/orders.md
@@ -8,13 +8,14 @@ Mostro daemon via Kind 38383 Nostr events and cached locally.
 ### Daemon confirmation & request correlation
 
 Every request that expects a daemon reply (`create_order`, `take_order`,
-`send_invoice`) carries a random u64 `request_id` nonce. The daemon echoes
+`send_invoice`, and `open_dispute` from the [disputes](disputes.md) API)
+carries a random u64 `request_id` nonce. The daemon echoes
 it in its reply (success or `CantDo`), and **only a reply echoing the exact
 nonce may resolve or consume the pending request** — stale events replayed
 by relays carry a different (or no) `request_id` and touch nothing. Each
 call waits up to 10 s; on timeout it returns `NoDaemonResponse` and nothing
 is persisted. A genuine late reply is still reconciled where meaningful
-(create), or logged and dropped (take / add-invoice).
+(create), or logged and dropped (take / add-invoice / dispute).
 
 ## Functions
 

--- a/specs/004-mostro-p2p-client/contracts/orders.md
+++ b/specs/004-mostro-p2p-client/contracts/orders.md
@@ -14,8 +14,24 @@ it in its reply (success or `CantDo`), and **only a reply echoing the exact
 nonce may resolve or consume the pending request** — stale events replayed
 by relays carry a different (or no) `request_id` and touch nothing. Each
 call waits up to 10 s; on timeout it returns `NoDaemonResponse` and nothing
-is persisted. A genuine late reply is still reconciled where meaningful
-(create), or logged and dropped (take / add-invoice / dispute).
+is persisted.
+
+What happens to a genuine reply that arrives **after** that timeout depends on
+the request. The pending record survives the timeout in every case — only its
+waiter detaches — so the late reply is still recognized as ours rather than as
+a stale replay:
+
+- **create**: reconciled — the daemon UUID is bound to the attempt's trade
+  index, and the Kind 38383 fingerprint path restores maker ownership.
+- **take / add-invoice**: logged and dropped; the reply's own status update is
+  processed by the per-action arms as usual.
+- **dispute**: reconciled — `record_late_acceptance` persists the accepted
+  dispute under the daemon-assigned id (unread, and without the reason, which
+  went with the timed-out call). So a `NoDaemonResponse` from `open_dispute` is
+  **not** proof that no dispute can appear for that trade later. Retrying after
+  the timeout does not break this: the retry takes the trade key over but
+  carries the superseded attempt's nonce forward, so a reply to either one is
+  still correlated. See [disputes.md](disputes.md) for the full behavior.
 
 ## Functions
 

--- a/specs/004-mostro-p2p-client/contracts/orders.md
+++ b/specs/004-mostro-p2p-client/contracts/orders.md
@@ -30,8 +30,8 @@ a stale replay:
   went with the timed-out call). So a `NoDaemonResponse` from `open_dispute` is
   **not** proof that no dispute can appear for that trade later. Retrying after
   the timeout does not break this: the retry takes the trade key over but
-  carries the superseded attempt's nonce forward, so a reply to either one is
-  still correlated. See [disputes.md](disputes.md) for the full behavior.
+  carries every superseded attempt's nonce forward, so a reply to any of them
+  is still correlated. See [disputes.md](disputes.md) for the full behavior.
 
 ## Functions
 

--- a/specs/004-mostro-p2p-client/data-model.md
+++ b/specs/004-mostro-p2p-client/data-model.md
@@ -191,7 +191,7 @@ An exception flow on an active trade.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| id | UUID | Primary key |
+| id | UUID | Primary key — the daemon's dispute id when we opened it (see below) |
 | trade_id | UUID | FK → Trade |
 | initiated_by | Enum | `Me` or `Counterparty` |
 | reason | String? | Optional reason text |
@@ -204,6 +204,13 @@ An exception flow on an active trade.
 - A dispute can only be opened on a trade with `current_step` between
   `PaymentLocked` and `AwaitingRelease`/`AwaitingFiat`.
 - Only one open dispute per trade.
+
+**On `id`**: for a dispute we opened, this is the UUID the daemon assigned and
+returned in its acceptance — the same id its Kind 38386 dispute event and the
+solver use. A record created for a **peer-opened** dispute (built from
+`admin-took-dispute`, which is the first the counterparty hears of it) still
+gets a locally minted UUID, so the two sides currently know the same dispute
+under different ids.
 
 ---
 

--- a/test/core/daemon_errors_test.dart
+++ b/test/core/daemon_errors_test.dart
@@ -53,6 +53,28 @@ void main() {
     );
   });
 
+  /// PR #275 review (Catrya): both `DisputeAlreadyOpen` refusals — the record
+  /// that already exists and the single-flight guard this PR adds — reach the
+  /// UI as the same marker and must not fall through to the generic failure.
+  test('maps both DisputeAlreadyOpen refusals', () {
+    expect(
+      localizedDaemonError(
+        l10n,
+        'DisputeAlreadyOpen: dispute already exists for trade abc',
+        fallback: 'x',
+      ),
+      l10n.disputeAlreadyOpen,
+    );
+    expect(
+      localizedDaemonError(
+        l10n,
+        'DisputeAlreadyOpen: an open_dispute for trade abc is already in flight',
+        fallback: 'x',
+      ),
+      l10n.disputeAlreadyOpen,
+    );
+  });
+
   test('maps timeout and storage markers, and falls back otherwise', () {
     expect(
       localizedDaemonError(l10n, 'NoDaemonResponse', fallback: 'x'),


### PR DESCRIPTION
Closes #202

## Problem

`open_dispute` treated a successful relay publish as a successful dispute: it persisted `Dispute { status: Open }` right after publishing and never registered a pending-request waiter. The `Dispute` message also carried no `request_id`, so the daemon's `CantDo` rejection matched nothing in the dispatcher and was dropped (`no matching pending request, ignoring event`). The dispute stayed locally Open and the UI navigated to the dispute detail — a false success.

## Fix

The Dispute message now carries a `request_id` nonce, which the daemon echoes in both `DisputeInitiatedByYou` and `CantDo` (verified in mostro `src/app/dispute.rs` and `src/app.rs`). `open_dispute` registers a pending record before publishing and waits up to 10 s, exactly like `create_order` / `take_order` / `send_invoice`. It persists only on a correlated acceptance; rejection and timeout return an error and write nothing.

The acceptance also carries the daemon's dispute UUID — the id its Kind 38386 event and the solver refer to — so the record is stored under it instead of a locally minted one.

No Dart changes: `_openDispute` already showed a localized SnackBar and rethrew without navigating, so propagating the error was enough.

## Notes

The daemon replies `CantDo` only for `MostroCantDo` causes. A duplicate dispute or a daemon-side DB failure is an internal error it merely logs, so those surface as `NoDaemonResponse` rather than a precise reason.

## Verification

`cargo build`, `cargo clippy --locked -- -D warnings`, `cargo test` (238 pass), `flutter analyze`, `flutter test` (195 pass). `frb-generate.sh` produces no drift — the public bridge surface is unchanged.

Tests cover the correlation layer, where the bug was: the kind/nonce gates of `take_matching_dispute`, a `CantDo` reaching the waiting caller through the dispatcher's lookup, and the dispute-id extraction. The end-to-end path needs a live daemon — pending manual check with the #203 repro.

## Follow-ups (not in this PR)

- A record created for a peer-opened dispute still gets a local UUID, so the two sides know the same dispute under different ids. Documented in `data-model.md`.
- `fiat_sent`, `release` and `cancel` still send no nonce and await no reply — the same false-success shape as this issue, in other actions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dispute requests now wait for daemon confirmation and use the daemon-provided dispute ID.
  * Concurrent dispute attempts for the same trade are rejected.
  * Late acceptance responses can reconcile disputes after a timeout.

* **Bug Fixes**
  * Improved handling of rejections, timeouts, malformed replies, publish failures, and duplicate disputes.
  * Prevented disputes from being recorded unless acceptance is confirmed.
  * Improved matching of dispute responses to their originating requests.

* **Documentation**
  * Clarified request correlation, timeouts, dispute identifiers, and peer-opened disputes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->