### PR TITLE
feat(#282): validate fixed-sats order amount against the node's min/max before submitting

### DIFF
--- a/lib/features/order/screens/add_order_screen.dart
+++ b/lib/features/order/screens/add_order_screen.dart
@@ -30,6 +30,31 @@ class AddOrderScreen extends ConsumerStatefulWidget {
   ConsumerState<AddOrderScreen> createState() => _AddOrderScreenState();
 }
 
+/// Returns the node's accepted `(min, max)` sats range when the entered
+/// fixed-sats amount is outside the node's advertised limits, otherwise null.
+///
+/// Pure and testable. Fixed-sats orders only (#282). Uses [BigInt] to match
+/// `NewOrderParams.amountSats`, so amounts beyond the signed 64-bit range are
+/// still compared rather than silently failing open. Only enforces the range
+/// when the node advertises BOTH a min and a max (they are published together
+/// in practice); when either bound is absent, or the amount is not yet a
+/// number, returns null so a valid order is never blocked and the daemon
+/// remains the backstop.
+@visibleForTesting
+({int min, int max})? satsOutOfNodeRange(
+  String fixedSatsStr,
+  int? minOrder,
+  int? maxOrder,
+) {
+  if (minOrder == null || maxOrder == null) return null;
+  final sats = BigInt.tryParse(fixedSatsStr.trim());
+  if (sats == null) return null;
+  if (sats < BigInt.from(minOrder) || sats > BigInt.from(maxOrder)) {
+    return (min: minOrder, max: maxOrder);
+  }
+  return null;
+}
+
 class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
   final _amountController = TextEditingController();
   final _minController = TextEditingController();
@@ -63,28 +88,6 @@ class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
     _minController.dispose();
     _maxController.dispose();
     super.dispose();
-  }
-
-  /// Returns the node's accepted sats range when the entered fixed-sats amount
-  /// is out of bounds, otherwise null. Fixed-sats orders only; market-price
-  /// validation needs an exchange-rate provider and is out of scope here (#282).
-  /// Fails open: returns null when the amount is not yet a number, or when the
-  /// node advertises no min/max (so a valid order is never blocked just because
-  /// the limits could not be read).
-  ({int min, int max})? _satsOutOfRange(
-    String fixedSatsStr,
-    int? minOrder,
-    int? maxOrder,
-  ) {
-    final sats = int.tryParse(fixedSatsStr);
-    if (sats == null) return null;
-    if (minOrder != null && sats < minOrder) {
-      return (min: minOrder, max: maxOrder ?? minOrder);
-    }
-    if (maxOrder != null && sats > maxOrder) {
-      return (min: minOrder ?? 0, max: maxOrder);
-    }
-    return null;
   }
 
   bool _checkValid(
@@ -179,8 +182,9 @@ class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
     // out of the node's sats range, but re-check here so no code path submits
     // an out-of-range fixed-sats order (#282).
     final node = ref.read(mostroNodeProvider).valueOrNull;
-    final outOfRange = !isMarket && fixedSatsStr.isNotEmpty
-        ? _satsOutOfRange(fixedSatsStr, node?.minOrderAmount, node?.maxOrderAmount)
+    final outOfRange = !isMarket && !_isRange && fixedSatsStr.isNotEmpty
+        ? satsOutOfNodeRange(
+            fixedSatsStr, node?.minOrderAmount, node?.maxOrderAmount)
         : null;
     if (_submitting ||
         !_checkValid(selectedMethods, customMethod, isMarket, fixedSatsStr) ||
@@ -261,8 +265,9 @@ class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
     final fiatCode = ref.watch(selectedFiatCodeProvider);
     final premium = ref.watch(premiumValueProvider);
     final node = ref.watch(mostroNodeProvider).valueOrNull;
-    final satsRangeError = (!isMarket && fixedSatsStr.isNotEmpty)
-        ? _satsOutOfRange(fixedSatsStr, node?.minOrderAmount, node?.maxOrderAmount)
+    final satsRangeError = (!isMarket && !_isRange && fixedSatsStr.isNotEmpty)
+        ? satsOutOfNodeRange(
+            fixedSatsStr, node?.minOrderAmount, node?.maxOrderAmount)
         : null;
     final isValid =
         _checkValid(selectedMethods, customMethod, isMarket, fixedSatsStr) &&

--- a/lib/features/order/screens/add_order_screen.dart
+++ b/lib/features/order/screens/add_order_screen.dart
@@ -8,6 +8,7 @@ import 'package:mostro/core/app_theme.dart';
 import 'package:mostro/core/daemon_errors.dart';
 import 'package:mostro/features/order/widgets/currency_section.dart';
 import 'package:mostro/features/settings/providers/settings_provider.dart';
+import 'package:mostro/features/about/providers/mostro_node_provider.dart';
 import 'package:mostro/features/order/widgets/order_preset_selector.dart';
 import 'package:mostro/features/order/widgets/payment_method_section.dart';
 import 'package:mostro/features/order/widgets/price_section.dart';
@@ -62,6 +63,28 @@ class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
     _minController.dispose();
     _maxController.dispose();
     super.dispose();
+  }
+
+  /// Returns the node's accepted sats range when the entered fixed-sats amount
+  /// is out of bounds, otherwise null. Fixed-sats orders only; market-price
+  /// validation needs an exchange-rate provider and is out of scope here (#282).
+  /// Fails open: returns null when the amount is not yet a number, or when the
+  /// node advertises no min/max (so a valid order is never blocked just because
+  /// the limits could not be read).
+  ({int min, int max})? _satsOutOfRange(
+    String fixedSatsStr,
+    int? minOrder,
+    int? maxOrder,
+  ) {
+    final sats = int.tryParse(fixedSatsStr);
+    if (sats == null) return null;
+    if (minOrder != null && sats < minOrder) {
+      return (min: minOrder, max: maxOrder ?? minOrder);
+    }
+    if (maxOrder != null && sats > maxOrder) {
+      return (min: minOrder ?? 0, max: maxOrder);
+    }
+    return null;
   }
 
   bool _checkValid(
@@ -152,7 +175,18 @@ class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
     final customMethod = ref.read(customPaymentMethodProvider);
     final isMarket = ref.read(isMarketPriceProvider);
     final fixedSatsStr = ref.read(fixedSatsProvider);
-    if (_submitting || !_checkValid(selectedMethods, customMethod, isMarket, fixedSatsStr)) return;
+    // Defence in depth: the submit button is already disabled when invalid or
+    // out of the node's sats range, but re-check here so no code path submits
+    // an out-of-range fixed-sats order (#282).
+    final node = ref.read(mostroNodeProvider).valueOrNull;
+    final outOfRange = !isMarket && fixedSatsStr.isNotEmpty
+        ? _satsOutOfRange(fixedSatsStr, node?.minOrderAmount, node?.maxOrderAmount)
+        : null;
+    if (_submitting ||
+        !_checkValid(selectedMethods, customMethod, isMarket, fixedSatsStr) ||
+        outOfRange != null) {
+      return;
+    }
     setState(() => _submitting = true);
 
     try {
@@ -226,7 +260,13 @@ class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
     final fixedSatsStr = ref.watch(fixedSatsProvider);
     final fiatCode = ref.watch(selectedFiatCodeProvider);
     final premium = ref.watch(premiumValueProvider);
-    final isValid = _checkValid(selectedMethods, customMethod, isMarket, fixedSatsStr);
+    final node = ref.watch(mostroNodeProvider).valueOrNull;
+    final satsRangeError = (!isMarket && fixedSatsStr.isNotEmpty)
+        ? _satsOutOfRange(fixedSatsStr, node?.minOrderAmount, node?.maxOrderAmount)
+        : null;
+    final isValid =
+        _checkValid(selectedMethods, customMethod, isMarket, fixedSatsStr) &&
+            satsRangeError == null;
     final l10n = AppLocalizations.of(context);
 
     return Scaffold(
@@ -347,6 +387,25 @@ class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
             color: cardBg,
             child: const PriceSection(),
           ),
+          // Out-of-range warning for fixed-sats orders (#282): show the node's
+          // accepted range so the user can correct it before submitting,
+          // instead of the daemon rejecting the order after the fact.
+          if (satsRangeError != null) ...[
+            const SizedBox(height: AppSpacing.sm),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
+              child: Text(
+                l10n.orderAmountOutOfRange(
+                  satsRangeError.min,
+                  satsRangeError.max,
+                ),
+                style: TextStyle(
+                  color: colors?.destructiveRed ?? const Color(0xFFD84D4D),
+                  fontSize: 13,
+                ),
+              ),
+            ),
+          ],
           const SizedBox(height: AppSpacing.xxl),
         ],
       ),

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -599,6 +599,7 @@
   "orderExpiryNoReputationNote": "Es wirkt sich nicht auf deine Reputation aus.",
   "minHint": "Min",
   "maxHint": "Max",
