### PR TITLE
test(escrow): one lock for one global, not two racing ones

### DIFF
--- a/rust/src/api/escrow.rs
+++ b/rust/src/api/escrow.rs
@@ -201,12 +201,12 @@ mod tests {
 
     /// The escrow globals are process-wide; serialize the tests that write them
     /// and start each one from a freshly-launched app's state.
+    ///
+    /// The lock itself lives in `mostro::escrow_mode`, next to the state it
+    /// guards, and is shared with that module's own tests. A private lock here
+    /// only serialized this module and raced the other one (#309).
     fn escrow_lock() -> std::sync::MutexGuard<'static, ()> {
-        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        let guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        escrow_mode::clear();
-        escrow_mode::set_overrides(EscrowOverrides::default());
-        guard
+        escrow_mode::lock_globals_for_test()
     }
 
     #[tokio::test]

--- a/rust/src/mostro/escrow_mode.rs
+++ b/rust/src/mostro/escrow_mode.rs
@@ -408,6 +408,26 @@ pub fn is_cashu_mode() -> bool {
     get_resolved().is_cashu_usable()
 }
 
+/// Serialize every test that writes the process-wide escrow globals, and reset
+/// them so each test starts from a freshly-launched app's state: nothing
+/// fetched, no override.
+///
+/// The lock lives with the state it guards, not with one of its callers. Two
+/// test modules touch these globals — this one and `crate::api::escrow` — and
+/// each used to keep its own private mutex, which serialized a module against
+/// itself while leaving it racing the other. That produced intermittent
+/// failures where one module's `set_from_tags` was erased by the other's
+/// `clear()` mid-test: issue #309.
+#[cfg(test)]
+pub(crate) fn lock_globals_for_test() -> std::sync::MutexGuard<'static, ()> {
+    static GLOBAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    // Recover from poisoning so one failing test does not cascade into the rest.
+    let guard = GLOBAL.lock().unwrap_or_else(|e| e.into_inner());
+    clear();
+    set_overrides(EscrowOverrides::default());
+    guard
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -416,18 +436,11 @@ mod tests {
         vec![name.to_string(), value.to_string()]
     }
 
-    /// Tests that touch the globals run in the same process and would otherwise
-    /// race each other. A poisoned lock is recovered from so one failing test
-    /// does not cascade into the others.
-    static GLOBAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    /// Take the globals and reset them, so each test starts from the state a
-    /// freshly-launched app has: nothing fetched, no override.
+    /// Take the globals and reset them. Shared with `crate::api::escrow`'s
+    /// tests through [`super::lock_globals_for_test`] — one lock for one piece
+    /// of global state (#309).
     fn own_the_global() -> std::sync::MutexGuard<'static, ()> {
-        let guard = GLOBAL.lock().unwrap_or_else(|e| e.into_inner());
-        clear();
-        set_overrides(EscrowOverrides::default());
-        guard
+        super::lock_globals_for_test()
     }
 
     #[test]


### PR DESCRIPTION
Closes #309.

## The bug

The escrow mode is process-wide state, and two test modules were serializing it against **two different mutexes**:

| Module | Lock |
|---|---|
| `api::escrow::tests` | private `static LOCK` |
| `mostro::escrow_mode::tests` | private `static GLOBAL` |

Each module was serialized against itself and raced the other. `escrow_lock()` calls `escrow_mode::clear()` on acquisition, so a test in one module could wipe the tags a test in the other had just set, mid-assertion:

```
---- api::escrow::tests::turning_the_override_off_restores_what_the_node_said ----
panicked at src/api/escrow.rs:300:9:
assertion `left == right` failed
  left: "unknown"
 right: "lightning"
```

Not always the same test — `setting_one_override_never_clobbers_the_other` failed the same way.

## The fix

Move the guard next to the state it protects: `escrow_mode::lock_globals_for_test()`, `#[cfg(test)] pub(crate)`, keeping the reset (`clear` + default overrides) and the poison recovery both helpers already did. Both test modules take that one lock now.

The point is not just this pair: any future module that touches these globals from a test gets the guarantee by reaching for the state's own helper, instead of inventing a third lock that races the other two.

## Verification

| Command | Runs | Failures before | Failures after |
|---|---|---|---|
| `cargo test --lib` (full suite, parallel) | 25 / 30 | **3** | **0** |
| `cargo test --lib api::escrow` (module alone) | 15 | 0 | 0 |
| `cargo test --lib -- --test-threads=1` | 5 | 0 | 0 |

The two green columns before the fix are what identified cross-module parallelism as the cause rather than anything inside the escrow tests.

`cargo clippy --lib` is warning-free. The diff is test-support only — no production code path changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved escrow-mode test isolation by using a shared lock for process-wide state.
  * Centralized test-state reset handling to make tests more reliable and prevent interference between test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->