### PR TITLE
fix(order): back from invoice screens lands on trade detail

### DIFF
--- a/lib/features/order/screens/add_lightning_invoice_screen.dart
+++ b/lib/features/order/screens/add_lightning_invoice_screen.dart
@@ -66,6 +66,49 @@ class _AddLightningInvoiceScreenState
     return true;
   }
 
+  /// Cancel button = cancel the trade itself (confirmed via dialog), not
+  /// just leave the screen — going back is what lands on trade detail (#268).
+  Future<void> _cancelOrder() async {
+    final l10n = AppLocalizations.of(context);
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(l10n.cancelTradeDialogTitle),
+        content: Text(l10n.cancelTradeDialogContent),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: Text(l10n.noButtonLabel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: Text(l10n.yesCancelButtonLabel),
+          ),
+        ],
+      ),
+    );
+    if (!mounted || confirmed != true) return;
+    try {
+      await orders_api.cancelOrder(orderId: widget.orderId);
+      if (!mounted) return;
+      _navigated = true;
+      refreshTrades(ref);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(l10n.cancelRequestSent)),
+      );
+      context.go(AppRoute.home);
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            localizedDaemonError(l10n, e, fallback: l10n.cancelRequestFailed),
+          ),
+        ),
+      );
+    }
+  }
+
   Future<void> _submit(WidgetRef ref) async {
     if (_submitting) return;
     final input = _invoiceController.text.trim();
@@ -271,7 +314,7 @@ class _AddLightningInvoiceScreenState
               children: [
                 Expanded(
                   child: TextButton(
-                    onPressed: () => context.pop(),
+                    onPressed: _cancelOrder,
                     child: Text(
                       l10n.cancel,
                       style: TextStyle(color: colors?.textSecondary),

--- a/lib/features/order/screens/add_lightning_invoice_screen.dart
+++ b/lib/features/order/screens/add_lightning_invoice_screen.dart
@@ -38,6 +38,8 @@ class _AddLightningInvoiceScreenState
     extends ConsumerState<AddLightningInvoiceScreen> {
   final _invoiceController = TextEditingController();
   bool _submitting = false;
+  /// `true` while a protocol cancel is in flight — blocks re-entry and submit.
+  bool _canceling = false;
   /// `true` when NWC is connected but generation failed → show manual form.
   bool _manualMode = false;
   /// One-shot guard so we don't navigate twice as further updates stream in.
@@ -69,6 +71,9 @@ class _AddLightningInvoiceScreenState
   /// Cancel button = cancel the trade itself (confirmed via dialog), not
   /// just leave the screen — going back is what lands on trade detail (#268).
   Future<void> _cancelOrder() async {
+    // Serialize state-changing requests: no cancel while a submit or another
+    // cancel is in flight (review round 1).
+    if (_submitting || _canceling) return;
     final l10n = AppLocalizations.of(context);
     final confirmed = await showDialog<bool>(
       context: context,
@@ -88,6 +93,7 @@ class _AddLightningInvoiceScreenState
       ),
     );
     if (!mounted || confirmed != true) return;
+    setState(() => _canceling = true);
     try {
       await orders_api.cancelOrder(orderId: widget.orderId);
       if (!mounted) return;
@@ -106,11 +112,13 @@ class _AddLightningInvoiceScreenState
           ),
         ),
       );
+    } finally {
+      if (mounted) setState(() => _canceling = false);
     }
   }
 
   Future<void> _submit(WidgetRef ref) async {
-    if (_submitting) return;
+    if (_submitting || _canceling) return;
     final input = _invoiceController.text.trim();
     // For Lightning Addresses, the sats amount must be resolved before sending —
     // the Rust side uses it to resolve the address. Bolt11 invoices encode
@@ -314,7 +322,8 @@ class _AddLightningInvoiceScreenState
               children: [
                 Expanded(
                   child: TextButton(
-                    onPressed: _cancelOrder,
+                    onPressed:
+                        (_submitting || _canceling) ? null : _cancelOrder,
                     child: Text(
                       l10n.cancel,
                       style: TextStyle(color: colors?.textSecondary),
@@ -324,7 +333,9 @@ class _AddLightningInvoiceScreenState
                 const SizedBox(width: AppSpacing.md),
                 Expanded(
                   child: FilledButton(
-                    onPressed: _isValid(ref) ? () => _submit(ref) : null,
+                    onPressed: (!_canceling && _isValid(ref))
+                        ? () => _submit(ref)
+                        : null,
                     style: FilledButton.styleFrom(
                       backgroundColor: green,
                       foregroundColor: Colors.black,

--- a/lib/features/order/screens/pay_lightning_invoice_screen.dart
+++ b/lib/features/order/screens/pay_lightning_invoice_screen.dart
@@ -35,6 +35,8 @@ class PayLightningInvoiceScreen extends ConsumerStatefulWidget {
 class _PayLightningInvoiceScreenState
     extends ConsumerState<PayLightningInvoiceScreen> {
   bool _waiting = false;
+  /// `true` while a protocol cancel is in flight — blocks re-entry.
+  bool _canceling = false;
   /// `true` when NWC is connected but payment failed → show QR fallback.
   bool _manualMode = false;
   /// One-shot guard so we don't navigate twice as further statuses stream in.
@@ -51,6 +53,8 @@ class _PayLightningInvoiceScreenState
   /// Cancel button = cancel the trade itself (confirmed via dialog), not
   /// just leave the screen — going back is what lands on trade detail (#268).
   Future<void> _cancelOrder() async {
+    // Serialize state-changing requests: one cancel at a time (review round 1).
+    if (_canceling) return;
     final l10n = AppLocalizations.of(context);
     final confirmed = await showDialog<bool>(
       context: context,
@@ -70,6 +74,7 @@ class _PayLightningInvoiceScreenState
       ),
     );
     if (!mounted || confirmed != true) return;
+    setState(() => _canceling = true);
     try {
       await orders_api.cancelOrder(orderId: widget.orderId);
       if (!mounted) return;
@@ -88,6 +93,8 @@ class _PayLightningInvoiceScreenState
           ),
         ),
       );
+    } finally {
+      if (mounted) setState(() => _canceling = false);
     }
   }
 
@@ -409,7 +416,7 @@ class _PayLightningInvoiceScreenState
                   SizedBox(
                     width: double.infinity,
                     child: OutlinedButton(
-                      onPressed: _cancelOrder,
+                      onPressed: _canceling ? null : _cancelOrder,
                       style: OutlinedButton.styleFrom(
                         foregroundColor:
                             colors?.destructiveRed ?? const Color(0xFFD84D4D),

--- a/lib/features/order/screens/pay_lightning_invoice_screen.dart
+++ b/lib/features/order/screens/pay_lightning_invoice_screen.dart
@@ -8,11 +8,13 @@ import 'package:url_launcher/url_launcher.dart';
 
 import 'package:mostro/core/app_routes.dart';
 import 'package:mostro/core/app_theme.dart';
+import 'package:mostro/core/daemon_errors.dart';
 import 'package:mostro/features/order/providers/trade_state_provider.dart';
 import 'package:mostro/features/settings/providers/nwc_provider.dart';
 import 'package:mostro/features/trades/providers/trades_providers.dart'
     show refreshTrades;
 import 'package:mostro/l10n/app_localizations.dart';
+import 'package:mostro/src/rust/api/orders.dart' as orders_api;
 import 'package:mostro/src/rust/api/types.dart' show OrderStatus, TradeUpdate;
 import 'package:mostro/shared/widgets/nwc_payment_widget.dart';
 
@@ -44,6 +46,49 @@ class _PayLightningInvoiceScreenState
   void _onPaymentDetected() {
     if (!mounted) return;
     setState(() => _waiting = true);
+  }
+
+  /// Cancel button = cancel the trade itself (confirmed via dialog), not
+  /// just leave the screen — going back is what lands on trade detail (#268).
+  Future<void> _cancelOrder() async {
+    final l10n = AppLocalizations.of(context);
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(l10n.cancelTradeDialogTitle),
+        content: Text(l10n.cancelTradeDialogContent),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: Text(l10n.noButtonLabel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: Text(l10n.yesCancelButtonLabel),
+          ),
+        ],
+      ),
+    );
+    if (!mounted || confirmed != true) return;
+    try {
+      await orders_api.cancelOrder(orderId: widget.orderId);
+      if (!mounted) return;
+      _navigated = true;
+      refreshTrades(ref);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(l10n.cancelRequestSent)),
+      );
+      context.go(AppRoute.home);
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            localizedDaemonError(l10n, e, fallback: l10n.cancelRequestFailed),
+          ),
+        ),
+      );
+    }
   }
 
   @override
@@ -364,7 +409,7 @@ class _PayLightningInvoiceScreenState
                   SizedBox(
                     width: double.infinity,
                     child: OutlinedButton(
-                      onPressed: () => context.pop(),
+                      onPressed: _cancelOrder,
                       style: OutlinedButton.styleFrom(
                         foregroundColor:
                             colors?.destructiveRed ?? const Color(0xFFD84D4D),

--- a/lib/features/order/screens/take_order_screen.dart
+++ b/lib/features/order/screens/take_order_screen.dart
@@ -49,6 +49,10 @@ class _TakeOrderScreenState extends ConsumerState<TakeOrderScreen> {
   @override
   void initState() {
     super.initState();
+    // Defense in depth (#268): if the user already participates in this
+    // order (deep link, stale book entry, back navigation), Take Order
+    // must not offer to take it again — land on the trade instead.
+    _redirectIfParticipant();
     // Try immediately in case the provider already has data.
     _tryStartCountdown();
     // If the provider is still loading, listen for the first value.
@@ -56,6 +60,12 @@ class _TakeOrderScreenState extends ConsumerState<TakeOrderScreen> {
       ref.listenManual(orderBookProvider, (_, __) => _tryStartCountdown(),
           fireImmediately: true);
     });
+  }
+
+  Future<void> _redirectIfParticipant() async {
+    final role = await orders_api.getTradeRole(orderId: widget.orderId);
+    if (!mounted || role == null) return;
+    context.go(AppRoute.tradeDetailPath(widget.orderId));
   }
 
   void _tryStartCountdown() {
@@ -142,9 +152,15 @@ class _TakeOrderScreenState extends ConsumerState<TakeOrderScreen> {
           // LN address was included in take-sell payload — go straight to trade.
           context.go(AppRoute.tradeDetailPath(widget.orderId));
         } else {
+          // Rebuild the stack with trade detail as the base so back/close
+          // from add-invoice lands on the trade, never back on Take Order
+          // offering to take an already-taken order (#268).
+          context.go(AppRoute.tradeDetailPath(widget.orderId));
           context.push(AppRoute.addInvoicePath(widget.orderId));
         }
       } else {
+        // Same stack shape for the seller's pay-invoice screen (#268).
+        context.go(AppRoute.tradeDetailPath(widget.orderId));
         context.push(AppRoute.payInvoicePath(widget.orderId));
       }
     } catch (e) {

--- a/lib/features/order/screens/take_order_screen.dart
+++ b/lib/features/order/screens/take_order_screen.dart
@@ -111,6 +111,16 @@ class _TakeOrderScreenState extends ConsumerState<TakeOrderScreen> {
     final order = orders.where((o) => o.id == widget.orderId).firstOrNull;
     if (order == null || _submitting) return;
 
+    // Serialize with the async initState redirect: a participant racing the
+    // role lookup must never dispatch a second take (which the daemon would
+    // reject and strand them on home instead of their trade).
+    final role = await orders_api.getTradeRole(orderId: widget.orderId);
+    if (!mounted) return;
+    if (role != null) {
+      context.go(AppRoute.tradeDetailPath(widget.orderId));
+      return;
+    }
+
     // Range orders: show amount modal first.
     if (order.isRange) {
       final amount = await showRangeAmountModal(


### PR DESCRIPTION
fix #268 

- After a successful take, trade detail becomes the base of the stack and the invoice screen is pushed on top, so back/close never returns to Take Order offering an already-taken order.
- The Cancel buttons on add-invoice and pay-invoice now confirm via dialog and send the protocol cancel (same flow and strings as trade detail), then go home.
- Defense in depth: Take Order redirects to trade detail when a persisted trade role shows the user already participates in the order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added confirmation and processing when canceling lightning invoice orders, including status feedback and navigation to the home screen.
  - Automatically redirects users who are already participating in an order to its trade details.
  - Updated order-taking navigation to prevent returning to the order selection screen after proceeding to invoice payment or creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->