+  "orderAmountOutOfRange": "Der Betrag muss für diesen Mostro-Knoten zwischen {min} und {max} Sats liegen",
   "fiatAmountHint": "Fiat-Betrag",
   "enterAmountForPreview": "Gib einen Betrag ein, um eine Live-Vorschau zu sehen.",
   "previewLabel": "VORSCHAU",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1279,6 +1279,14 @@
   "@minHint": {"description": "Hint for the minimum amount input"},
   "maxHint": "Max",
   "@maxHint": {"description": "Hint for the maximum amount input"},
+  "orderAmountOutOfRange": "Amount must be between {min} and {max} sats for this Mostro node",
+  "@orderAmountOutOfRange": {
+    "description": "Shown when a fixed-sats order amount is outside the node min/max order amount",
+    "placeholders": {
+      "min": {"type": "int"},
+      "max": {"type": "int"}
+    }
+  },
   "fiatAmountHint": "Fiat amount",
   "@fiatAmountHint": {"description": "Hint for the fiat amount input"},
   "enterAmountForPreview": "Enter an amount to see a live preview.",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -599,6 +599,7 @@
   "orderExpiryNoReputationNote": "No afectará tu reputación.",
   "minHint": "Mín",
   "maxHint": "Máx",
+  "orderAmountOutOfRange": "El monto debe estar entre {min} y {max} sats para este nodo Mostro",
   "fiatAmountHint": "Monto fiat",
   "enterAmountForPreview": "Ingresa un monto para ver una vista previa en vivo.",
   "previewLabel": "VISTA PREVIA",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -599,6 +599,7 @@
   "orderExpiryNoReputationNote": "Cela n'affectera pas votre réputation.",
   "minHint": "Min",
   "maxHint": "Max",
