### PR TITLE
fix(#267): add bottom SafeArea insets so the system bar doesn't overlap content

### DIFF
--- a/lib/features/about/screens/about_screen.dart
+++ b/lib/features/about/screens/about_screen.dart
@@ -71,9 +71,13 @@ class AboutScreen extends ConsumerWidget {
     return Scaffold(
       appBar: AppBar(title: Text(l10n.aboutScreenTitle)),
       body: ListView(
-        padding: const EdgeInsets.symmetric(
-          horizontal: AppSpacing.lg,
-          vertical: AppSpacing.lg,
+        // #267: add the bottom system-bar inset so the last item isn't hidden
+        // behind the gesture / 3-button navigation bar.
+        padding: EdgeInsets.fromLTRB(
+          AppSpacing.lg,
+          AppSpacing.lg,
+          AppSpacing.lg,
+          AppSpacing.lg + MediaQuery.of(context).viewPadding.bottom,
         ),
         children: [
           // ── App Information Card ───────────────────────────────────────────

--- a/lib/features/account/screens/account_screen.dart
+++ b/lib/features/account/screens/account_screen.dart
@@ -117,7 +117,14 @@ class _AccountScreenState extends ConsumerState<AccountScreen> {
     return Scaffold(
       appBar: AppBar(title: Text(l10n.accountScreenTitle)),
       body: ListView(
-        padding: const EdgeInsets.all(AppSpacing.lg),
+        // #267: bottom system-bar inset so the Import/Refresh row and last
+        // item clear the gesture / 3-button navigation bar.
+        padding: EdgeInsets.fromLTRB(
+          AppSpacing.lg,
+          AppSpacing.lg,
+          AppSpacing.lg,
+          AppSpacing.lg + MediaQuery.of(context).viewPadding.bottom,
+        ),
         children: [
           // ── Backup ritual banner — entry point for the 3-step backup
           // flow while the backup reminder is active.

--- a/lib/features/disputes/screens/dispute_chat_screen.dart
+++ b/lib/features/disputes/screens/dispute_chat_screen.dart
@@ -110,11 +110,13 @@ class _DisputeChatScreenState extends ConsumerState<DisputeChatScreen> {
           // ── Message input (in-progress only) ─────────────────────────
           if (isInProgress)
             Padding(
-              padding: const EdgeInsets.fromLTRB(
+              // #267: add the bottom system-bar inset so the message input
+              // clears the gesture / 3-button navigation bar.
+              padding: EdgeInsets.fromLTRB(
                 AppSpacing.md,
                 AppSpacing.xs,
                 AppSpacing.md,
-                AppSpacing.md,
+                AppSpacing.md + MediaQuery.of(context).viewPadding.bottom,
               ),
               child: DisputeMessageInput(
                 onSendText: _onSendText,

--- a/lib/features/notifications/screens/notifications_screen.dart
+++ b/lib/features/notifications/screens/notifications_screen.dart
@@ -134,9 +134,13 @@ class _NotificationsScreenState extends ConsumerState<NotificationsScreen> {
         ),
         Expanded(
           child: ListView(
-            padding: const EdgeInsets.symmetric(
-              horizontal: AppSpacing.lg,
-              vertical: AppSpacing.md,
+            // #267: add the bottom system-bar inset so the last item isn't
+            // hidden behind the gesture / 3-button navigation bar.
+            padding: EdgeInsets.fromLTRB(
+              AppSpacing.lg,
+              AppSpacing.md,
+              AppSpacing.lg,
+              AppSpacing.md + MediaQuery.of(context).viewPadding.bottom,
             ),
             children: [
               // ── System section (banners) ──

--- a/lib/features/order/screens/add_lightning_invoice_screen.dart
+++ b/lib/features/order/screens/add_lightning_invoice_screen.dart
@@ -249,7 +249,14 @@ class _AddLightningInvoiceScreenState
     return Scaffold(
       appBar: AppBar(title: Text(l10n.addInvoiceTitle)),
       body: Padding(
-        padding: const EdgeInsets.all(AppSpacing.lg),
+        // #267: bottom system-bar inset so the Cancel/Submit row clears the
+        // gesture / 3-button navigation bar.
+        padding: EdgeInsets.fromLTRB(
+          AppSpacing.lg,
+          AppSpacing.lg,
+          AppSpacing.lg,
+          AppSpacing.lg + MediaQuery.of(context).viewPadding.bottom,
+        ),
         child: Column(
           children: [
             // Info card

--- a/lib/features/order/screens/pay_lightning_invoice_screen.dart
+++ b/lib/features/order/screens/pay_lightning_invoice_screen.dart
@@ -232,7 +232,14 @@ class _PayLightningInvoiceScreenState
         return Scaffold(
           appBar: AppBar(title: Text(l10n.payLightningInvoiceTitle)),
           body: Padding(
-            padding: const EdgeInsets.all(AppSpacing.lg),
+            // #267: bottom system-bar inset so the Cancel button clears the
+            // gesture / 3-button navigation bar.
+            padding: EdgeInsets.fromLTRB(
+              AppSpacing.lg,
+              AppSpacing.lg,
+              AppSpacing.lg,
+              AppSpacing.lg + MediaQuery.of(context).viewPadding.bottom,
+            ),
             child: Column(
               children: [
                 // Info card with QR

--- a/lib/features/settings/screens/connect_wallet_screen.dart
+++ b/lib/features/settings/screens/connect_wallet_screen.dart
@@ -113,7 +113,14 @@ class _ConnectWalletScreenState extends ConsumerState<ConnectWalletScreen> {
     return Scaffold(
       appBar: AppBar(title: Text(l10n.connectWalletTitle)),
       body: Padding(
-        padding: const EdgeInsets.all(AppSpacing.lg),
+        // #267: bottom system-bar inset so the Connect button clears the
+        // gesture / 3-button navigation bar.
+        padding: EdgeInsets.fromLTRB(
+          AppSpacing.lg,
+          AppSpacing.lg,
+          AppSpacing.lg,
+          AppSpacing.lg + MediaQuery.of(context).viewPadding.bottom,
+        ),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [

--- a/lib/features/settings/screens/log_report_screen.dart
+++ b/lib/features/settings/screens/log_report_screen.dart
@@ -108,7 +108,14 @@ class _LogReportScreenState extends ConsumerState<LogReportScreen> {
                     ),
                   )
                 : ListView.builder(
-                    padding: const EdgeInsets.all(AppSpacing.md),
+                    // #267: bottom system-bar inset so the last log entry
+                    // clears the gesture / 3-button navigation bar.
+                    padding: EdgeInsets.fromLTRB(
+                      AppSpacing.md,
+                      AppSpacing.md,
+                      AppSpacing.md,
+                      AppSpacing.md + MediaQuery.of(context).viewPadding.bottom,
+                    ),
                     itemCount: entries.length,
                     itemBuilder: (context, index) {
                       return _LogEntryTile(

--- a/lib/features/settings/screens/notification_settings_screen.dart
+++ b/lib/features/settings/screens/notification_settings_screen.dart
@@ -71,7 +71,14 @@ class _NotificationSettingsScreenState
         title: Text(l10n.pushNotificationsSettingTitle),
       ),
       body: ListView(
-        padding: const EdgeInsets.all(AppSpacing.lg),
+        // #267: add the bottom system-bar inset so the last item isn't hidden
+        // behind the gesture / 3-button navigation bar.
+        padding: EdgeInsets.fromLTRB(
+          AppSpacing.lg,
+          AppSpacing.lg,
+          AppSpacing.lg,
+          AppSpacing.lg + MediaQuery.of(context).viewPadding.bottom,
+        ),
         children: [
           Padding(
             padding: const EdgeInsets.only(bottom: AppSpacing.md),

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -42,7 +42,14 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         ),
       ),
       body: ListView(
-        padding: const EdgeInsets.all(AppSpacing.lg),
+        // #267: add the bottom system-bar inset so the last item isn't hidden
+        // behind the gesture / 3-button navigation bar.
+        padding: EdgeInsets.fromLTRB(
+          AppSpacing.lg,
+          AppSpacing.lg,
+          AppSpacing.lg,
+          AppSpacing.lg + MediaQuery.of(context).viewPadding.bottom,
+        ),
         children: [
           // 1 — Language
           _settingsCard(

--- a/lib/features/settings/screens/wallet_settings_screen.dart
+++ b/lib/features/settings/screens/wallet_settings_screen.dart
@@ -34,7 +34,14 @@ class WalletSettingsScreen extends ConsumerWidget {
         ),
       ),
       body: Padding(
-        padding: const EdgeInsets.all(AppSpacing.lg),
+        // #267: bottom system-bar inset so the Disconnect/Connect button clears
+        // the gesture / 3-button navigation bar.
+        padding: EdgeInsets.fromLTRB(
+          AppSpacing.lg,
+          AppSpacing.lg,
+          AppSpacing.lg,
+          AppSpacing.lg + MediaQuery.of(context).viewPadding.bottom,
+        ),
         child: wallet == null
             ? _DisconnectedView(green: green, cardBg: cardBg, theme: theme, colors: colors)
             : _ConnectedView(

--- a/lib/features/settings/widgets/mostro_node_selector.dart
+++ b/lib/features/settings/widgets/mostro_node_selector.dart
@@ -1,3 +1,4 @@
+import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -121,8 +122,10 @@ class _MostroNodeSelectorState extends ConsumerState<MostroNodeSelector> {
         left: AppSpacing.lg,
         right: AppSpacing.lg,
         top: AppSpacing.lg,
-        bottom: MediaQuery.viewInsetsOf(context).bottom +
-            MediaQuery.viewPaddingOf(context).bottom +
+        bottom: math.max(
+              MediaQuery.viewInsetsOf(context).bottom,
+              MediaQuery.viewPaddingOf(context).bottom,
+            ) +
             AppSpacing.lg,
       ),
       child: Column(

--- a/lib/features/settings/widgets/mostro_node_selector.dart
+++ b/lib/features/settings/widgets/mostro_node_selector.dart
@@ -121,7 +121,9 @@ class _MostroNodeSelectorState extends ConsumerState<MostroNodeSelector> {
         left: AppSpacing.lg,
         right: AppSpacing.lg,
         top: AppSpacing.lg,
-        bottom: MediaQuery.viewInsetsOf(context).bottom + AppSpacing.lg,
+        bottom: MediaQuery.viewInsetsOf(context).bottom +
+            MediaQuery.viewPaddingOf(context).bottom +
+            AppSpacing.lg,
       ),
       child: Column(
         mainAxisSize: MainAxisSize.min,

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -509,7 +509,14 @@ class _TradeDetailScreenState extends ConsumerState<TradeDetailScreen> {
         actions: [_buildOverflowMenu()],
       ),
       body: ListView(
-        padding: const EdgeInsets.all(AppSpacing.lg),
+        // #267: add the bottom system-bar inset so the last item isn't hidden
+        // behind the gesture / 3-button navigation bar.
+        padding: EdgeInsets.fromLTRB(
+          AppSpacing.lg,
+          AppSpacing.lg,
+          AppSpacing.lg,
+          AppSpacing.lg + MediaQuery.of(context).viewPadding.bottom,
+        ),
         children: [
           // Persistent chat chip — always-on access to the counterpart.
           if (inFlight) ...[

--- a/lib/features/walkthrough/screens/walkthrough_screen.dart
+++ b/lib/features/walkthrough/screens/walkthrough_screen.dart
@@ -74,6 +74,14 @@ class WalkthroughScreen extends ConsumerWidget {
         shape: const CircleBorder(),
       ),
       globalBackgroundColor: theme.scaffoldBackgroundColor,
+      // #267: pad the Skip/Back/Next/Done controls past the bottom system bar.
+      // The package's default controlsPadding has no bottom inset.
+      controlsPadding: EdgeInsets.fromLTRB(
+        16.0,
+        4.0,
+        16.0,
+        4.0 + MediaQuery.of(context).viewPadding.bottom,
+      ),
     );
   }
 

--- a/lib/features/walkthrough/screens/walkthrough_screen.dart
+++ b/lib/features/walkthrough/screens/walkthrough_screen.dart
@@ -78,9 +78,9 @@ class WalkthroughScreen extends ConsumerWidget {
       // The package's default controlsPadding has no bottom inset.
       controlsPadding: EdgeInsets.fromLTRB(
         16.0,
-        4.0,
         16.0,
-        4.0 + MediaQuery.of(context).viewPadding.bottom,
+        16.0,
+        16.0 + MediaQuery.of(context).viewPadding.bottom,
       ),
     );
   }

--- a/test/features/settings/widgets/mostro_node_selector_test.dart
+++ b/test/features/settings/widgets/mostro_node_selector_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro/core/app_theme.dart';
+import 'package:mostro/features/settings/widgets/mostro_node_selector.dart';
+import 'package:mostro/l10n/app_localizations.dart';
+import '../../../support/provider_harness.dart';
+
+/// Pump the selector with the given bottom [keyboardInset] (viewInsets) and
+/// [systemBarInset] (viewPadding). A tall surface keeps a large keyboard inset
+/// from overflowing the test viewport.
+Future<void> _pump(
+  WidgetTester tester, {
+  double keyboardInset = 0,
+  double systemBarInset = 0,
+}) async {
+  tester.view.physicalSize = const Size(1200, 3000);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+  final container = createContainer();
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(
+        theme: buildDarkTheme(),
+        locale: const Locale('en'),
+        localizationsDelegates: const [
+          AppLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Builder(
+          builder: (context) => MediaQuery(
+            data: MediaQuery.of(context).copyWith(
+              viewInsets: EdgeInsets.only(bottom: keyboardInset),
+              viewPadding: EdgeInsets.only(bottom: systemBarInset),
+              padding: EdgeInsets.only(bottom: systemBarInset),
+            ),
+            child: const Scaffold(
+              resizeToAvoidBottomInset: false,
+              body: MostroNodeSelector(),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('MostroNodeSelector bottom inset', () {
+    testWidgets('renders with the keyboard hidden', (tester) async {
+      await _pump(tester, keyboardInset: 0, systemBarInset: 34);
+      expect(find.byType(OutlinedButton), findsOneWidget);
+      expect(find.byType(FilledButton), findsOneWidget);
+    });
+
+    testWidgets('renders with the keyboard visible', (tester) async {
+      await _pump(tester, keyboardInset: 300, systemBarInset: 34);
+      expect(find.byType(OutlinedButton), findsOneWidget);
+      expect(find.byType(FilledButton), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Closes #267.

## Problem
Most screens don't handle the bottom safe-area inset, so the phone's system navigation bar (gesture bar ~24dp / 3-button bar ~48dp) overlaps the bottom of the content. The largest bottom padding in use was `AppSpacing.lg` (16px), which isn't enough for either bar, and there's no global `SafeArea` wrapper (no `ShellRoute` / shared scaffold), so each screen must protect itself.

## Fix
Add `MediaQuery.of(context).viewPadding.bottom` to the bottom padding of each affected screen the same mechanism the `BottomNavBar` screens already rely on. Minimal and per-screen: the existing padding is extended, no widget trees are restructured.

**Scrollable content (last item was hidden at max scroll):**
settings, notification settings, notifications, log report, trade detail, about.

**Interactive elements pinned at the bottom:**
dispute chat (message input), walkthrough (Skip/Back/Next/Done controls), add / pay lightning invoice (Cancel/Submit), connect wallet, wallet settings, account (Import/Refresh row).

Screens already handled by `BottomNavBar` or an existing `SafeArea` (Home, Trades, Chat, Add/My/Take Order, Backup ritual, Rate) are untouched.

## Testing
Verified on Linux desktop with a **simulated 48px bottom system bar** (temporarily injecting `MediaQuery` `viewPadding.bottom: 48` at the app root plus a translucent band marking the bar). On every affected screen the last item / bottom control now clears the simulated bar instead of being overlapped.

_Screenshots below._

`flutter analyze` clean across all 13 files.
<img width="1447" height="824" alt="Screenshot 2026-08-09 193825" src="https://github.com/user-attachments/assets/f484354d-6eac-47f2-9636-59d9a45ce389" />
<img width="1312" height="787" alt="Screenshot 2026-08-09 193903" src="https://github.com/user-attachments/assets/050e1147-718c-4544-9541-0194188209be" />
<img width="1286" height="768" alt="Screenshot 2026-08-09 193937" src="https://github.com/user-attachments/assets/ec3e043a-f909-4913-9523-8ca331a83202" />
<img width="1301" height="778" alt="Screenshot 2026-08-09 193958" src="https://github.com/user-attachments/assets/96596891-5f2b-4ff1-818e-9c263a5ad692" />
<img width="1285" height="763" alt="Screenshot 2026-08-09 194021" src="https://github.com/user-attachments/assets/690eee2a-b130-4762-b9e7-85297c9ec13e" />
<img width="1294" height="784" alt="Screenshot 2026-08-09 194100" src="https://github.com/user-attachments/assets/72c0d915-d6b1-4884-b456-cc4d5ba4c15d" />
<img width="1303" height="774" alt="Screenshot 2026-08-09 194113" src="https://github.com/user-attachments/assets/e7bbbcff-208d-42a4-a945-c92d51b37542" />
<img width="1313" height="787" alt="Screenshot 2026-08-09 194211" src="https://github.com/user-attachments/assets/7d03bcc3-5a32-4572-9710-9729ca42c4d6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bottom spacing across account, settings, notifications, trade, dispute, invoice, walkthrough, and other screens.
  * Content, forms, list items, and action buttons now remain visible above gesture and navigation bars.
  * Improved bottom-sheet spacing when the keyboard or system navigation controls are visible.
  * Added coverage to verify correct layout behavior with and without the on-screen keyboard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->