### PR TITLE
fix(#269): bucket My Trades filter by live status, not the stale snapshot

### DIFF
--- a/lib/features/trades/providers/trades_providers.dart
+++ b/lib/features/trades/providers/trades_providers.dart
@@ -207,7 +207,14 @@ final filteredTradesWithOrderStateProvider =
   // of truth. Until the live status has loaded we fall back to the snapshot
   // bucket, so nothing briefly escapes the active filter.
   final items = trades.map((trade) {
-    final live = ref.watch(tradeStatusProvider(trade.order.id)).valueOrNull;
+    // Terminal trades cannot change further, so don't create a long-lived 2s
+    // poller for them — mirroring the guard in orderBookNotificationCountProvider
+    // (#299 review). Their snapshot status is authoritative here: order status
+    // only ever moves toward terminal, so a snapshot can lag but never run ahead,
+    // and falling back to it (live == null) buckets them by their real status.
+    final live = _terminalOrderStatuses.contains(trade.order.status)
+        ? null
+        : ref.watch(tradeStatusProvider(trade.order.id)).valueOrNull;
     return _tradeInfoToItem(
       trade,
       statusOverride: live == null ? null : orderStatusToFilter(live),

--- a/lib/features/trades/providers/trades_providers.dart
+++ b/lib/features/trades/providers/trades_providers.dart
@@ -114,7 +114,10 @@ TradeStatusFilter orderStatusToFilter(rust_types.OrderStatus status) {
 // ── Internal helpers ──────────────────────────────────────────────────────────
 
 /// Converts a [rust_types.TradeInfo] to a [TradeListItem].
-TradeListItem _tradeInfoToItem(rust_types.TradeInfo trade) {
+TradeListItem _tradeInfoToItem(
+  rust_types.TradeInfo trade, {
+  TradeStatusFilter? statusOverride,
+}) {
   final fiatDisplay = _formatFiat(
     trade.order.fiatAmount,
     trade.order.fiatAmountMin,
@@ -128,7 +131,7 @@ TradeListItem _tradeInfoToItem(rust_types.TradeInfo trade) {
     // TradeRole.buyer = the user is buying Bitcoin (took a sell order or
     // created a buy order). TradeRole.seller = selling Bitcoin.
     isSelling: trade.role == rust_types.TradeRole.seller,
-    status: orderStatusToFilter(trade.order.status),
+    status: statusOverride ?? orderStatusToFilter(trade.order.status),
     // order.isMine is true when the local user published this order (maker).
     role: trade.order.isMine ? TradeRole.creator : TradeRole.taker,
     fiatAmount: fiatDisplay,
@@ -197,7 +200,19 @@ final filteredTradesWithOrderStateProvider =
   final filter = ref.watch(selectedStatusFilterProvider);
   final trades = await ref.watch(rawTradesProvider.future);
 
-  final items = trades.map(_tradeInfoToItem).toList();
+  // Bucket each trade by the SAME live status its row chip shows, so the filter
+  // and the chip can never disagree (issue #269). The persisted snapshot in the
+  // DB can lag behind gift-wrap / 38383 updates (and, for own orders, is not
+  // always synced back to Pending), so tradeStatusProvider is the single source
+  // of truth. Until the live status has loaded we fall back to the snapshot
+  // bucket, so nothing briefly escapes the active filter.
+  final items = trades.map((trade) {
+    final live = ref.watch(tradeStatusProvider(trade.order.id)).valueOrNull;
+    return _tradeInfoToItem(
+      trade,
+      statusOverride: live == null ? null : orderStatusToFilter(live),
+    );
+  }).toList();
 
   final filtered = filter == TradeStatusFilter.all
       ? items

--- a/test/features/trades/filtered_trades_provider_test.dart
+++ b/test/features/trades/filtered_trades_provider_test.dart
@@ -192,5 +192,26 @@ void main() {
         ['order-z'],
       );
     });
+    test(
+        'a terminal trade keeps its snapshot bucket and ignores live status (#299)',
+        () async {
+      // A terminal trade must not spawn a live-status poller. Override its
+      // tradeStatusProvider with a NON-terminal live status: if the guard
+      // failed to skip the watch, the trade would follow that live status out
+      // of the success bucket. Because terminal trades bucket by snapshot, the
+      // override is never read, so it stays in success (#299 review).
+      final container = createContainer(overrides: [
+        rawTradesProvider.overrideWith(
+          (ref) async => [fakeTrade(id: 'done', status: OrderStatus.success)],
+        ),
+        tradeStatusProvider('order-done').overrideWith(
+          (ref) => Stream.value(OrderStatus.pending),
+        ),
+      ]);
+      expect(
+        await _orderIds(container, filter: TradeStatusFilter.success),
+        ['order-done'],
+      );
+    });
   });
 }

--- a/test/features/trades/filtered_trades_provider_test.dart
+++ b/test/features/trades/filtered_trades_provider_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mostro/features/trades/providers/trades_providers.dart';
+import 'package:mostro/features/order/providers/trade_state_provider.dart';
 import 'package:mostro/src/rust/api/types.dart' show TradeInfo, OrderStatus;
 
 import '../../support/fake_trades.dart';
@@ -93,6 +94,62 @@ void main() {
       expected.forEach((status, bucket) {
         expect(orderStatusToFilter(status), bucket, reason: '$status');
       });
+    });
+  });
+
+  group('live status buckets the filter (issue #269)', () {
+    // A trade whose persisted snapshot is Pending, but whose live status (the
+    // one the row chip shows) has already moved to waitingBuyerInvoice. The
+    // filter must follow the live status, not the stale snapshot.
+    ProviderContainer staleSnapshotContainer() => createContainer(overrides: [
+          rawTradesProvider.overrideWith(
+            (ref) async => [fakeTrade(id: 'x', status: OrderStatus.pending)],
+          ),
+          tradeStatusProvider('order-x').overrideWith(
+            (ref) => Stream.value(OrderStatus.waitingBuyerInvoice),
+          ),
+        ]);
+
+    // Wait for the overridden tradeStatusProvider stream to emit its first
+    // value, so the derived filter provider sees the live status rather than
+    // racing the snapshot fallback (which only applies until live loads).
+    Future<void> primeLiveStatus(ProviderContainer c) async {
+      await c.read(tradeStatusProvider('order-x').future);
+    }
+
+    test('trade does NOT appear under the stale Pending bucket', () async {
+      final container = staleSnapshotContainer();
+      await primeLiveStatus(container);
+      expect(
+        await _orderIds(container, filter: TradeStatusFilter.pending),
+        isEmpty,
+      );
+    });
+
+    test('trade appears under the live Waiting Invoice bucket', () async {
+      final container = staleSnapshotContainer();
+      await primeLiveStatus(container);
+      expect(
+        await _orderIds(container, filter: TradeStatusFilter.waitingInvoice),
+        ['order-x'],
+      );
+    });
+
+    test('falls back to the snapshot bucket until live status loads', () async {
+      // No tradeStatusProvider override: live is unavailable, so the snapshot
+      // status (Pending) is used. This preserves behaviour before first poll.
+      final container = createContainer(overrides: [
+        rawTradesProvider.overrideWith(
+          (ref) async => [fakeTrade(id: 'y', status: OrderStatus.pending)],
+        ),
+        tradeStatusProvider('order-y').overrideWith(
+          (ref) => const Stream.empty(),
+        ),
+      ]);
+      expect(
+        await _orderIds(container, filter: TradeStatusFilter.pending),
+        ['order-y'],
+      );
     });
   });
 }