+  "orderAmountOutOfRange": "Le montant doit être compris entre {min} et {max} sats pour ce nœud Mostro",
   "fiatAmountHint": "Montant fiat",
   "enterAmountForPreview": "Saisissez un montant pour voir un aperçu en direct.",
   "previewLabel": "APERÇU",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -599,6 +599,7 @@
   "orderExpiryNoReputationNote": "Non influirà sulla tua reputazione.",
   "minHint": "Min",
   "maxHint": "Max",
+  "orderAmountOutOfRange": "L'importo deve essere compreso tra {min} e {max} sats per questo nodo Mostro",
   "fiatAmountHint": "Importo fiat",
   "enterAmountForPreview": "Inserisci un importo per vedere un'anteprima in tempo reale.",
   "previewLabel": "ANTEPRIMA",

--- a/test/features/order/sats_out_of_node_range_test.dart
+++ b/test/features/order/sats_out_of_node_range_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro/features/order/screens/add_order_screen.dart';
+
+void main() {
+  group('satsOutOfNodeRange (#282)', () {
+    test('returns null when the node advertises no bounds', () {
+      expect(satsOutOfNodeRange('5000', null, null), isNull);
+    });
+
+    test('returns null when only the min is advertised (needs both)', () {
+      expect(satsOutOfNodeRange('100', 500, null), isNull);
+    });
+
+    test('returns null when only the max is advertised (needs both)', () {
+      expect(satsOutOfNodeRange('999999', null, 500000), isNull);
+    });
+
+    test('returns null for non-numeric or empty input', () {
+      expect(satsOutOfNodeRange('abc', 500, 500000), isNull);
+      expect(satsOutOfNodeRange('', 500, 500000), isNull);
+    });
+
+    test('below the minimum returns the accepted range', () {
+      expect(satsOutOfNodeRange('300', 500, 500000), (min: 500, max: 500000));
+    });
+
+    test('above the maximum returns the accepted range', () {
+      expect(
+        satsOutOfNodeRange('600000', 500, 500000),
+        (min: 500, max: 500000),
+      );
+    });
+
+    test('exactly at either bound is in range (null)', () {
+      expect(satsOutOfNodeRange('500', 500, 500000), isNull);
+      expect(satsOutOfNodeRange('500000', 500, 500000), isNull);
+    });
+
+    test('inside the range returns null', () {
+      expect(satsOutOfNodeRange('5000', 500, 500000), isNull);
+    });
+
+    test('amounts beyond the 64-bit int range are still caught (BigInt)', () {
+      // 2^63 = 9223372036854775808, one past int64 max. int.tryParse would
+      // return null here and fail open; BigInt.tryParse must catch it as
+      // above-max instead.
+      expect(
+        satsOutOfNodeRange('9223372036854775808', 500, 500000),
+        (min: 500, max: 500000),
+      );
+    });
+
+    test('trims surrounding whitespace before parsing', () {
+      expect(satsOutOfNodeRange('  300  ', 500, 500000), (min: 500, max: 500000));
+    });
+  });
+}


