### PR TITLE
fix(orders): handle inbound add-invoice in the kind-14 ingest

### DIFF
--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -2012,6 +2012,55 @@ async fn dispatch_mostro_message(
                 }
             }
         }
+        // Mostro asks the buyer for a Lightning invoice with AddInvoice. A
+        // taker's first copy is consumed by the take waiter as the take
+        // reply; this arm covers the maker-buyer, whose buy order was taken
+        // and the hold invoice paid. The message arrives on the global feed
+        // with no trade_index, so the order id is the only usable key.
+        Action::AddInvoice => {
+            let order_id = match &kind.id {
+                Some(id) => id.to_string(),
+                None => {
+                    log::warn!("[orders] gift-wrap AddInvoice has no order id");
+                    return;
+                }
+            };
+            let Some((new_status, amount)) = add_invoice_sync(&kind.payload) else {
+                // The daemon follows up with a second AddInvoice carrying a
+                // Peer payload (counterparty reputation) — ignored for now.
+                log::debug!(
+                    "[orders] gift-wrap AddInvoice for order={order_id}: no Order payload, ignoring"
+                );
+                return;
+            };
+            crate::api::logging::blog_info(
+                "orders",
+                format!(
+                    "status order={} →{new_status:?} src=kind14/AddInvoice",
+                    crate::api::logging::short_id(&order_id),
+                ),
+            );
+            // Sync the book with status AND calculated sats: the add-invoice
+            // screen polls the book for the amount (tradeAmountProvider) and
+            // refuses to submit an LN address without it.
+            if let Some(mut info) = order_book().get_order(&order_id).await {
+                info.status = new_status.clone();
+                if amount.is_some() {
+                    info.amount_sats = amount;
+                }
+                order_book().upsert_order(info).await;
+            }
+            if let Some(db) = crate::db::app_db::db() {
+                if let Err(e) = db
+                    .update_trade_fields(&order_id, Some(new_status), None, amount)
+                    .await
+                {
+                    log::warn!(
+                        "[orders] failed to sync add-invoice for order={order_id}: {e}"
+                    );
+                }
+            }
+        }
         // Mostro sends PayInvoice to the seller with the hold invoice bolt11
         // when a buyer takes a sell order (or a seller takes a buy order).
         Action::PayInvoice => {
@@ -2279,6 +2328,7 @@ async fn dispatch_mostro_message(
 fn status_for_action(action: &mostro_core::message::Action) -> Option<OrderStatus> {
     use mostro_core::message::Action;
     match action {
+        Action::AddInvoice => Some(OrderStatus::WaitingBuyerInvoice),
         Action::WaitingSellerToPay => Some(OrderStatus::WaitingPayment),
         Action::WaitingBuyerInvoice => Some(OrderStatus::WaitingBuyerInvoice),
         Action::BuyerTookOrder
@@ -2303,6 +2353,32 @@ fn status_for_action(action: &mostro_core::message::Action) -> Option<OrderStatu
         }
         Action::AdminSettled => Some(OrderStatus::SettledByAdmin),
         Action::AdminCanceled => Some(OrderStatus::CanceledByAdmin),
+        _ => None,
+    }
+}
+
+/// Extracts the status and calculated sats to persist from an inbound
+/// `add-invoice` payload.
+///
+/// Returns `None` when the payload carries no order data — notably the
+/// daemon's follow-up `add-invoice` with a `Peer` payload (counterparty
+/// reputation), which is deliberately not consumed yet.
+fn add_invoice_sync(
+    payload: &Option<mostro_core::message::Payload>,
+) -> Option<(OrderStatus, Option<u64>)> {
+    match payload {
+        Some(mostro_core::message::Payload::Order(so)) => {
+            let status = so
+                .status
+                .and_then(map_core_status)
+                .unwrap_or(OrderStatus::WaitingBuyerInvoice);
+            let amount = if so.amount > 0 {
+                Some(so.amount as u64)
+            } else {
+                None
+            };
+            Some((status, amount))
+        }
         _ => None,
     }
 }
@@ -4178,6 +4254,45 @@ mod tests {
             }
             _ => panic!("expected TakeAccepted"),
         }
