### PR TITLE
feat(logging): instrument core flows with an end-to-end debug trace

### DIFF
--- a/lib/core/daemon_errors.dart
+++ b/lib/core/daemon_errors.dart
@@ -31,6 +31,11 @@ String localizedDaemonError(
   if (raw.contains('NoDaemonResponse')) {
     return l10n.sessionTimeoutMessage;
   }
+  // No relay accepted the event — it never left the device. Same remedy as
+  // a daemon timeout: check the connection and retry.
+  if (raw.contains('NoRelayAccepted')) {
+    return l10n.sessionTimeoutMessage;
+  }
   // No durable storage: no trade key can be derived (issue #249).
   if (raw.contains('StorageUnavailable')) {
     return l10n.storageUnavailable;

--- a/rust/src/api/logging.rs
+++ b/rust/src/api/logging.rs
@@ -140,8 +140,11 @@ impl log::Log for BridgeLogger {
             return;
         };
 
-        platform_console(record);
-        forward_log(record.level(), record.target(), &record.args().to_string());
+        // Format once and scrub before ANY sink sees the text, so a leaked
+        // secret can reach neither the console/logcat nor the retained buffer.
+        let message = scrub_secrets(&record.args().to_string()).into_owned();
+        platform_console(record.level(), record.target(), &message);
+        forward_log(record.level(), record.target(), &message);
     }
 
     fn flush(&self) {}
@@ -151,9 +154,10 @@ impl log::Log for BridgeLogger {
 
 /// Android discards a process's stderr, so records go to logcat. The fixed tag
 /// keeps `adb logcat -s mostro` useful; `android_logger` prepends the module
-/// path to the message.
+/// path to the message. Takes the pre-scrubbed message text (not the raw
+/// record) so redaction happens once, upstream, for every sink.
 #[cfg(target_os = "android")]
-fn platform_console(record: &log::Record) {
+fn platform_console(level: log::Level, target: &str, message: &str) {
     use log::Log as _;
 
     static ANDROID: OnceLock<android_logger::AndroidLogger> = OnceLock::new();
@@ -161,14 +165,20 @@ fn platform_console(record: &log::Record) {
         .get_or_init(|| {
             android_logger::AndroidLogger::new(android_logger::Config::default().with_tag("mostro"))
         })
-        .log(record);
+        .log(
+            &log::Record::builder()
+                .level(level)
+                .target(target)
+                .args(format_args!("{message}"))
+                .build(),
+        );
 }
 
 /// `wasm32` has no stderr; devtools filters on the console severity.
 #[cfg(target_arch = "wasm32")]
-fn platform_console(record: &log::Record) {
-    let line = format!("{}: {}", record.target(), record.args());
-    match record.level() {
+fn platform_console(level: log::Level, target: &str, message: &str) {
+    let line = format!("{target}: {message}");
+    match level {
         log::Level::Error => web_sys::console::error_1(&line.into()),
         log::Level::Warn => web_sys::console::warn_1(&line.into()),
         log::Level::Info => web_sys::console::info_1(&line.into()),
@@ -179,17 +189,55 @@ fn platform_console(record: &log::Record) {
 /// Desktop and iOS: stderr, which is what `flutter run` shows. The timestamp
 /// is UTC time-of-day; the Flutter side renders local time.
 #[cfg(all(not(target_os = "android"), not(target_arch = "wasm32")))]
-fn platform_console(record: &log::Record) {
+fn platform_console(level: log::Level, target: &str, message: &str) {
     let secs = crate::rt::unix_now();
     eprintln!(
         "{:02}:{:02}:{:02}Z [{:<5}] {}: {}",
         (secs / 3600) % 24,
         (secs / 60) % 60,
         secs % 60,
-        record.level(),
-        record.target(),
-        record.args(),
+        level,
+        target,
+        message,
     );
+}
+
+// ── Redaction helpers ────────────────────────────────────────────────────────
+
+/// First 8 chars of an id (event id, order UUID, pubkey) — enough to correlate
+/// log lines, deliberately not enough to reconstruct the full identifier.
+// TODO(#241): the allow goes away when the wire-boundary instrumentation
+// commits start consuming this.
+#[allow(dead_code)]
+pub(crate) fn short_id(id: &str) -> &str {
+    id.get(..8).unwrap_or(id)
+}
+
+/// Safety net applied to every record before any sink: masks `nsec1…` key
+/// material wherever it appears. Call-site discipline is the primary rule
+/// (never log secrets); this guarantees a slip cannot reach the console,
+/// logcat, or the retained buffer. Returns the input unchanged (no
+/// allocation) when there is nothing to mask.
+pub(crate) fn scrub_secrets(message: &str) -> std::borrow::Cow<'_, str> {
+    const MARKER: &str = "nsec1";
+    if !message.contains(MARKER) {
+        return std::borrow::Cow::Borrowed(message);
+    }
+    let mut out = String::with_capacity(message.len());
+    let mut rest = message;
+    while let Some(pos) = rest.find(MARKER) {
+        let after = pos + MARKER.len();
+        out.push_str(&rest[..after]);
+        out.push_str("[redacted]");
+        // Skip the bech32 payload: the alphanumeric run following the prefix.
+        let tail = &rest[after..];
+        let skip = tail
+            .find(|c: char| !c.is_ascii_alphanumeric())
+            .unwrap_or(tail.len());
+        rest = &tail[skip..];
+    }
+    out.push_str(rest);
+    std::borrow::Cow::Owned(out)
 }
 
 // ── Buffer and Flutter stream ────────────────────────────────────────────────
@@ -329,6 +377,54 @@ mod tests {
         })
         .await
         .unwrap_or_else(|_| panic!("timed out waiting for a '{tag}' entry"))
+    }
+
+    #[test]
+    fn short_id_truncates_without_panicking() {
+        assert_eq!(short_id("0ed2bc2f-5d03-427d-a507-920438bb3925"), "0ed2bc2f");
+        assert_eq!(short_id("abc"), "abc");
+        assert_eq!(short_id(""), "");
+    }
+
+    #[test]
+    fn scrub_secrets_masks_nsec_and_leaves_clean_text_alone() {
+        // Clean text: borrowed through unchanged, no allocation.
+        let clean = "order=0ed2bc2f status Pending→Active";
+        assert!(matches!(
+            scrub_secrets(clean),
+            std::borrow::Cow::Borrowed(_)
+        ));
+
+        let dirty = "imported key nsec1qyfxw6vlx3s24r0uzkkfnvyd5wsy4751m0nrg2 done";
+        let scrubbed = scrub_secrets(dirty);
+        assert_eq!(scrubbed, "imported key nsec1[redacted] done");
+
+        // Multiple occurrences, including at the end of the string.
+        let double = "a nsec1abc b nsec1def";
+        assert_eq!(scrub_secrets(double), "a nsec1[redacted] b nsec1[redacted]");
+    }
+
+    /// The #241 invariant: key material logged by mistake must reach neither
+    /// the retained buffer (`recent_logs`) nor the live stream.
+    #[tokio::test]
+    async fn forbidden_material_never_reaches_recent_logs() {
+        install_log_bridge();
+        let mut stream = on_log_entry();
+
+        log::warn!(target: "scrub_probe", "oops nsec1deadbeefdeadbeef leaked");
+
+        let entry = recv_tagged(&mut stream, "scrub_probe").await;
+        assert!(!entry.message.contains("nsec1dead"), "stream leaked: {}", entry.message);
+        assert!(entry.message.contains("nsec1[redacted]"));
+
+        let retained = recent_logs();
+        assert!(
+            retained
+                .iter()
+                .filter(|e| e.tag == "scrub_probe")
+                .all(|e| !e.message.contains("nsec1dead")),
+            "recent_logs leaked the key"
+        );
     }
 
     #[test]

--- a/rust/src/api/logging.rs
+++ b/rust/src/api/logging.rs
@@ -206,9 +206,6 @@ fn platform_console(level: log::Level, target: &str, message: &str) {
 
 /// First 8 chars of an id (event id, order UUID, pubkey) — enough to correlate
 /// log lines, deliberately not enough to reconstruct the full identifier.
-// TODO(#241): the allow goes away when the wire-boundary instrumentation
-// commits start consuming this.
-#[allow(dead_code)]
 pub(crate) fn short_id(id: &str) -> &str {
     id.get(..8).unwrap_or(id)
 }

--- a/rust/src/api/logging.rs
+++ b/rust/src/api/logging.rs
@@ -211,18 +211,28 @@ pub(crate) fn short_id(id: &str) -> &str {
 }
 
 /// Safety net applied to every record before any sink: masks `nsec1…` key
-/// material wherever it appears. Call-site discipline is the primary rule
-/// (never log secrets); this guarantees a slip cannot reach the console,
-/// logcat, or the retained buffer. Returns the input unchanged (no
-/// allocation) when there is nothing to mask.
+/// material wherever it appears, in any casing (bech32 also allows uniform
+/// uppercase). Call-site discipline is the primary rule (never log secrets);
+/// this guarantees a slip cannot reach the console, logcat, or the retained
+/// buffer. Returns the input unchanged (no allocation) when there is nothing
+/// to mask.
 pub(crate) fn scrub_secrets(message: &str) -> std::borrow::Cow<'_, str> {
-    const MARKER: &str = "nsec1";
-    if !message.contains(MARKER) {
+    const MARKER: &[u8] = b"nsec1";
+
+    // Case-insensitive marker search without allocating on the clean path.
+    fn find_marker(haystack: &str) -> Option<usize> {
+        haystack
+            .as_bytes()
+            .windows(MARKER.len())
+            .position(|w| w.eq_ignore_ascii_case(MARKER))
+    }
+
+    if find_marker(message).is_none() {
         return std::borrow::Cow::Borrowed(message);
     }
     let mut out = String::with_capacity(message.len());
     let mut rest = message;
-    while let Some(pos) = rest.find(MARKER) {
+    while let Some(pos) = find_marker(rest) {
         let after = pos + MARKER.len();
         out.push_str(&rest[..after]);
         out.push_str("[redacted]");
@@ -235,6 +245,18 @@ pub(crate) fn scrub_secrets(message: &str) -> std::borrow::Cow<'_, str> {
     }
     out.push_str(rest);
     std::borrow::Cow::Owned(out)
+}
+
+/// Bounds and normalizes text that originates from a remote peer (relay error
+/// strings, NOTICE/CLOSED messages) before it enters a log record: control
+/// characters are replaced (a newline could forge log-entry boundaries) and
+/// the length is capped so a hostile relay cannot bloat the retained buffer.
+pub(crate) fn sanitize_relay_text(text: &str) -> String {
+    const MAX_CHARS: usize = 200;
+    text.chars()
+        .map(|c| if c.is_control() { ' ' } else { c })
+        .take(MAX_CHARS)
+        .collect()
 }
 
 // ── Buffer and Flutter stream ────────────────────────────────────────────────
@@ -399,6 +421,23 @@ mod tests {
         // Multiple occurrences, including at the end of the string.
         let double = "a nsec1abc b nsec1def";
         assert_eq!(scrub_secrets(double), "a nsec1[redacted] b nsec1[redacted]");
+
+        // bech32 allows uniform uppercase — the marker must match any casing.
+        let upper = "key NSEC1QYFXW6VLX3S24R0UZKK end";
+        assert_eq!(scrub_secrets(upper), "key NSEC1[redacted] end");
+        let mixed = "key NsEc1abcDEF end";
+        assert_eq!(scrub_secrets(mixed), "key NsEc1[redacted] end");
+    }
+
+    #[test]
+    fn sanitize_relay_text_strips_control_chars_and_caps_length() {
+        assert_eq!(
+            sanitize_relay_text("auth-required:\nplease\tauth"),
+            "auth-required: please auth"
+        );
+        let long = "x".repeat(500);
+        assert_eq!(sanitize_relay_text(&long).chars().count(), 200);
+        assert_eq!(sanitize_relay_text("plain error"), "plain error");
     }
 
     /// The #241 invariant: key material logged by mistake must reach neither

--- a/rust/src/api/logging.rs
+++ b/rust/src/api/logging.rs
@@ -256,7 +256,9 @@ pub(crate) fn display_relay(url: &str) -> String {
     };
     let authority = rest.split(['/', '?', '#']).next().unwrap_or("");
     let host = authority.rsplit('@').next().unwrap_or(authority);
-    format!("{scheme}://{host}")
+    // The authority may still carry control characters — same policy as any
+    // remote-influenced text before it enters a log record.
+    sanitize_relay_text(&format!("{scheme}://{host}"))
 }
 
 /// Bounds and normalizes text that originates from a remote peer (relay error
@@ -451,6 +453,11 @@ mod tests {
         );
         // Not a URL at all: falls back to plain sanitization.
         assert_eq!(display_relay("not a url"), "not a url");
+        // Control characters in the authority cannot forge log boundaries.
+        assert_eq!(
+            display_relay("wss://relay.example\nforged"),
+            "wss://relay.example forged"
+        );
     }
 
     #[test]

--- a/rust/src/api/logging.rs
+++ b/rust/src/api/logging.rs
@@ -247,6 +247,18 @@ pub(crate) fn scrub_secrets(message: &str) -> std::borrow::Cow<'_, str> {
     std::borrow::Cow::Owned(out)
 }
 
+/// Renders a relay URL as `scheme://host[:port]` only — userinfo, path,
+/// query and fragment are dropped so tokenized/private relay URLs never
+/// enter a log record.
+pub(crate) fn display_relay(url: &str) -> String {
+    let Some((scheme, rest)) = url.split_once("://") else {
+        return sanitize_relay_text(url);
+    };
+    let authority = rest.split(['/', '?', '#']).next().unwrap_or("");
+    let host = authority.rsplit('@').next().unwrap_or(authority);
+    format!("{scheme}://{host}")
+}
+
 /// Bounds and normalizes text that originates from a remote peer (relay error
 /// strings, NOTICE/CLOSED messages) before it enters a log record: control
 /// characters are replaced (a newline could forge log-entry boundaries) and
@@ -427,6 +439,18 @@ mod tests {
         assert_eq!(scrub_secrets(upper), "key NSEC1[redacted] end");
         let mixed = "key NsEc1abcDEF end";
         assert_eq!(scrub_secrets(mixed), "key NsEc1[redacted] end");
+    }
+
+    #[test]
+    fn display_relay_keeps_only_scheme_and_host() {
+        assert_eq!(display_relay("wss://nos.lol"), "wss://nos.lol");
+        assert_eq!(display_relay("wss://relay.example.com:7777"), "wss://relay.example.com:7777");
+        assert_eq!(
+            display_relay("wss://user:token@relay.example.com/path?secret=x#f"),
+            "wss://relay.example.com"
+        );
+        // Not a URL at all: falls back to plain sanitization.
+        assert_eq!(display_relay("not a url"), "not a url");
     }
 
     #[test]

--- a/rust/src/api/messages.rs
+++ b/rust/src/api/messages.rs
@@ -358,15 +358,20 @@ async fn publish_chat_payload(ctx: &ChatContext, payload: &str) -> Result<nostr_
     for relay in &output.success {
         crate::api::logging::blog_info(
             "publish",
-            format!("ev={} kind=14 relay={relay} OK", crate::api::logging::short_id(&eid)),
+            format!(
+                "ev={} kind=14 relay={} OK",
+                crate::api::logging::short_id(&eid),
+                crate::api::logging::display_relay(&relay.to_string()),
+            ),
         );
     }
     for (relay, err) in &output.failed {
         crate::api::logging::blog_warn(
             "publish",
             format!(
-                "ev={} kind=14 relay={relay} FAIL: {}",
+                "ev={} kind=14 relay={} FAIL: {}",
                 crate::api::logging::short_id(&eid),
+                crate::api::logging::display_relay(&relay.to_string()),
                 crate::api::logging::sanitize_relay_text(err),
             ),
         );

--- a/rust/src/api/messages.rs
+++ b/rust/src/api/messages.rs
@@ -348,10 +348,25 @@ async fn publish_chat_payload(ctx: &ChatContext, payload: &str) -> Result<nostr_
         crate::nostr::gift_wrap::mostro_wrap(&ctx.trade_keys, &ctx.conv, &ctx.sign, payload)
             .await?;
     let pool = crate::api::nostr::get_pool().map_err(|_| anyhow!("relay pool not ready"))?;
-    pool.client()
+    let output = pool
+        .client()
         .send_event(&outer)
         .await
         .map_err(|e| anyhow!("publish failed: {e}"))?;
+    // Envelope metadata only — chat plaintext never enters a log record.
+    let eid = outer.id.to_hex();
+    for relay in &output.success {
+        crate::api::logging::blog_info(
+            "publish",
+            format!("ev={} kind=14 relay={relay} OK", crate::api::logging::short_id(&eid)),
+        );
+    }
+    for (relay, err) in &output.failed {
+        crate::api::logging::blog_warn(
+            "publish",
+            format!("ev={} kind=14 relay={relay} FAIL: {err}", crate::api::logging::short_id(&eid)),
+        );
+    }
     Ok(inner)
 }
 

--- a/rust/src/api/messages.rs
+++ b/rust/src/api/messages.rs
@@ -364,7 +364,11 @@ async fn publish_chat_payload(ctx: &ChatContext, payload: &str) -> Result<nostr_
     for (relay, err) in &output.failed {
         crate::api::logging::blog_warn(
             "publish",
-            format!("ev={} kind=14 relay={relay} FAIL: {err}", crate::api::logging::short_id(&eid)),
+            format!(
+                "ev={} kind=14 relay={relay} FAIL: {}",
+                crate::api::logging::short_id(&eid),
+                crate::api::logging::sanitize_relay_text(err),
+            ),
         );
     }
     Ok(inner)

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -1228,11 +1228,14 @@ pub async fn send_invoice(
         remove_pending_request(&trade_pk_hex, request_id);
         return Err(e);
     }
-    log::info!(
-        "[orders] add_invoice published for order={order_id} trade_index={trade_index} \
-         ln_address={} amount={:?} — waiting for daemon",
-        invoice_or_address.contains('@'),
-        amount_opt
+    crate::api::logging::blog_info(
+        "orders",
+        format!(
+            "add_invoice published for order={order_id} trade_index={trade_index} \
+             ln_address={} amount={:?} — waiting for daemon",
+            invoice_or_address.contains('@'),
+            amount_opt
+        ),
     );
 
     // Wait for the daemon's verdict: a rejected invoice (e.g. InvalidInvoice)
@@ -1891,6 +1894,13 @@ async fn dispatch_mostro_message(
                     } else {
                         // Sync the Canceled status into the trade DB so My
                         // Trades reflects the cancellation immediately.
+                        crate::api::logging::blog_info(
+                            "orders",
+                            format!(
+                                "status order={} →Canceled src=kind14/Canceled (history kept)",
+                                crate::api::logging::short_id(&oid),
+                            ),
+                        );
                         if let Err(e) = db
                             .update_trade_fields(
                                 &oid,
@@ -1971,10 +1981,13 @@ async fn dispatch_mostro_message(
                 .and_then(map_core_status)
                 .or_else(|| status_for_action(&kind.action))
             {
-                log::info!(
-                    "[orders] gift-wrap {:?}: syncing order={order_id} status={:?}",
-                    kind.action,
-                    new_status
+                crate::api::logging::blog_info(
+                    "orders",
+                    format!(
+                        "status order={} →{new_status:?} src=kind14/{:?}",
+                        crate::api::logging::short_id(&order_id),
+                        kind.action,
+                    ),
                 );
                 order_book().update_order_status(&order_id, new_status.clone()).await;
                 if let Some(db) = crate::db::app_db::db() {
@@ -2031,6 +2044,13 @@ async fn dispatch_mostro_message(
                 amount
             );
             // Save the hold invoice and update status to WaitingPayment.
+            crate::api::logging::blog_info(
+                "orders",
+                format!(
+                    "status order={} →WaitingPayment src=kind14/PayInvoice",
+                    crate::api::logging::short_id(&order_id),
+                ),
+            );
             order_book().update_order_status(&order_id, crate::api::types::OrderStatus::WaitingPayment).await;
             if let Some(db) = crate::db::app_db::db() {
                 if let Err(e) = db
@@ -2082,10 +2102,13 @@ async fn dispatch_mostro_message(
             // reply classification).
             let new_status = status_for_action(&kind.action);
             if let Some(status) = new_status {
-                log::info!(
-                    "[orders] gift-wrap {:?}: syncing order={order_id} status={:?}",
-                    kind.action,
-                    status
+                crate::api::logging::blog_info(
+                    "orders",
+                    format!(
+                        "status order={} →{status:?} src=kind14/{:?}",
+                        crate::api::logging::short_id(&order_id),
+                        kind.action,
+                    ),
                 );
                 order_book().update_order_status(&order_id, status.clone()).await;
                 if let Some(db) = crate::db::app_db::db() {
@@ -2328,6 +2351,29 @@ fn map_core_status(s: mostro_core::order::Status) -> Option<OrderStatus> {
 /// so `in-progress` means "taken", never "escrow locked". Letting it overwrite
 /// a status learned from a daemon message drags an Active trade back to
 /// InProgress and offers actions the daemon then rejects (issue #203).
+/// Logs one wire→trade status sync decision. A real transition logs at info;
+/// blocked (`applies=false`) and no-op decisions log at debug so relay
+/// redelivery churn stays out of a shipped build's log while remaining
+/// visible in a debugging session (#277).
+fn log_wire_status_sync(
+    order_id: &str,
+    wire: &OrderStatus,
+    local: Option<&OrderStatus>,
+    applies: bool,
+    src: &str,
+) {
+    let line = format!(
+        "status order={} wire={wire:?} local={} applies={applies} src={src}",
+        crate::api::logging::short_id(order_id),
+        local.map_or_else(|| "-".to_string(), |s| format!("{s:?}")),
+    );
+    if applies && local != Some(wire) {
+        crate::api::logging::blog_info("orders", line);
+    } else {
+        crate::api::logging::blog_debug("orders", line);
+    }
+}
+
 fn wire_status_applies(local: Option<&OrderStatus>, wire: &OrderStatus) -> bool {
     match local {
         None | Some(OrderStatus::Pending) => true,
@@ -2518,6 +2564,15 @@ async fn subscribe_single_order(order_id: &str) {
                             last_activity = crate::rt::time::Instant::now();
                             let local = local_trade_status(&order.id).await;
                             let applies = wire_status_applies(local.as_ref(), &order.status);
+                            // This subscription only exists for orders we
+                            // created or took, so every decision is ours to log.
+                            log_wire_status_sync(
+                                &order.id,
+                                &order.status,
+                                local.as_ref(),
+                                applies,
+                                "38383/d-tag",
+                            );
                             if let Some(db) = crate::db::app_db::db() {
                                 if let Err(e) = db
                                     .update_trade_fields(
@@ -3231,6 +3286,16 @@ async fn ingest_order_event(event: &nostr_sdk::Event) {
                 let local = local_trade_status(&info.id).await;
                 let applies = wire_status_applies(local.as_ref(), &info.status);
                 if info.is_mine {
+                    // Only own orders: for stranger book entries `local`
+                    // falls back to the book itself and would log every
+                    // public update.
+                    log_wire_status_sync(
+                        &info.id,
+                        &info.status,
+                        local.as_ref(),
+                        applies,
+                        "38383/book",
+                    );
                     if let Some(db) = crate::db::app_db::db() {
                         if let Err(e) = db
                             .update_trade_fields(

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -2640,15 +2640,20 @@ async fn publish_event_json(event_json: &str) -> Result<()> {
     for relay in &output.success {
         crate::api::logging::blog_info(
             "publish",
-            format!("ev={} kind={kind} relay={relay} OK", crate::api::logging::short_id(&eid)),
+            format!(
+                "ev={} kind={kind} relay={} OK",
+                crate::api::logging::short_id(&eid),
+                crate::api::logging::display_relay(&relay.to_string()),
+            ),
         );
     }
     for (relay, err) in &output.failed {
         crate::api::logging::blog_warn(
             "publish",
             format!(
-                "ev={} kind={kind} relay={relay} FAIL: {}",
+                "ev={} kind={kind} relay={} FAIL: {}",
                 crate::api::logging::short_id(&eid),
+                crate::api::logging::display_relay(&relay.to_string()),
                 crate::api::logging::sanitize_relay_text(err),
             ),
         );
@@ -3450,8 +3455,9 @@ async fn _run_order_subscription() {
                             crate::api::logging::blog_debug(
                                 "relay",
                                 format!(
-                                    "raw ev={} kind={kind} sub={subscription_id} relay={relay_url}",
+                                    "raw ev={} kind={kind} sub={subscription_id} relay={}",
                                     crate::api::logging::short_id(&event.id.to_hex()),
+                                    crate::api::logging::display_relay(&relay_url.to_string()),
                                 ),
                             );
                         }
@@ -3459,7 +3465,10 @@ async fn _run_order_subscription() {
                     RelayMessage::EndOfStoredEvents(sub_id) => {
                         crate::api::logging::blog_debug(
                             "relay",
-                            format!("eose sub={sub_id} relay={relay_url}"),
+                            format!(
+                                "eose sub={sub_id} relay={}",
+                                crate::api::logging::display_relay(&relay_url.to_string()),
+                            ),
                         );
                     }
                     RelayMessage::Closed {
@@ -3469,7 +3478,8 @@ async fn _run_order_subscription() {
                         crate::api::logging::blog_warn(
                             "relay",
                             format!(
-                                "closed sub={subscription_id} relay={relay_url} msg={}",
+                                "closed sub={subscription_id} relay={} msg={}",
+                                crate::api::logging::display_relay(&relay_url.to_string()),
                                 crate::api::logging::sanitize_relay_text(&message),
                             ),
                         );
@@ -3478,7 +3488,8 @@ async fn _run_order_subscription() {
                         crate::api::logging::blog_warn(
                             "relay",
                             format!(
-                                "notice relay={relay_url} msg={}",
+                                "notice relay={} msg={}",
+                                crate::api::logging::display_relay(&relay_url.to_string()),
                                 crate::api::logging::sanitize_relay_text(&msg),
                             ),
                         );
@@ -3486,7 +3497,10 @@ async fn _run_order_subscription() {
                     RelayMessage::Auth { .. } => {
                         crate::api::logging::blog_debug(
                             "relay",
-                            format!("auth-challenge relay={relay_url}"),
+                            format!(
+                                "auth-challenge relay={}",
+                                crate::api::logging::display_relay(&relay_url.to_string()),
+                            ),
                         );
                     }
                     _ => {}

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -2653,6 +2653,15 @@ async fn publish_event_json(event_json: &str) -> Result<()> {
             ),
         );
     }
+    // The SDK returns Ok even when every relay rejected the event (verified
+    // in nostr-relay-pool 0.44: `send_event_to` has no empty-success guard).
+    // Without this, fire-and-forget actions (fiat-sent, release, cancel)
+    // would report success having reached zero relays, and correlated ones
+    // would wait 10s for a reply that can never arrive. Partial success
+    // stays Ok. Stable marker — Dart maps it to a localized message.
+    if output.success.is_empty() {
+        anyhow::bail!("NoRelayAccepted");
+    }
     Ok(())
 }
 

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -1231,8 +1231,9 @@ pub async fn send_invoice(
     crate::api::logging::blog_info(
         "orders",
         format!(
-            "add_invoice published for order={order_id} trade_index={trade_index} \
+            "add_invoice published for order={} trade_index={trade_index} \
              ln_address={} amount={:?} — waiting for daemon",
+            crate::api::logging::short_id(&order_id),
             invoice_or_address.contains('@'),
             amount_opt
         ),
@@ -1295,7 +1296,10 @@ pub async fn send_fiat_sent(order_id: String) -> Result<()> {
     publish_event_json(&event_json).await?;
     crate::api::logging::blog_info(
         "orders",
-        format!("fiat_sent published for order={order_id} trade_index={trade_index}"),
+        format!(
+            "fiat_sent published for order={} trade_index={trade_index}",
+            crate::api::logging::short_id(&order_id),
+        ),
     );
     Ok(())
 }
@@ -1323,7 +1327,10 @@ pub async fn release_order(order_id: String) -> Result<()> {
     publish_event_json(&event_json).await?;
     crate::api::logging::blog_info(
         "orders",
-        format!("release published for order={order_id} trade_index={trade_index}"),
+        format!(
+            "release published for order={} trade_index={trade_index}",
+            crate::api::logging::short_id(&order_id),
+        ),
     );
     Ok(())
 }
@@ -1371,7 +1378,10 @@ pub async fn cancel_order(order_id: String) -> Result<()> {
 
     crate::api::logging::blog_info(
         "orders",
-        format!("cancel published for order={order_id} trade_index={trade_index}"),
+        format!(
+            "cancel published for order={} trade_index={trade_index}",
+            crate::api::logging::short_id(&order_id),
+        ),
     );
     Ok(())
 }
@@ -2637,8 +2647,9 @@ async fn publish_event_json(event_json: &str) -> Result<()> {
         crate::api::logging::blog_warn(
             "publish",
             format!(
-                "ev={} kind={kind} relay={relay} FAIL: {err}",
-                crate::api::logging::short_id(&eid)
+                "ev={} kind={kind} relay={relay} FAIL: {}",
+                crate::api::logging::short_id(&eid),
+                crate::api::logging::sanitize_relay_text(err),
             ),
         );
     }
@@ -3449,14 +3460,18 @@ async fn _run_order_subscription() {
                         crate::api::logging::blog_warn(
                             "relay",
                             format!(
-                                "closed sub={subscription_id} relay={relay_url} msg={message}"
+                                "closed sub={subscription_id} relay={relay_url} msg={}",
+                                crate::api::logging::sanitize_relay_text(&message),
                             ),
                         );
                     }
                     RelayMessage::Notice(msg) => {
                         crate::api::logging::blog_warn(
                             "relay",
-                            format!("notice relay={relay_url} msg={msg}"),
+                            format!(
+                                "notice relay={relay_url} msg={}",
+                                crate::api::logging::sanitize_relay_text(&msg),
+                            ),
                         );
                     }
                     RelayMessage::Auth { .. } => {

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -2836,6 +2836,14 @@ async fn subscribe_node_filters(
         .subscribe_with_id(orders_subscription_id(), order_filter, None)
         .await
         .map_err(|e| anyhow::anyhow!("order subscribe failed: {e}"))?;
+    crate::api::logging::blog_info(
+        "relay",
+        format!(
+            "sub created id={} kinds=[38383] author={}",
+            orders_subscription_id(),
+            crate::api::logging::short_id(&mostro_pubkey.to_hex()),
+        ),
+    );
 
     // Kind-14 NIP-44 replies authored by Mostro for all known trade pubkeys.
     // The author pin disambiguates from NIP-17 peer chat (also kind 14).
@@ -2845,6 +2853,7 @@ async fn subscribe_node_filters(
     // changes and late reconciliations are never lost. Only the ephemeral
     // per-trade subscription (subscribe_gift_wraps) carries a cutoff.
     if !trade_pubkeys.is_empty() {
+        let p_count = trade_pubkeys.len();
         let dm_filter = nostr_sdk::Filter::new()
             .kind(nostr_sdk::Kind::PrivateDirectMessage)
             .author(mostro_pubkey)
@@ -2853,6 +2862,13 @@ async fn subscribe_node_filters(
             .subscribe_with_id(mostro_dm_subscription_id(), dm_filter, None)
             .await
             .map_err(|e| anyhow::anyhow!("dm subscribe failed: {e}"))?;
+        crate::api::logging::blog_info(
+            "relay",
+            format!(
+                "sub created id={} kinds=[14] p_count={p_count}",
+                mostro_dm_subscription_id(),
+            ),
+        );
     }
     Ok(())
 }
@@ -2973,6 +2989,7 @@ async fn resubscribe_global_dm_filter() {
     if trade_pubkeys.is_empty() {
         return;
     }
+    let p_count = trade_pubkeys.len();
     let dm_filter = nostr_sdk::Filter::new()
         .kind(nostr_sdk::Kind::PrivateDirectMessage)
         .author(mostro_pubkey)
@@ -2983,6 +3000,14 @@ async fn resubscribe_global_dm_filter() {
         .await
     {
         log::warn!("[orders] bulk DM filter refresh failed: {e}");
+    } else {
+        crate::api::logging::blog_info(
+            "relay",
+            format!(
+                "sub replaced id={} kinds=[14] p_count={p_count}",
+                mostro_dm_subscription_id(),
+            ),
+        );
     }
 }
 
@@ -3273,6 +3298,45 @@ async fn _run_order_subscription() {
                 }
                 ingest_order_event(&event).await;
             }
+            // Raw relay control messages. Observation only — every arm just
+            // logs. CLOSED and NOTICE are anomalies (a relay refusing or
+            // complaining about a subscription) that were previously
+            // swallowed by the catch-all and undiagnosable in the field.
+            Ok(RelayPoolNotification::Message { relay_url, message }) => {
+                use nostr_sdk::RelayMessage;
+                match message {
+                    RelayMessage::EndOfStoredEvents(sub_id) => {
+                        crate::api::logging::blog_debug(
+                            "relay",
+                            format!("eose sub={sub_id} relay={relay_url}"),
+                        );
+                    }
+                    RelayMessage::Closed {
+                        subscription_id,
+                        message,
+                    } => {
+                        crate::api::logging::blog_warn(
+                            "relay",
+                            format!(
+                                "closed sub={subscription_id} relay={relay_url} msg={message}"
+                            ),
+                        );
+                    }
+                    RelayMessage::Notice(msg) => {
+                        crate::api::logging::blog_warn(
+                            "relay",
+                            format!("notice relay={relay_url} msg={msg}"),
+                        );
+                    }
+                    RelayMessage::Auth { .. } => {
+                        crate::api::logging::blog_debug(
+                            "relay",
+                            format!("auth-challenge relay={relay_url}"),
+                        );
+                    }
+                    _ => {}
+                }
+            }
             Ok(RelayPoolNotification::Shutdown) => {
                 log::info!("[orders] relay pool shutdown — subscription loop exiting");
                 break;
@@ -3285,7 +3349,6 @@ async fn _run_order_subscription() {
                 log::warn!("[orders] lagged by {n} messages");
                 continue;
             }
-            _ => {}
         }
     }
 }

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -1290,7 +1290,10 @@ pub async fn send_fiat_sent(order_id: String) -> Result<()> {
     )
     .await?;
     publish_event_json(&event_json).await?;
-    log::info!("[orders] fiat_sent published for order={order_id} trade_index={trade_index}");
+    crate::api::logging::blog_info(
+        "orders",
+        format!("fiat_sent published for order={order_id} trade_index={trade_index}"),
+    );
     Ok(())
 }
 
@@ -1315,7 +1318,10 @@ pub async fn release_order(order_id: String) -> Result<()> {
     )
     .await?;
     publish_event_json(&event_json).await?;
-    log::info!("[orders] release published for order={order_id} trade_index={trade_index}");
+    crate::api::logging::blog_info(
+        "orders",
+        format!("release published for order={order_id} trade_index={trade_index}"),
+    );
     Ok(())
 }
 
@@ -1360,7 +1366,10 @@ pub async fn cancel_order(order_id: String) -> Result<()> {
         }
     }
 
-    log::info!("[orders] cancel published for order={order_id} trade_index={trade_index}");
+    crate::api::logging::blog_info(
+        "orders",
+        format!("cancel published for order={order_id} trade_index={trade_index}"),
+    );
     Ok(())
 }
 
@@ -1476,6 +1485,13 @@ pub(crate) async fn subscribe_gift_wraps(trade_pubkey: nostr_sdk::PublicKey, tra
 
                     let eid = event.id.to_hex();
                     if is_duplicate_gift_wrap(&eid) {
+                        crate::api::logging::blog_debug(
+                            "gift-wrap",
+                            format!(
+                                "drop ev={} reason=duplicate",
+                                crate::api::logging::short_id(&eid)
+                            ),
+                        );
                         continue;
                     }
                     crate::api::logging::blog_info("gift-wrap", format!(
@@ -2547,10 +2563,30 @@ async fn publish_event_json(event_json: &str) -> Result<()> {
         crate::api::nostr::get_pool().map_err(|_| anyhow::anyhow!("RelayPoolNotInitialized"))?;
     let event: nostr_sdk::Event =
         serde_json::from_str(event_json).map_err(|e| anyhow::anyhow!("invalid event JSON: {e}"))?;
-    pool.client()
+    let kind = event.kind.as_u16();
+    let eid = event.id.to_hex();
+    let output = pool
+        .client()
         .send_event(&event)
         .await
         .map_err(|e| anyhow::anyhow!("publish failed: {e}"))?;
+    // Per-relay outcome: with one relay habitually down, knowing WHERE each
+    // event actually landed is what makes delivery issues diagnosable.
+    for relay in &output.success {
+        crate::api::logging::blog_info(
+            "publish",
+            format!("ev={} kind={kind} relay={relay} OK", crate::api::logging::short_id(&eid)),
+        );
+    }
+    for (relay, err) in &output.failed {
+        crate::api::logging::blog_warn(
+            "publish",
+            format!(
+                "ev={} kind={kind} relay={relay} FAIL: {err}",
+                crate::api::logging::short_id(&eid)
+            ),
+        );
+    }
     Ok(())
 }
 
@@ -3056,7 +3092,17 @@ async fn handle_global_gift_wrap(
         match found {
             Some(f) => f,
             None => {
-                // Not addressed to any of our known trade keys — skip silently.
+                // The bulk filter pins author + our own p-tags, so a kind-14
+                // that reaches here without a matching key is an anomaly
+                // (stale filter after regenerate? key map gap?) — worth a warn.
+                crate::api::logging::blog_warn(
+                    "gift-wrap",
+                    format!(
+                        "drop ev={} reason=no-matching-p-tag map={}",
+                        crate::api::logging::short_id(&event.id.to_hex()),
+                        trade_key_map.len(),
+                    ),
+                );
                 return;
             }
         }
@@ -3064,6 +3110,10 @@ async fn handle_global_gift_wrap(
 
     let eid = event.id.to_hex();
     if is_duplicate_gift_wrap(&eid) {
+        crate::api::logging::blog_debug(
+            "gift-wrap",
+            format!("drop ev={} reason=duplicate", crate::api::logging::short_id(&eid)),
+        );
         return;
     }
     crate::api::logging::blog_info("gift-wrap", format!(
@@ -3305,6 +3355,22 @@ async fn _run_order_subscription() {
             Ok(RelayPoolNotification::Message { relay_url, message }) => {
                 use nostr_sdk::RelayMessage;
                 match message {
+                    // Ground truth for delivery questions: this fires for
+                    // every frame the relay pushes, BEFORE the SDK's
+                    // first-time-seen dedup that gates the Event
+                    // notification above (#277).
+                    RelayMessage::Event { subscription_id, event } => {
+                        let kind = event.kind.as_u16();
+                        if kind == 14 || kind == 1059 {
+                            crate::api::logging::blog_debug(
+                                "relay",
+                                format!(
+                                    "raw ev={} kind={kind} sub={subscription_id} relay={relay_url}",
+                                    crate::api::logging::short_id(&event.id.to_hex()),
+                                ),
+                            );
+                        }
+                    }
                     RelayMessage::EndOfStoredEvents(sub_id) => {
                         crate::api::logging::blog_debug(
                             "relay",

--- a/rust/src/mostro/session.rs
+++ b/rust/src/mostro/session.rs
@@ -94,6 +94,15 @@ impl SessionManager {
         if sessions.contains_key(&order_id) {
             return Err(anyhow!("SessionAlreadyExists: {}", order_id));
         }
+        crate::api::logging::blog_info(
+            "session",
+            format!(
+                "created order={} idx={} role={:?}",
+                crate::api::logging::short_id(&order_id),
+                session.trade_key_index,
+                session.role,
+            ),
+        );
         sessions.insert(order_id, session.clone());
         Ok(session)
     }
@@ -122,7 +131,12 @@ impl SessionManager {
 
     /// Remove a session (on completion, cancellation, or timeout).
     pub async fn remove_session(&self, order_id: &str) {
-        self.sessions.write().await.remove(order_id);
+        if self.sessions.write().await.remove(order_id).is_some() {
+            crate::api::logging::blog_info(
+                "session",
+                format!("removed order={}", crate::api::logging::short_id(order_id)),
+            );
+        }
     }
 
     /// Store the ECDH admin shared key derived from `adminTookDispute`.

--- a/rust/src/nostr/relay_pool.rs
+++ b/rust/src/nostr/relay_pool.rs
@@ -183,7 +183,13 @@ impl RelayPool {
                             // matters (INFO); the connecting↔disconnected
                             // retry churn of an unreachable relay stays at
                             // DEBUG so it doesn't drown a shipped build's log.
-                            let line = format!("relay {url} {:?}→{new_status:?}", info.status);
+                            // Host-only display: a user-added relay URL may
+                            // carry tokens/userinfo that must not be retained.
+                            let line = format!(
+                                "relay {} {:?}→{new_status:?}",
+                                crate::api::logging::display_relay(&url),
+                                info.status,
+                            );
                             if matches!(info.status, RelayStatus::Connected)
                                 || matches!(new_status, RelayStatus::Connected)
                             {

--- a/rust/src/nostr/relay_pool.rs
+++ b/rust/src/nostr/relay_pool.rs
@@ -179,6 +179,18 @@ impl RelayPool {
                     let mut relays_w = relays.write().await;
                     if let Some(info) = relays_w.iter_mut().find(|r| r.url == url) {
                         if info.status != new_status {
+                            // Gaining/losing a connection is the signal that
+                            // matters (INFO); the connecting↔disconnected
+                            // retry churn of an unreachable relay stays at
+                            // DEBUG so it doesn't drown a shipped build's log.
+                            let line = format!("relay {url} {:?}→{new_status:?}", info.status);
+                            if matches!(info.status, RelayStatus::Connected)
+                                || matches!(new_status, RelayStatus::Connected)
+                            {
+                                crate::api::logging::blog_info("relay", line);
+                            } else {
+                                crate::api::logging::blog_debug("relay", line);
+                            }
                             info.status = new_status;
                             if matches!(info.status, RelayStatus::Connected) {
                                 info.last_connected_at = Some(unix_now());

--- a/rust/src/nwc/client.rs
+++ b/rust/src/nwc/client.rs
@@ -116,6 +116,19 @@ mod native {
             let relay_urls: Vec<String> =
                 uri.relays.iter().map(|r| r.to_string()).collect();
 
+            // Host-only display: NWC relay URLs are the likeliest of all to
+            // carry tokens, and the URI itself (secret!) never enters a log.
+            crate::api::logging::blog_info(
+                "nwc",
+                format!(
+                    "connected relays={} wallet-relay={}",
+                    relay_urls.len(),
+                    relay_urls
+                        .first()
+                        .map_or_else(|| "-".to_string(), |u| crate::api::logging::display_relay(u)),
+                ),
+            );
+
             Ok(Self {
                 client,
                 info: NwcWalletInfo {
@@ -136,6 +149,9 @@ mod native {
         /// BEFORE publishing the request so the response is never missed,
         /// even if the wallet replies before EOSE.
         async fn send_request(&self, request: Request) -> Result<Nip47Response> {
+            // Method name only — params (invoices, amounts) never enter a log.
+            let method = format!("{:?}", request.method);
+            crate::api::logging::blog_info("nwc", format!("→ {method}"));
             let event = request
                 .to_event(&self.uri)
                 .map_err(|e| anyhow!("Failed to build NIP-47 request event: {e}"))?;
@@ -192,6 +208,28 @@ mod native {
 
             // Always clean up the subscription, even on timeout/error.
             self.client.unsubscribe(&sub_id).await;
+
+            // One outcome line per round-trip; wallet/transport error text is
+            // remote-controlled, so it passes through sanitize_relay_text.
+            match &result {
+                Ok(resp) => match &resp.error {
+                    Some(err) => crate::api::logging::blog_warn(
+                        "nwc",
+                        format!(
+                            "← {method} ERROR: {}",
+                            crate::api::logging::sanitize_relay_text(&err.to_string()),
+                        ),
+                    ),
+                    None => crate::api::logging::blog_info("nwc", format!("← {method} OK")),
+                },
+                Err(e) => crate::api::logging::blog_warn(
+                    "nwc",
+                    format!(
+                        "← {method} FAILED: {}",
+                        crate::api::logging::sanitize_relay_text(&e.to_string()),
+                    ),
+                ),
+            }
 
             result
         }
@@ -343,6 +381,7 @@ mod native {
         /// Disconnect the nostr-sdk client from all relays.
         pub async fn disconnect(&self) {
             self.client.disconnect().await;
+            crate::api::logging::blog_info("nwc", "disconnected".to_string());
         }
     }
 

--- a/rust/src/nwc/client.rs
+++ b/rust/src/nwc/client.rs
@@ -121,7 +121,7 @@ mod native {
             crate::api::logging::blog_info(
                 "nwc",
                 format!(
-                    "connected relays={} wallet-relay={}",
+                    "client ready relays-configured={} wallet-relay={}",
                     relay_urls.len(),
                     relay_urls
                         .first()
@@ -150,7 +150,7 @@ mod native {
         /// even if the wallet replies before EOSE.
         async fn send_request(&self, request: Request) -> Result<Nip47Response> {
             // Method name only — params (invoices, amounts) never enter a log.
-            let method = format!("{:?}", request.method);
+            let method = request.method.to_string();
             crate::api::logging::blog_info("nwc", format!("→ {method}"));
             let event = request
                 .to_event(&self.uri)
@@ -220,7 +220,16 @@ mod native {
                             crate::api::logging::sanitize_relay_text(&err.to_string()),
                         ),
                     ),
-                    None => crate::api::logging::blog_info("nwc", format!("← {method} OK")),
+                    None if resp.result.is_some() => {
+                        crate::api::logging::blog_info("nwc", format!("← {method} OK"))
+                    }
+                    // Neither error nor result: the wallet answered with an
+                    // incomplete payload — callers will fail to parse it, so
+                    // the log must not claim success.
+                    None => crate::api::logging::blog_warn(
+                        "nwc",
+                        format!("← {method} EMPTY_RESPONSE"),
+                    ),
                 },
                 Err(e) => crate::api::logging::blog_warn(
                     "nwc",

--- a/rust/src/queue/outbox.rs
+++ b/rust/src/queue/outbox.rs
@@ -66,10 +66,9 @@ impl MessageOutbox {
     pub fn enqueue(&self, event_json: String) {
         let now = unix_now();
         let msg = QueuedMessage::new(event_json, now);
-        self.queue
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .push(msg);
+        let mut q = self.queue.lock().unwrap_or_else(|e| e.into_inner());
+        q.push(msg);
+        crate::api::logging::blog_info("queue", format!("enqueued pending={}", q.len()));
     }
 
     /// Attempt to publish all pending messages.
@@ -114,14 +113,30 @@ impl MessageOutbox {
                 Ok(()) => {
                     msg.status = QueuedMessageStatus::Sent;
                     sent += 1;
+                    crate::api::logging::blog_info(
+                        "queue",
+                        format!("flushed after {} retries", msg.retry_count),
+                    );
                 }
-                Err(_) => {
+                Err(e) => {
                     msg.retry_count += 1;
                     if msg.retry_count >= MAX_RETRIES {
                         msg.status = QueuedMessageStatus::Failed;
+                        crate::api::logging::blog_warn(
+                            "queue",
+                            format!("giving up after {MAX_RETRIES} retries: {e}"),
+                        );
                     } else {
                         msg.status = QueuedMessageStatus::Pending;
                         msg.next_retry_at = Some(now + msg.next_retry_delay_secs());
+                        crate::api::logging::blog_warn(
+                            "queue",
+                            format!(
+                                "publish failed (attempt {}), retrying in {}s: {e}",
+                                msg.retry_count,
+                                msg.next_retry_delay_secs(),
+                            ),
+                        );
                     }
                 }
             }

--- a/rust/src/queue/outbox.rs
+++ b/rust/src/queue/outbox.rs
@@ -68,7 +68,7 @@ impl MessageOutbox {
         let msg = QueuedMessage::new(event_json, now);
         let mut q = self.queue.lock().unwrap_or_else(|e| e.into_inner());
         q.push(msg);
-        crate::api::logging::blog_info("queue", format!("enqueued pending={}", q.len()));
+        crate::api::logging::blog_info("queue", format!("enqueued total={}", q.len()));
     }
 
     /// Attempt to publish all pending messages.
@@ -124,7 +124,10 @@ impl MessageOutbox {
                         msg.status = QueuedMessageStatus::Failed;
                         crate::api::logging::blog_warn(
                             "queue",
-                            format!("giving up after {MAX_RETRIES} retries: {e}"),
+                            format!(
+                                "giving up after {MAX_RETRIES} failures: {}",
+                                crate::api::logging::sanitize_relay_text(&e.to_string()),
+                            ),
                         );
                     } else {
                         msg.status = QueuedMessageStatus::Pending;
@@ -132,9 +135,10 @@ impl MessageOutbox {
                         crate::api::logging::blog_warn(
                             "queue",
                             format!(
-                                "publish failed (attempt {}), retrying in {}s: {e}",
+                                "publish failed (attempt {}), retrying in {}s: {}",
                                 msg.retry_count,
                                 msg.next_retry_delay_secs(),
+                                crate::api::logging::sanitize_relay_text(&e.to_string()),
                             ),
                         );
                     }


### PR DESCRIPTION
Closes #241 

## Scope

Four additive commits — log statements over existing code paths, no logic
changes:

1. **Redaction helpers + tests**: `short_id()` (8-char ids) and
   `scrub_secrets()` (masks `nsec1…`), applied once at the logger choke
   point so no sink — console, logcat, retained buffer — can leak key
   material. Tests prove forbidden material never reaches `recent_logs()`.
2. **Relay & subscription lifecycle**: relay status transitions from the
   pool monitor (gain/loss at info, retry churn at debug), subscription
   create/replace with filter shape, and the notification loop no longer
   swallows relay control messages: EOSE/auth at debug, CLOSED/NOTICE at
   warn.
3. **Wire boundaries**: per-relay OK/FAIL for every published event
   (protocol + chat envelope, metadata only), outbox
   enqueue/flush/retry/give-up, raw inbound kind-14/1059 frames at debug
   (before the SDK's first-seen dedup), and the two previously silent
   drops (unmatched p-tag → warn, duplicate → debug).
4. **Trade state transitions**: every wire→status sync logs its decision
   (`wire`, `local`, `applies`, source channel — real transitions at
   info, blocked/no-op at debug), uniform status lines for the kind-14
   arms, session create/remove, and the request-correlation story
   completed (created/resolved/timeout; latency by subtracting log
   timestamps — no struct changes).

## Out of scope

- **Dart-side log unification** (routing Dart logs into the Rust ring so
  the in-app Logs screen and `adb logcat -s mostro` carry the whole
  story): deferred until the Logs screen work happens; for development,
  `adb logcat -s mostro flutter` already shows both halves.
- A latency field on `PendingRequest`: timestamps on the created/resolved
  lines make the duration derivable without touching the struct.
- Fixes for anything the new logs reveal (e.g. the #277 kind-14 catch-up
  findings) — those go in their own PRs.

## Cost

Info-level flow lines are a handful per protocol action; everything
chatty (raw frames, EOSE, dedup, book updates) sits at debug, which is
off in release builds and costs a branch when disabled.

## Manual testing

- Desktop: `flutter run` shows the full trace (Rust via stderr).
- Android: `adb logcat -s mostro flutter -v time` (or `-s mostro:I` for
  info+ only). Create → take → invoice → release reads end-to-end.

Plus one behavior fix requested in review: publish_event_json now rejects total publish failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive `nsec1` key material is now removed from live and retained logs.
  * Log messages and relay-provided text are sanitized before display.
  * Relay identifiers are shortened or filtered to avoid exposing sensitive details.

* **Improvements**
  * Added clearer diagnostics for order processing, relay activity, sessions, queue retries, and connection status.
  * Relay publishing now reports individual successes and failures.
  * Queue and wallet connection logs include safer retry, error, and request details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->