### PR DESCRIPTION
## Problem
The create-order form only checked that a fixed-sats amount was positive (`_checkValid` in `add_order_screen.dart`). It never compared the amount against the Mostro node's `min_order_amount` / `max_order_amount`, even though the app already parses both into `MostroInstance` (shown on the About screen). An out-of-range fixed-sats order was only rejected by the daemon *after* submission (`OutOfRangeSatsAmount`).

## Fix
Read the node's min/max from `mostroNodeProvider` and, for fixed-sats orders, disable submit and show an inline message naming the accepted range when the amount is out of bounds:

> Amount must be between {min} and {max} sats for this Mostro node

- `_satsOutOfRange(...)` returns the node's range when the entered amount is out of bounds, else null.
- `build` folds this into `isValid`, so the submit button disables live as the user types.
- A defence-in-depth check in `_submit` re-verifies the range so no code path submits an out-of-range fixed-sats order.
- **Fails open**: when the node advertises no limits, or the amount isn't yet a number, submission is not blocked (a valid order is never rejected just because the limits couldn't be read).

## Scope
Per the issue, this covers **fixed-sats orders only**:
- **Market-price orders** need an exchange-rate provider to convert fiat -> sats client-side before the same check can apply. That's out of scope here and deferred to a separate issue (the issue notes this).
- **Range orders** are unaffected their amount isn't a single fixed value, so the min/max sats check doesn't apply.

## Testing
`flutter analyze` clean; strings localized in all five locales. Verified on a physical device (Nokia C31):
- A fixed-sats amount below the node's minimum (e.g. 300 against a 500 floor) disables submit and shows the range message.
- An in-range amount (e.g. 5000 within 500–500000) re-enables submit.

<img width="720" height="1600" alt="1000265297" src="https://github.com/user-attachments/assets/cb13b381-b429-46fd-a8bf-df05f4a1fae3" />
<img width="720" height="1600" alt="1000265296" src="https://github.com/user-attachments/assets/0a4a1e69-f0f4-4fbe-b6b2-7e5149ff3f1b" />


## Separate issue noticed while verifying
The form currently lets you toggle range mode on *and* enter a fixed sats amount, which sends both a fiat range and a single `amountSats`; the daemon rejects that as "Invalid amount". This is pre-existing and independent of the min/max validation here I can file it separately.

<img width="720" height="1600" alt="1000265339" src="https://github.com/user-attachments/assets/19a800d3-b154-417f-80be-a57fd23011dd" />

<img width="720" height="1600" alt="1000265340" src="https://github.com/user-attachments/assets/e7a20e73-96f1-4d00-8f8b-ffea8a7900c9" />

Closes #282.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation for fixed-sats orders based on the selected node’s minimum and maximum limits.
  - Displays the accepted satoshi range below the price section.
  - Prevents submission when the entered amount falls outside the permitted range.
  - Added translated validation messages in English, German, Spanish, French, and Italian.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->