+    }
+
+    /// Inbound add-invoice (maker-buyer path): the Order payload carries the
+    /// status and calculated sats to persist; anything else — notably the
+    /// daemon's follow-up Peer payload with the counterparty's reputation —
+    /// syncs nothing.
+    #[test]
+    fn add_invoice_sync_maps_payloads() {
+        use mostro_core::message::Payload;
+        use mostro_core::order::Status;
+
+        // Real-world shape from the reproduction: status + calculated sats.
+        let so = small_order_with(Status::WaitingBuyerInvoice, 484);
+        match add_invoice_sync(&Some(Payload::Order(so))) {
+            Some((status, amount)) => {
+                assert_eq!(status, crate::api::types::OrderStatus::WaitingBuyerInvoice);
+                assert_eq!(amount, Some(484));
+            }
+            None => panic!("expected Order payload to sync"),
+        }
+
+        // Unpriced amount must not persist as Some(0).
+        let so = small_order_with(Status::WaitingBuyerInvoice, 0);
+        let (_, amount) =
+            add_invoice_sync(&Some(Payload::Order(so))).expect("Order payload must sync");
+        assert_eq!(amount, None);
+
+        // No payload → nothing to sync.
+        assert!(add_invoice_sync(&None).is_none());
+    }
+
+    /// A payload-less add-invoice must still imply WaitingBuyerInvoice, both
+    /// for the ingest fallback and for action-only take replies.
+    #[test]
+    fn status_for_action_maps_add_invoice() {
+        assert_eq!(
+            status_for_action(&mostro_core::message::Action::AddInvoice),
+            Some(crate::api::types::OrderStatus::WaitingBuyerInvoice)
+        );
     }
 
     /// Only the pending create's own local UUID may be rebound to an incoming

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -4281,6 +4281,14 @@ mod tests {
             add_invoice_sync(&Some(Payload::Order(so))).expect("Order payload must sync");
         assert_eq!(amount, None);
 
+        // The daemon's follow-up Peer payload (counterparty reputation) must
+        // sync nothing — it would otherwise clobber the just-written status.
+        let peer = Payload::Peer(mostro_core::message::Peer {
+            pubkey: String::new(),
+            reputation: None,
+        });
+        assert!(add_invoice_sync(&Some(peer)).is_none());
+
         // No payload → nothing to sync.
         assert!(add_invoice_sync(&None).is_none());
     }
@@ -4293,6 +4301,21 @@ mod tests {
             status_for_action(&mostro_core::message::Action::AddInvoice),
             Some(crate::api::types::OrderStatus::WaitingBuyerInvoice)
         );
+
+        // The mapping also feeds classify_take_reply: a payload-less
+        // add-invoice take reply must carry the implied status instead of
+        // persisting the trade as Pending.
+        match classify_take_reply(&mostro_core::message::Action::AddInvoice, &None) {
+            DaemonReply::TakeAccepted { status, amount_sats, hold_invoice, .. } => {
+                assert_eq!(
+                    status,
+                    Some(crate::api::types::OrderStatus::WaitingBuyerInvoice)
+                );
+                assert!(amount_sats.is_none());
+                assert!(hold_invoice.is_none());
+            }
+            _ => panic!("expected TakeAccepted"),
+        }
     }
 
     /// Only the pending create's own local UUID may be rebound to an incoming

--- a/specs/004-mostro-p2p-client/contracts/orders.md
+++ b/specs/004-mostro-p2p-client/contracts/orders.md
@@ -242,9 +242,10 @@ what to listen to. Reference: <https://mostro.network/protocol/seller_pay_hold_i
 
 ### Inbound gift-wrap actions consumed by `process_gift_wrap_rumor`
 
-| Action                             | Payload variant                                     | Effect on the seller's trade row                                                 |
+| Action                             | Payload variant                                     | Effect on the local trade row                                                    |
 |------------------------------------|-----------------------------------------------------|----------------------------------------------------------------------------------|
 | `WaitingBuyerInvoice`              | (status sync)                                       | `status → WaitingBuyerInvoice`                                                   |