--- a/test/features/trades/filtered_trades_provider_test.dart
+++ b/test/features/trades/filtered_trades_provider_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mostro/features/trades/providers/trades_providers.dart';
@@ -149,6 +151,45 @@ void main() {
       expect(
         await _orderIds(container, filter: TradeStatusFilter.pending),
         ['order-y'],
+      );
+    });
+
+    test('re-buckets live when the status transitions', () async {
+      // The core promise of #269: as a trade's live status changes, it moves
+      // between filter buckets in step with its chip. Drive the live status
+      // with a controllable stream and assert the trade leaves the old bucket
+      // and enters the new one.
+      final controller = StreamController<OrderStatus>();
+      addTearDown(controller.close);
+      final container = createContainer(overrides: [
+        rawTradesProvider.overrideWith(
+          (ref) async => [fakeTrade(id: 'z', status: OrderStatus.pending)],
+        ),
+        tradeStatusProvider('order-z').overrideWith((ref) => controller.stream),
+      ]);
+
+      // First live status: Pending. In the Pending bucket, not Waiting Invoice.
+      controller.add(OrderStatus.pending);
+      await container.read(tradeStatusProvider('order-z').future);
+      expect(
+        await _orderIds(container, filter: TradeStatusFilter.pending),
+        ['order-z'],
+      );
+      expect(
+        await _orderIds(container, filter: TradeStatusFilter.waitingInvoice),
+        isEmpty,
+      );
+
+      // Transition to Waiting Invoice: leaves Pending, enters Waiting Invoice.
+      controller.add(OrderStatus.waitingBuyerInvoice);
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        await _orderIds(container, filter: TradeStatusFilter.pending),
+        isEmpty,
+      );
+      expect(
+        await _orderIds(container, filter: TradeStatusFilter.waitingInvoice),
+        ['order-z'],
       );
     });
   });


### PR DESCRIPTION
## Problem
Each row's status chip shows the live status (`tradeStatusProvider`), but the filter dropdown bucketed trades using the status loaded once from the DB snapshot (`rawTradesProvider` -> `filteredTradesWithOrderStateProvider`). The snapshot only refreshes on pull-to-refresh / retry / after create-take, so changing the filter did not reload it, and status changes arriving via gift wrap / 38383 did not invalidate it.

Result: chip-vs-filter mismatches. A taken order stayed in the **Pending** bucket while its chip read **Waiting Invoice**.

## Fix
Bucket the filter with the **same live status the chip uses**, making it the single source of truth. `filteredTradesWithOrderStateProvider` now reads `tradeStatusProvider` per trade and buckets on that, falling back to the snapshot status only until the live status has loaded (so nothing briefly escapes the active filter).

Because the provider watches each trade's live status, the list re-buckets in real time: a trade moving Pending to Waiting Invoice leaves the Pending filter immediately, matching its chip. `_tradeInfoToItem` gained an optional `statusOverride` so the provider can supply the live bucket without duplicating the mapping.

## Testing
- A trade whose snapshot is Pending but whose live status is Waiting Invoice is **excluded** from the Pending bucket and **included** in the Waiting Invoice bucket.
- The snapshot fallback (live status not yet loaded) is covered.
- `flutter analyze` clean; verified on a physical device (Nokia C31): whatever a trade's chip shows, selecting that status in the filter shows it and selecting a different status hides it.

## Note on the DB layer
For own orders the 38383 ingest skips syncing `Pending` back (`orders.rs:2873`), so the persisted row can remain stale. **This change fixes the user-visible mismatch regardless** (the live status bypasses the stale snapshot). The persisted-status write-back is a separate data-correctness item and would be a good follow-up; happy to take it on if you'd like it in-scope.

Closes #269.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trade filtering now reflects the latest live trade status.
  * Trades continue using their saved status until live status information is available.
  * Trade lists now remain consistent with the statuses displayed in trade rows.

* **Tests**
  * Added coverage for live-status filtering and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->