+| `AddInvoice`                       | `Payload::Order(small_order)`                       | Maker-buyer path (a taker's nonce-correlated copy is consumed by the take interception, even when late): `status → WaitingBuyerInvoice` (payload status, fallback `status_for_action`), `amount_sats ← small_order.amount` when > 0 — synced to book **and** DB so `tradeAmountProvider` sees the sats. Keyed by the message's order id (`trade_index` is `None`). The follow-up `AddInvoice` with a `Payload::Peer` (counterparty reputation) is ignored. |
 | `PayInvoice`                       | `Payload::PaymentRequest(small_order, bolt11, amt)` | `hold_invoice ← bolt11`, `amount_sats ← amt ?? small_order.amount`, `status → WaitingPayment` |
 | `BuyerTookOrder` / `HoldInvoicePaymentAccepted` | `SmallOrder` with `status = active`      | `status → Active` (routed through `map_core_status` kebab-case)                  |
 | `FiatSentOk`                       | (status sync)                                       | `status → FiatSent`                                                              |

--- a/specs/004-mostro-p2p-client/contracts/orders.md
+++ b/specs/004-mostro-p2p-client/contracts/orders.md
@@ -240,7 +240,7 @@ call — it arrives as a Kind 14 (NIP-44) message from mostrod. This
 section documents the full chain so Flutter providers and screens know
 what to listen to. Reference: <https://mostro.network/protocol/seller_pay_hold_invoice.html>.
 
-### Inbound gift-wrap actions consumed by `process_gift_wrap_rumor`
+### Inbound Kind 14 actions consumed by `dispatch_mostro_message`
 
 | Action                             | Payload variant                                     | Effect on the local trade row                                                    |
 |------------------------------------|-----------------------------------------------------|----------------------------------------------------------------------------------|


### PR DESCRIPTION
Closes #287 

## Problem

The kind-14 ingest (`dispatch_mostro_message`) had no arm for an inbound
`add-invoice`, so it fell into the catch-all and was dropped. That message is
how the daemon asks a **maker buyer** for their invoice after the seller taker
paid the hold invoice. The trade never reached `WaitingBuyerInvoice`, the user
was never prompted to act, and the daemon canceled the order by timeout
(reproduced against a real daemon — see the timeline in #287).

## Fix

- New `Action::AddInvoice` arm, next to the existing `PayInvoice` one. It is
  keyed by the message's order id (the message arrives on the global feed with
  `trade_index=None`), and persists the status and the calculated sats to both
  the order book and the trade DB.
- The order book gets the amount too because the add-invoice screen polls it
  (`tradeAmountProvider`) and refuses an LN address — and NWC auto-generation —
  without a known amount.
- The daemon's follow-up `add-invoice` carrying a `Payload::Peer` (counterparty
  reputation) is ignored for now.
- `status_for_action` now maps `AddInvoice → WaitingBuyerInvoice`, covering
  payload-less messages.
- A taker is unaffected: their nonce-correlated copy is still consumed by the
  take interception before the per-action arms run.

No Dart changes: with the status persisted, the existing `MyOrderScreen`
branch (`waitingBuyerInvoice && !isSelling`) already navigates the maker buyer
to the add-invoice screen. Global auto-navigation from anywhere in the app is
tracked separately in #283.

## Changes

- `rust/src/api/orders.rs`: new ingest arm, `add_invoice_sync` helper,
  `status_for_action` mapping, unit tests.
- `specs/004-mostro-p2p-client/contracts/orders.md`: `AddInvoice` row in the
  inbound actions table; stale section heading fixed (`dispatch_mostro_message`
  over Kind 14, not the long-gone `process_gift_wrap_rumor`).

## Testing

- `cargo test` (249 passed) and `cargo clippy` (no new warnings).
- `./scripts/frb-generate.sh --check` — no bridge surface changes.
- Manual reproduction of the maker-buyer flow pending review feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for processing inbound invoice messages and updating order amounts and statuses.
  * Improved handling of invoice responses, including replies without payloads and zero-amount orders.
  * Non-order follow-up messages are now safely ignored.

* **Documentation**
  * Documented invoice message handling, trade updates, amount synchronization, and late-message processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->