### PR TITLE
refactor: drop every protocol-v1 gift-wrap path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,10 +101,13 @@ bridged by flutter_rust_bridge.
   **NIP-44 / signed Kind 14** (transport v2), via `wrap_mostro_message`/`unwrap_mostro_message`.
 - **Peer chat**: **chat envelope** (kind 14 signed with `K_sign`, NIP-44 inner kind 1
   signed by the trade key — <https://mostro.network/protocol/chat.html>), via
-  `mostro_wrap`/`mostro_unwrap` + `crypto/chat_keys.rs`. Outbound NIP-59 is gone from
-  this channel (gift-wrap flood attack, issue #246); inbound 1059 is still accepted
-  from pre-migration peers until the dual-read deadline (`LEGACY_CHAT_DEPRECATION_TS`).
-- **Dispute admin chat**: still **NIP-59 gift wrap / Kind 1059**, via `wrap`/`unwrap`.
+  `mostro_wrap`/`mostro_unwrap` + `crypto/chat_keys.rs`. NIP-59 is gone from this
+  channel in **both** directions (gift-wrap flood attack, issue #246).
+- **Dispute admin chat**: the **same chat envelope**, keyed to the solver's pubkey
+  (<https://mostro.network/protocol/dispute_chat.html> — "no gift wrap and no
+  ephemeral key"). The interop dual-path for gift-wrap-only solvers is gone too;
+  until mostrix#102 ships, such a solver is not reachable from here.
+- **This client speaks protocol v2 only** — nothing reads or writes kind 1059.
 - All live in `rust/src/nostr/gift_wrap.rs` (rename to `transport.rs` pending).
 - Wire status strings are **kebab-case** (`waiting-buyer-invoice`, `fiat-sent`).
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Mostro App is the official cross-platform client for the [Mostro](https://mostro
 **Key features:**
 
 - **Non-custodial** — Your keys stay on your device. No exchange holds your funds.
-- **Privacy-first** — End-to-end encrypted over Nostr: NIP-44 direct messages with the Mostro daemon, NIP-59 Gift Wrap for peer-to-peer chat. Optional privacy mode hides reputation data.
+- **Privacy-first** — End-to-end encrypted over Nostr: NIP-44 direct messages with the Mostro daemon, and a signed kind-14 envelope for peer-to-peer and dispute chat. Optional privacy mode hides reputation data.
 - **Lightning-native** — All BTC settlements happen via Lightning invoices (BOLT 11). Supports [Nostr Wallet Connect (NWC)](https://nwc.dev) for automated invoice generation.
 - **Censorship-resistant** — Built on the Nostr network; no central server or domain to block.
 - **Multi-platform** — Single codebase targets Android, iOS, Web (PWA), macOS, Windows, and Linux.
@@ -109,7 +109,7 @@ The Mostro protocol is a message-passing specification built on top of [Nostr](h
 |---------|-------------|
 | **Order Book** | Mostro daemons publish pending orders as Nostr events of [Kind 38383](https://mostro.network/protocol/list_orders.html) — parameterized replaceable events. |
 | **Trade Messages** | All trade actions (take order, add invoice, confirm fiat sent, release funds) are sent as NIP-44-encrypted direct messages — signed Kind 14 events authored by the per-trade key and directed to the Mostro node pubkey (Mostro protocol v2). |
-| **P2P Chat** | Direct messages between buyer and seller (and dispute–admin chat) use [NIP-59 Gift Wrap](https://github.com/nostr-protocol/nips/blob/master/59.md) (Kind 1059) directed to the peer's pubkey. |
+| **P2P Chat** | Direct messages between buyer and seller (and dispute–admin chat) ride the [chat envelope](https://mostro.network/protocol/chat.html): a Kind 14 event signed with `K_sign` and `p`-tagged to `pub(K_conv)`, both derived from the trade-key ECDH secret, carrying a NIP-44 encrypted Kind 1 inner event signed by the sender's trade key. |
 | **Hold Invoices** | The seller pays a Lightning hold invoice when taking a buy order. Funds are locked until the buyer confirms fiat receipt, then the daemon releases the HTLC. |
 | **Reputation** | Each trade can result in a mutual star rating, published as a Nostr event by the daemon. |
 | **Disputes** | Either party can open a dispute, escalating to a human Mostro operator for resolution. |
@@ -138,13 +138,11 @@ Both parties rate each other (optional)
 |------|-------------|
 | `38383` | Public order book (published by Mostro daemon) |
 | `14` | NIP-44 direct DM — encrypted trade messages to/from the daemon, signed by the trade key (Mostro protocol v2) |
-| `1059` | NIP-59 Gift Wrap — P2P chat between peers and dispute–admin chat |
 
 ### Protocol Reference
 
 - Full spec: [mostro.network/protocol](https://mostro.network/protocol)
 - NIP-44 Encrypted Payloads: [github.com/nostr-protocol/nips/blob/master/44.md](https://github.com/nostr-protocol/nips/blob/master/44.md)
-- NIP-59 Gift Wrap: [github.com/nostr-protocol/nips/blob/master/59.md](https://github.com/nostr-protocol/nips/blob/master/59.md)
 - Order Kind 38383: [mostro.network/protocol/list_orders.html](https://mostro.network/protocol/list_orders.html)
 
 ---
@@ -495,7 +493,7 @@ app/
 │       ├── crypto/             #   BIP-32/39 derivation, ECDH, file encryption
 │       ├── db/                 #   SQLite (native) / IndexedDB (WASM)
 │       ├── mostro/             #   Protocol FSM & state machine
-│       ├── nostr/              #   Relay pool, gift wrap, event parsers
+│       ├── nostr/              #   Relay pool, message envelopes, event parsers
 │       ├── nwc/                #   Nostr Wallet Connect client
 │       └── queue/              #   Offline outbound message queue
 │
@@ -610,7 +608,7 @@ We aim to acknowledge reports within 72 hours and provide a fix within 30 days f
 ### Security Model
 
 - **Keys never leave the device** — the BIP-39 seed is stored in platform secure storage (`flutter_secure_storage`, backed by Android Keystore / iOS Keychain / Linux SecretService).
-- **End-to-end encrypted trade messages** — all communication between the app and the Mostro daemon uses NIP-44 encrypted direct messages (secp256k1 ECDH + ChaCha20 + HMAC-SHA256). Peer-to-peer and dispute chat use NIP-59 Gift Wrap.
+- **End-to-end encrypted trade messages** — all communication between the app and the Mostro daemon uses NIP-44 encrypted direct messages (secp256k1 ECDH + ChaCha20 + HMAC-SHA256). Peer-to-peer and dispute chat use the signed kind-14 chat envelope, whose author is pinned to the conversation key so third parties cannot inject messages.
 - **Per-trade ephemeral keys** — a new BIP-32 child key is derived for each trade, preventing cross-trade correlation even if a single trade key is compromised.
 - **The Mostro daemon never sees plaintext** — all messages are encrypted to the daemon's public key; only the holder of the corresponding private key can decrypt them.
 - **No telemetry** — the app does not collect analytics, crash reports, or any usage data.

--- a/docs/cashu/README.md
+++ b/docs/cashu/README.md
@@ -519,15 +519,22 @@ actions and screens; C5 established all shared plumbing.
 
 - **Seller release:** on confirm (existing release UI), FRB `release_cashu(order_id)`:
   sign escrow proofs with `P_S` (C4 `sign_proofs`) → send `Payload::CashuSignatures`
-  **directly to the buyer's trade pubkey via NIP-59 gift wrap** (`wrap`/`unwrap` in
-  `rust/src/nostr/gift_wrap.rs` — peer-to-peer path, same channel as peer chat, *not*
-  the Kind-14 daemon transport) → then send `Action::Release` to mostrod (state update
-  only, per upstream Track B).
-- **Buyer redemption:** new arm in the gift-wrap handler
-  (`handle_global_gift_wrap` / peer message path): on receiving `CashuSignatures` for
-  an active order, **persist signatures first**, then `combine_and_redeem` (C4) into
-  the wallet; mark trade success; handle late arrival (buyer offline — signatures wait
-  in the NIP-59 inbox; redeem on next startup scan of unredeemed trades).
+  **directly to the buyer over the peer chat envelope** (`mostro_wrap`/`mostro_unwrap`
+  in `rust/src/nostr/gift_wrap.rs` — same channel as peer chat, *not* the Kind-14
+  daemon transport) → then send `Action::Release` to mostrod (state update only, per
+  upstream Track B).
+
+  This deliberately does **not** use NIP-59 gift wrap. The raw `wrap`/`unwrap`
+  helpers this section originally named were removed along with every other
+  protocol-v1 path: an ephemeral-authored 1059 carrying spendable signatures is
+  exactly the unattributable-injection shape the envelope was adopted to close
+  (#246). The envelope pins the author to the conversation key, so the buyer can
+  tell a real signature payload from a stranger's.
+- **Buyer redemption:** new arm in the peer-chat receive path: on receiving
+  `CashuSignatures` for an active order, **persist signatures first**, then
+  `combine_and_redeem` (C4) into the wallet; mark trade success; handle late arrival
+  (buyer offline — signatures wait on the relay within the chat subscription's
+  cursor window; redeem on next startup scan of unredeemed trades).
 - **Locktime margin guard (upstream Track B obligation):** before letting the buyer
   send `fiat-sent`, warn/block when remaining locktime < `cashu_settlement_margin_days`
   (from C1 tags), matching the daemon's rejection.

--- a/rust/src/api/disputes.rs
+++ b/rust/src/api/disputes.rs
@@ -330,40 +330,6 @@ pub async fn submit_evidence(trade_id: String, text: String) -> Result<()> {
     let ctx = crate::api::messages::admin_chat_context(trade_index, &admin_pubkey).await?;
     let inner = crate::api::messages::publish_chat_payload_for(&ctx, &text).await?;
 
-    // Interop dual-write (PR #254 review): the current solver client
-    // (mostrix) still reads only NIP-59 gift wrap — its envelope migration is
-    // tracked in mostrix#102. Until the deprecation date the evidence also
-    // goes out in the pre-migration shape it understands, gift-wrapped
-    // straight to the solver. Best-effort: the envelope copy above is the
-    // durable one, and this copy disappears with the dual-read window.
-    if crate::rt::unix_now() < crate::api::messages::LEGACY_CHAT_DEPRECATION_TS {
-        let legacy_send: Result<()> = async {
-            let sender_keys = crate::api::identity::get_active_trade_keys(trade_index).await?;
-            let payload = serde_json::json!({
-                "type": "evidence",
-                "trade_id": trade_id,
-                "text": text,
-            })
-            .to_string();
-            let event_json = crate::nostr::gift_wrap::wrap(
-                &sender_keys,
-                &admin_pubkey,
-                &payload,
-                nostr_sdk::Kind::from(14u16),
-            )
-            .await
-            .map_err(|e| anyhow!("legacy wrap failed: {e}"))?;
-            crate::api::orders::publish_event(&event_json)
-                .await
-                .map_err(|e| anyhow!("legacy publish failed: {e}"))?;
-            Ok(())
-        }
-        .await;
-        if let Err(e) = legacy_send {
-            log::warn!("[disputes] legacy evidence copy not sent trade={trade_id}: {e}");
-        }
-    }
-
     // Record it locally so the dispute conversation has history, exactly as a
     // peer message does. Keyed by the inner event id, so our own echo arriving
     // from a relay dedups against this record instead of duplicating it.

--- a/rust/src/api/messages.rs
+++ b/rust/src/api/messages.rs
@@ -5,11 +5,10 @@
 /// event signed with `K_sign` and `p`-tagged to `pub(K_conv)` — both derived
 /// from the trade-key ECDH secret via `crate::crypto::chat_keys` — carrying a
 /// NIP-44 encrypted kind 1 inner event signed by the sender's trade key. The
-/// old NIP-59 gift wrap (kind 1059) — whose random ephemeral authors made
-/// third-party flooding unattributable and unfilterable — is no longer
-/// written; it is still *read* from pre-migration peers until
-/// [`LEGACY_CHAT_DEPRECATION_TS`] so mixed-version trades keep chatting.
-/// Admin/dispute chat (api/disputes.rs) still uses gift wrap.
+/// old NIP-59 gift wrap — whose random ephemeral authors made third-party
+/// flooding unattributable and unfilterable — is neither written nor read:
+/// this client speaks protocol v2 only. The admin/dispute chat
+/// (api/disputes.rs) rides the same envelope.
 ///
 /// Messages persist to the `messages` table (native; web is memory-only until
 /// IndexedDB lands, #233); the in-memory store is a write-through cache. The
@@ -883,14 +882,6 @@ const OUTER_LRU_CAP: usize = 512;
 const MAX_STORED_MESSAGES_PER_TRADE: usize = 1000;
 const MAX_STORED_BYTES_PER_TRADE: usize = 5 * 1024 * 1024;
 
-/// End of the dual-read migration window: until this instant (unix seconds,
-/// 2026-12-31T00:00:00Z) the client also *accepts* the superseded NIP-59
-/// gift-wrap chat (kind 1059) from pre-migration peers. It always *sends*
-/// the new envelope. After the deadline the legacy subscription is simply
-/// not created. Trades in flight at the cutover keep working: the legacy
-/// path only reads, never writes.
-pub(crate) const LEGACY_CHAT_DEPRECATION_TS: i64 = 1_798_675_200;
-
 /// Subscription id for the chat envelope of one order — explicit so every
 /// exit path can unsubscribe and a lingering relay subscription never
 /// outlives its task.
@@ -947,26 +938,6 @@ impl ChatChannel {
         crate::db::settings_keys::chat_cursor(&format!("{}{order_id}", self.id_prefix()))
     }
 
-    /// Whether to also read the pre-migration gift-wrap form until
-    /// [`LEGACY_CHAT_DEPRECATION_TS`]. Both channels do: the peer chat for
-    /// pre-migration counterparties (#246), and the dispute chat because the
-    /// current solver client still speaks only gift wrap
-    /// (mostrix#102 tracks its migration) — without the dual-read its
-    /// replies would be invisible (PR #254 review).
-    fn reads_legacy_gift_wrap(self) -> bool {
-        true
-    }
-}
-
-/// Subscription id for the legacy gift-wrap dual-read of one channel of one
-/// order. Channel-scoped like the primary id: each task owns and cleans up
-/// exactly its own subscriptions, so a dispute listener exiting can never
-/// tear down the peer task's live legacy delivery (PR #254 review).
-fn legacy_chat_subscription_id(channel: ChatChannel, order_id: &str) -> nostr_sdk::SubscriptionId {
-    nostr_sdk::SubscriptionId::new(format!(
-        "mostro-chat-legacy-{}{order_id}",
-        channel.id_prefix()
-    ))
 }
 
 /// Orders with a live chat task. Single-owner guard: `on_peer_pubkey_received`
@@ -1095,9 +1066,8 @@ fn parse_chat_payload(payload: &str) -> (String, Option<AttachmentInfo>) {
 /// third-party flooding: relays drop everything not signed by the
 /// conversation key, so junk never reaches us — bounded by the persisted
 /// `since` cursor plus a `limit`, so a restart never re-downloads an
-/// unbounded backlog. Until [`LEGACY_CHAT_DEPRECATION_TS`] it additionally
-/// dual-reads the superseded NIP-59 gift wrap (kind 1059) so pre-migration
-/// peers keep working; it never *writes* the legacy form.
+/// unbounded backlog. Kind 14 is the only shape read: this client speaks
+/// protocol v2 only and never subscribes to the superseded gift wrap.
 ///
 /// Incoming events run the spec's cheapest-check-first pipeline: author →
 /// outer-id LRU → rate-limit budget → `mostro_unwrap` (p tag, timestamp
@@ -1147,9 +1117,6 @@ pub(crate) async fn subscribe_incoming_chat(
         let client = pool.client();
         client
             .unsubscribe(&chat_subscription_id(channel, &order_id))
-            .await;
-        client
-            .unsubscribe(&legacy_chat_subscription_id(channel, &order_id))
             .await;
     }
     log::debug!("[messages] incoming-chat subscription exiting order={order_id}");
@@ -1250,8 +1217,6 @@ async fn run_chat_subscription(
     // locally (the cursor only advances on durably stored messages).
     let cursor = load_chat_cursor(channel, order_id).await.unwrap_or(0);
     let sub_id = chat_subscription_id(channel, order_id);
-    let legacy_sub_id = legacy_chat_subscription_id(channel, order_id);
-    let reads_legacy = channel.reads_legacy_gift_wrap();
 
     let mut filter = nostr_sdk::Filter::new()
         .kind(nostr_sdk::Kind::PrivateDirectMessage)
@@ -1271,52 +1236,9 @@ async fn run_chat_subscription(
         return;
     }
 
-    // Dual-read window: also accept the superseded gift-wrap envelope from
-    // pre-migration peers, read-only, until the deprecation date. The legacy
-    // address is the old NIP-04-style shared pubkey.
-    let legacy_shared: Option<nostr_sdk::Keys> = if reads_legacy && unix_now() < LEGACY_CHAT_DEPRECATION_TS {
-        // The legacy address doubles as the decryption key. For the peer
-        // chat, v1 gift-wraps to the NIP-04-style shared pubkey, so the
-        // receiver unwraps with the shared SECRET as its keypair. For the
-        // dispute chat, the pre-migration solver (mostrix) gift-wraps
-        // straight to the trade pubkey, so the trade keys unwrap it.
-        let keys = match channel {
-            ChatChannel::Peer => crate::crypto::ecdh::derive_nip04_shared_key(trade_keys, peer_pubkey)
-                .ok()
-                .and_then(|raw| nostr_sdk::SecretKey::from_slice(&raw).ok())
-                .map(nostr_sdk::Keys::new),
-            ChatChannel::Dispute => Some(trade_keys.clone()),
-        };
-        match keys {
-            None => {
-                log::warn!("[messages] legacy shared key derivation failed order={order_id}");
-                None
-            }
-            Some(keys) => {
-                let legacy_filter = nostr_sdk::Filter::new()
-                    .kind(nostr_sdk::Kind::GiftWrap)
-                    .pubkey(keys.public_key())
-                    .limit(CHAT_BACKLOG_LIMIT);
-                match client
-                    .subscribe_with_id(legacy_sub_id.clone(), legacy_filter, None)
-                    .await
-                {
-                    Ok(_) => Some(keys),
-                    Err(e) => {
-                        log::warn!("[messages] legacy chat subscribe failed: {e}");
-                        None
-                    }
-                }
-            }
-        }
-    } else {
-        None
-    };
-
     log::info!(
-        "[messages] incoming-chat subscription active order={order_id} author={} since={cursor} legacy={}",
+        "[messages] incoming-chat subscription active order={order_id} author={} since={cursor}",
         sign_pubkey.to_hex(),
-        legacy_shared.is_some(),
     );
 
     let mut state = ChatRxState::new(channel, cursor);
@@ -1331,19 +1253,6 @@ async fn run_chat_subscription(
                 if subscription_id == sub_id {
                     handle_chat_event(channel, order_id, &allowed_signers, conv, &sign_pubkey, &my_trade_pubkey, &event, &mut state)
                         .await;
-                } else if subscription_id == legacy_sub_id {
-                    if let Some(shared) = &legacy_shared {
-                        handle_legacy_chat_event(
-                            channel,
-                            order_id,
-                            shared,
-                            &my_trade_pubkey,
-                            &allowed_signers,
-                            &event,
-                            &mut state,
-                        )
-                        .await;
-                    }
                 }
                 if state.flooded {
                     return;
@@ -1353,7 +1262,7 @@ async fn run_chat_subscription(
                 // EOSE for one of our subscriptions: stored catch-up is over,
                 // the token bucket meters everything from here on.
                 if let nostr_sdk::RelayMessage::EndOfStoredEvents(sid) = message {
-                    if *sid == sub_id || *sid == legacy_sub_id {
+                    if *sid == sub_id {
                         state.live = true;
                     }
                 }
@@ -1487,138 +1396,6 @@ async fn handle_chat_event(
     }
 }
 
-/// Validate and store one legacy gift-wrap chat event (dual-read window).
-///
-/// The legacy envelope has no author to pin, so this path keeps the old
-/// exposure — but bounded: same LRU, same live-stream budget, same size cap
-/// before decryption, same durable dedup and quota. It exists only so a
-/// pre-migration counterparty is not cut off mid-trade, and disappears at
-/// [`LEGACY_CHAT_DEPRECATION_TS`].
-async fn handle_legacy_chat_event(
-    channel: ChatChannel,
-    order_id: &str,
-    legacy_shared: &nostr_sdk::Keys,
-    my_trade_pubkey: &nostr_sdk::PublicKey,
-    allowed_signers: &[nostr_sdk::PublicKey],
-    event: &nostr_sdk::Event,
-    state: &mut ChatRxState,
-) {
-    let legacy_shared_hex = legacy_shared.public_key().to_hex();
-    if event.kind != nostr_sdk::Kind::GiftWrap {
-        return;
-    }
-    let is_for_us = event.tags.iter().any(|t| {
-        let s = t.as_slice();
-        s.first().map(|v| v.as_str()) == Some("p")
-            && s.get(1).map(|v| v.as_str()) == Some(legacy_shared_hex.as_str())
-    });
-    if !is_for_us {
-        return;
-    }
-    if !state.outer_seen.insert(&event.id.to_hex()) {
-        return;
-    }
-    if !state.budget_ok(order_id) {
-        return;
-    }
-    if event.content.len() > crate::nostr::gift_wrap::MAX_CONTENT_BYTES {
-        state.reject(order_id);
-        return;
-    }
-
-    let event_json = match serde_json::to_string(event) {
-        Ok(j) => j,
-        Err(_) => return,
-    };
-    let rumor_json = match crate::nostr::gift_wrap::unwrap(legacy_shared, &event_json).await {
-        Ok(j) => j,
-        Err(e) => {
-            log::debug!("[messages] legacy chat decrypt failed order={order_id}: {e}");
-            state.reject(order_id);
-            return;
-        }
-    };
-    let rumor: serde_json::Value = match serde_json::from_str(&rumor_json) {
-        Ok(v) => v,
-        Err(_) => {
-            state.reject(order_id);
-            return;
-        }
-    };
-
-    // The rumor is unsigned (NIP-59), so the claimed sender is only checked
-    // for membership: this is exactly the weakness the new envelope fixes.
-    // Anyone can wrap to the public shared address, so an unauthorized or
-    // malformed sender still counts toward the flood breaker — resetting the
-    // streak before this check would let a flooder keep it at zero forever.
-    let sender_hex = rumor.get("pubkey").and_then(|v| v.as_str()).unwrap_or("");
-    let Ok(sender) = nostr_sdk::PublicKey::from_hex(sender_hex) else {
-        state.reject(order_id);
-        return;
-    };
-    if !allowed_signers.contains(&sender) {
-        state.reject(order_id);
-        return;
-    }
-    state.consecutive_rejected = 0;
-
-    // No id, no dedup identity: a fabricated fallback id would make the same
-    // rumor accepted again on every replay, so it is rejected outright.
-    let Some(rumor_id) = rumor
-        .get("id")
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string())
-    else {
-        log::debug!("[messages] legacy rumor without id order={order_id} — dropped");
-        return;
-    };
-    match message_store().is_known(order_id, &rumor_id).await {
-        Err(e) => {
-            log::warn!("[messages] {e} — dropping legacy event order={order_id}");
-            return;
-        }
-        Ok(true) => return,
-        Ok(false) => {}
-    }
-
-    let raw_content = rumor.get("content").and_then(|v| v.as_str()).unwrap_or("");
-    if message_store()
-        .quota_exceeded(order_id, raw_content.len())
-        .await
-    {
-        log::warn!("[messages] retention quota reached order={order_id} — dropping message");
-        return;
-    }
-
-    // Legacy senders wrapped text as {"text": ...}; also accept the file
-    // pointer shape and plain text.
-    let (content, attachment) = match serde_json::from_str::<serde_json::Value>(raw_content)
-        .ok()
-        .and_then(|v| v.get("text").and_then(|t| t.as_str()).map(String::from))
-    {
-        Some(text) => (text, None),
-        None => parse_chat_payload(raw_content),
-    };
-
-    let is_echo = sender == *my_trade_pubkey;
-    let msg = ChatMessage {
-        id: rumor_id,
-        trade_id: order_id.to_string(),
-        sender_pubkey: sender_hex.to_string(),
-        content,
-        message_type: channel.message_type(),
-        is_mine: is_echo,
-        is_read: is_echo,
-        has_attachment: attachment.is_some(),
-        attachment,
-        created_at: rumor
-            .get("created_at")
-            .and_then(|v| v.as_i64())
-            .unwrap_or_else(unix_now),
-    };
-    let _ = message_store().add_message(msg).await;
-}
-
 /// Rebuild the chat listeners for every persisted trade that can still chat.
 ///
 /// Called once the relay pool is up (`api::nostr::initialize`): sessions are
@@ -1707,17 +1484,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn only_the_peer_channel_reads_the_legacy_gift_wrap() {
-        // The dispute chat migrates straight to the envelope, so it has no
-        // pre-migration form to dual-read and never subscribes to kind 1059.
-        // Both channels dual-read until the deprecation date: the peer chat
-        // for pre-migration counterparties, the dispute chat because the
-        // current solver client (mostrix#102) still writes only gift wrap.
-        assert!(ChatChannel::Peer.reads_legacy_gift_wrap());
-        assert!(ChatChannel::Dispute.reads_legacy_gift_wrap());
-    }
-
     /// PR #254 review: the peer and dispute streams are independent, so each
     /// channel owns its own durable cursor (peer keeps the historical key so
     /// existing installs do not refetch) and its own subscription ids.
@@ -1735,9 +1501,52 @@ mod tests {
             ChatChannel::Peer.cursor_key("o1"),
             ChatChannel::Dispute.cursor_key("o1"),
         );
-        assert_ne!(
-            legacy_chat_subscription_id(ChatChannel::Peer, "o1"),
-            legacy_chat_subscription_id(ChatChannel::Dispute, "o1"),
+    }
+
+    /// Protocol v1 is not spoken in either direction: the chat pipeline reads
+    /// kind 14 only, so a gift wrap addressed to us is somebody else's traffic
+    /// and must never reach the store — not even during a migration window,
+    /// because there is no longer one.
+    #[tokio::test]
+    async fn a_gift_wrap_never_reaches_the_chat_store() {
+        use nostr_sdk::prelude::*;
+
+        let sign = Keys::generate();
+        let trade = Keys::generate();
+        let conv = Keys::generate();
+        let order_id = uuid::Uuid::new_v4().to_string();
+
+        // Authored by the very key the subscription pins, so the only thing
+        // standing between this event and the store is the kind check.
+        let gift_wrap = EventBuilder::new(Kind::GiftWrap, "ciphertext")
+            .tag(Tag::public_key(trade.public_key()))
+            .sign_with_keys(&sign)
+            .unwrap();
+
+        let mut state = ChatRxState::new(ChatChannel::Peer, 0);
+        handle_chat_event(
+            ChatChannel::Peer,
+            &order_id,
+            &[trade.public_key(), sign.public_key()],
+            &conv,
+            &sign.public_key(),
+            &trade.public_key(),
+            &gift_wrap,
+            &mut state,
+        )
+        .await;
+
+        assert!(
+            get_messages(order_id).await.unwrap().is_empty(),
+            "a kind-1059 event must not be read by the chat pipeline"
+        );
+        // Observing the store alone would pass for the wrong reason — the
+        // ciphertext is junk, so it would be dropped further down anyway.
+        // The LRU insert is the first side effect after the kind check, so a
+        // still-unseen id is what proves the event was rejected *on its kind*.
+        assert!(
+            state.outer_seen.insert(&gift_wrap.id.to_hex()),
+            "the gift wrap must be rejected on its kind, before any other work"
         );
     }
 
@@ -2069,99 +1878,6 @@ mod tests {
         // An untouched trade has room.
         let other = uuid::Uuid::new_v4().to_string();
         assert!(!store.quota_exceeded(&other, 1024).await);
-    }
-
-    #[tokio::test]
-    async fn legacy_gift_wrap_is_accepted_during_the_window() {
-        use nostr_sdk::prelude::*;
-
-        // Mixed-version pair: the peer still runs the pre-migration client
-        // and gift-wraps {"text": ...} to the NIP-04-style shared pubkey.
-        let my_keys = Keys::generate();
-        let peer_keys = Keys::generate();
-        let shared_keys = {
-            let raw =
-                crate::crypto::ecdh::derive_nip04_shared_key(&peer_keys, &my_keys.public_key())
-                    .unwrap();
-            Keys::new(SecretKey::from_slice(&raw).unwrap())
-        };
-        let shared_pk = shared_keys.public_key();
-        let payload = serde_json::json!({ "text": "hola desde v1" }).to_string();
-        let event_json = crate::nostr::gift_wrap::wrap(
-            &peer_keys,
-            &shared_pk,
-            &payload,
-            Kind::PrivateDirectMessage,
-        )
-        .await
-        .unwrap();
-        let event: Event = serde_json::from_str(&event_json).unwrap();
-
-        let order_id = uuid::Uuid::new_v4().to_string();
-        let mut state = ChatRxState::new(ChatChannel::Peer, 0);
-        handle_legacy_chat_event(
-            ChatChannel::Peer,
-            &order_id,
-            &shared_keys,
-            &my_keys.public_key(),
-            &[my_keys.public_key(), peer_keys.public_key()],
-            &event,
-            &mut state,
-        )
-        .await;
-
-        let msgs = get_messages(order_id.clone()).await.unwrap();
-        assert_eq!(msgs.len(), 1, "legacy message must be accepted");
-        assert_eq!(msgs[0].content, "hola desde v1");
-        assert!(!msgs[0].is_mine);
-
-        // Replay of the same rumor in a fresh wrap is deduped durably.
-        let event_json2 = crate::nostr::gift_wrap::wrap(
-            &peer_keys,
-            &shared_pk,
-            &payload,
-            Kind::PrivateDirectMessage,
-        )
-        .await
-        .unwrap();
-        let event2: Event = serde_json::from_str(&event_json2).unwrap();
-        handle_legacy_chat_event(
-            ChatChannel::Peer,
-            &order_id,
-            &shared_keys,
-            &my_keys.public_key(),
-            &[my_keys.public_key(), peer_keys.public_key()],
-            &event2,
-            &mut state,
-        )
-        .await;
-        // Different rumor id (new timestamp/id) → may store; a stranger's
-        // wrap must never store.
-        let stranger = Keys::generate();
-        let stranger_json = crate::nostr::gift_wrap::wrap(
-            &stranger,
-            &shared_pk,
-            &serde_json::json!({ "text": "spoof" }).to_string(),
-            Kind::PrivateDirectMessage,
-        )
-        .await
-        .unwrap();
-        let stranger_event: Event = serde_json::from_str(&stranger_json).unwrap();
-        handle_legacy_chat_event(
-            ChatChannel::Peer,
-            &order_id,
-            &shared_keys,
-            &my_keys.public_key(),
-            &[my_keys.public_key(), peer_keys.public_key()],
-            &stranger_event,
-            &mut state,
-        )
-        .await;
-        let msgs = get_messages(order_id).await.unwrap();
-        assert!(
-            msgs.iter().all(|m| m.content != "spoof"),
-            "stranger-authored rumor must be rejected"
-        );
     }
 
     #[test]

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -3627,7 +3627,10 @@ async fn _run_order_subscription() {
                     // notification above (#277).
                     RelayMessage::Event { subscription_id, event } => {
                         let kind = event.kind.as_u16();
-                        if kind == 14 || kind == 1059 {
+                        // Kind 14 only: nothing subscribes to the superseded
+                        // gift wrap, so a 1059 frame here would be noise from
+                        // somebody else's subscription.
+                        if kind == 14 {
                             crate::api::logging::blog_debug(
                                 "relay",
                                 format!(

--- a/rust/src/nostr/gift_wrap.rs
+++ b/rust/src/nostr/gift_wrap.rs
@@ -16,10 +16,8 @@
 ///   signed by the sender's trade key. Replaced the simplified NIP-59 gift
 ///   wrap, which allowed unattributable third-party flooding — issue #246.
 ///
-/// * `wrap` / `unwrap` — raw JSON content gift-wrapped (NIP-59, Kind 1059),
-///   still used for dispute admin messages only. Their payloads are not
-///   `mostro_core::Message` values, so they stay on the local helper — see
-///   issue #101, "Scope".
+/// There is no third entry point: this client does not speak protocol v1 in
+/// either direction, so nothing here reads or writes a gift wrap.
 use anyhow::{anyhow, Result};
 use mostro_core::message::Message;
 use mostro_core::nip59::{UnwrappedMessage, WrapOptions};
@@ -66,10 +64,9 @@ pub async fn wrap_mostro_message(
 
 /// Try to open an incoming Mostro event using `trade_keys`.
 ///
-/// Delegates to `mostro_core::transport::unwrap_incoming`, which dispatches by
-/// event kind: a Kind 14 event is opened on the protocol-v2 NIP-44 path, a
-/// Kind 1059 event on the legacy gift-wrap path. (This app subscribes only to
-/// Kind 14, but the dispatcher accepts both.)
+/// Delegates to `mostro_core::transport::unwrap_incoming`. This app speaks
+/// protocol v2 only: it subscribes to Kind 14 and never to the superseded
+/// gift-wrap transport, so the v1 arm of that dispatcher is unreachable here.
 ///
 /// Returns `Ok(None)` only when the NIP-44 content cannot be decrypted with
 /// the given key — the canonical "not addressed to me" signal, used by the
@@ -315,71 +312,6 @@ pub fn mostro_unwrap(
 
 // ── NIP-59 gift wrap (dispute admin messages only) ───────────────────────────
 //
-// These wrap arbitrary JSON content in a Kind 14 rumor. Kept as local glue
-// for the admin/dispute channel; the P2P chat moved to `mostro_wrap` above.
-
-/// Wrap a plaintext JSON payload as a NIP-59 Gift Wrap event addressed to
-/// `recipient_pubkey`, signed by `sender_keys`.
-///
-/// When the connected Mostro requires NIP-13 Proof of Work the difficulty
-/// is applied to the **gift wrap** (the outer Kind 1059 event).
-///
-/// Returns the serialised `Event` JSON ready for publication.
-pub async fn wrap(
-    sender_keys: &Keys,
-    recipient_pubkey: &PublicKey,
-    content: &str,
-    kind: Kind,
-) -> Result<String> {
-    let rumor = EventBuilder::new(kind, content).build(sender_keys.public_key());
-
-    let seal = EventBuilder::seal(sender_keys, recipient_pubkey, rumor)
-        .await
-        .map_err(|e| anyhow!("NIP-59 seal failed: {e}"))?
-        .sign_with_keys(sender_keys)
-        .map_err(|e| anyhow!("seal sign failed: {e}"))?;
-
-    let pow = crate::mostro::pow::get_pow();
-    let gift_wrap = if pow > 0 {
-        // Build the gift wrap manually so we can inject .pow() — the SDK's
-        // gift_wrap_from_seal helper doesn't support NIP-13.
-        let ephemeral_keys = Keys::generate();
-        let encrypted = nip44::encrypt(
-            ephemeral_keys.secret_key(),
-            recipient_pubkey,
-            seal.as_json(),
-            nip44::Version::default(),
-        )
-        .map_err(|e| anyhow!("NIP-44 encrypt failed: {e}"))?;
-
-        EventBuilder::new(Kind::GiftWrap, encrypted)
-            .tag(Tag::public_key(*recipient_pubkey))
-            .custom_created_at(Timestamp::tweaked(nip59::RANGE_RANDOM_TIMESTAMP_TWEAK))
-            .pow(pow)
-            .sign_with_keys(&ephemeral_keys)
-            .map_err(|e| anyhow!("gift wrap sign+pow failed: {e}"))?
-    } else {
-        EventBuilder::gift_wrap_from_seal(recipient_pubkey, &seal, [])
-            .map_err(|e| anyhow!("NIP-59 gift_wrap failed: {e}"))?
-    };
-
-    Ok(gift_wrap.as_json())
-}
-
-/// Unwrap a NIP-59 Gift Wrap event using `recipient_keys`.
-///
-/// Returns the inner rumor as a serialised `UnsignedEvent` JSON string.
-pub async fn unwrap(recipient_keys: &Keys, gift_wrap_json: &str) -> Result<String> {
-    let event = Event::from_json(gift_wrap_json)
-        .map_err(|e| anyhow!("invalid gift wrap JSON: {e}"))?;
-
-    let unwrapped = nip59::extract_rumor(recipient_keys, &event)
-        .await
-        .map_err(|e| anyhow!("NIP-59 unwrap failed: {e}"))?;
-
-    Ok(unwrapped.rumor.as_json())
-}
-
 #[cfg(test)]
 mod chat_envelope_tests {
     use super::*;

--- a/rust/src/nostr/gift_wrap.rs
+++ b/rust/src/nostr/gift_wrap.rs
@@ -310,8 +310,6 @@ pub fn mostro_unwrap(
     Ok(inner)
 }
 
-// ── NIP-59 gift wrap (dispute admin messages only) ───────────────────────────
-//
 #[cfg(test)]
 mod chat_envelope_tests {
     use super::*;

--- a/specs/004-mostro-p2p-client/contracts/messages.md
+++ b/specs/004-mostro-p2p-client/contracts/messages.md
@@ -7,19 +7,28 @@ of the protocol spec (<https://mostro.network/protocol/chat.html>, issue
 #246): a kind 14 outer event signed with `K_sign` and `p`-tagged to
 `pub(K_conv)` — both HKDF-SHA256 derivations of the trade-key ECDH secret —
 carrying a NIP-44 encrypted kind 1 inner event signed by the sender's trade
-key. NIP-59 gift wrap (kind 1059) is no longer *written* for peer chat (its
-random ephemeral authors made third-party flooding unattributable); it is
-still *read* from pre-migration peers until the dual-read deadline
-(`LEGACY_CHAT_DEPRECATION_TS`, 2026-12-31T00:00:00Z), bounded by the same
-LRU / rate budget / size cap / durable dedup / quota as the new envelope.
+key. NIP-59 gift wrap (kind 1059) is **not spoken in either direction** on
+this channel: its random ephemeral authors made third-party flooding
+unattributable (#246), and the protocol spec now defines the envelope as
+the only chat transport.
+
 Admin/dispute chat uses the **same chat envelope**, keyed to the solver's
 pubkey (from `admin-took-dispute`) instead of the counterparty's trade key
-(<https://mostro.network/protocol/dispute_chat.html>). Interop dual-path
-until `LEGACY_CHAT_DEPRECATION_TS`: the current solver client (mostrix)
-still speaks only NIP-59 gift wrap (mostrix#102), so outgoing evidence is
-additionally *written* as a gift wrap to the solver, and solver gift wraps
-addressed to the trade pubkey are still *read*, under the same bounds as
-the peer dual-read. Each channel keeps its **own** durable `since` cursor
+(<https://mostro.network/protocol/dispute_chat.html>, which states it
+carries "no gift wrap and no ephemeral key").
+
+> **Interop note.** An earlier revision of this contract mandated a
+> gift-wrap dual read/write on the dispute channel until
+> `LEGACY_CHAT_DEPRECATION_TS` (2026-12-31T00:00:00Z), because the solver
+> client (mostrix) still writes kind 1059 — its migration is mostrix#102.
+> That dual path, and the constant, were removed when this client dropped
+> every protocol-v1 path: the cutoff is now "protocol v2 only, always"
+> rather than a date. Until mostrix#102 ships, a solver replying in the
+> legacy shape is not visible here and evidence sent from here does not
+> reach a gift-wrap-only solver. This is a known, accepted interop gap,
+> not an oversight.
+
+Each channel keeps its **own** durable `since` cursor
 (`chat_cursor:<order>` for peer, `chat_cursor:dispute-<order>` for
 dispute) and its own subscription ids, so the two independent streams can
 never suppress or tear down each other. Messages persist locally after


### PR DESCRIPTION
This client speaks **protocol v2 only**, but it still carried a read side for NIP-59 gift wrap (kind 1059) and one write. This removes both.

Refs #123 (the README half).

## What was still there

| Path | Direction | Where |
|---|---|---|
| Dual-read chat subscription, both channels, until a deprecation date | read | `api/messages.rs` |
| Dispute evidence copy for the pre-migration solver | **write** | `api/disputes.rs` |
| `gift_wrap::wrap` / `unwrap` — raw Kind-1059 helpers | both | `nostr/gift_wrap.rs` |
| `kind == 14 \|\| kind == 1059` in the raw relay-frame debug log | log | `api/orders.rs` |

## What is gone

- `LEGACY_CHAT_DEPRECATION_TS`, `reads_legacy_gift_wrap`, `legacy_chat_subscription_id`, the legacy filter and subscription, its branch in the chat event loop, its EOSE arm, and `handle_legacy_chat_event` (~124 lines).
- The dispute evidence dual-write in `submit_evidence`.
- The raw `wrap` / `unwrap` helpers, dead once those two callers went.
- `1059` from the debug-log filter — nothing subscribes to it, so such a frame is another subscription's noise.

`wrap_mostro_message` and `mostro_wrap` are untouched: they build kind 14 and are the only transports left.

## ⚠️ Behaviour change to weigh before merging

The dispute dual-read was not dead weight. It existed because **the solver client (mostrix) still writes gift wrap** — its migration is tracked in mostrix#102. Until that lands, a solver replying over the legacy shape will not be visible in this app, and evidence submitted from here no longer reaches a gift-wrap-only solver.

That is the intended consequence of dropping v1 rather than an oversight, but it is a live dispute-channel interop gap and the reason to check where mostrix#102 stands before this ships.

## Cashu spec

`docs/cashu/README.md` C6 planned to reuse the removed raw helpers for the P2P signature handoff, so it would now name functions that do not exist. It points at the chat envelope instead — which is the better design independently: an ephemeral-authored 1059 carrying spendable signatures is exactly the unattributable-injection shape the envelope was adopted to close (#246).

## README

Corrects the transport section, which still described chat as NIP-59 gift wrap after #247 and #254 moved both channels to kind 14 — `:37`, the "P2P Chat" concept row, the `1059` row in the kinds table, and the security section. This is the correction half of #123; the "list every supported NIP and BUD" half is still open there.

## Test

A gift wrap **authored by the very key the chat subscription pins** must be rejected on its kind. The assertion runs through `state.outer_seen`, not the message store: a junk ciphertext would be dropped further down anyway, so a store-only assertion passes for the wrong reason. Confirmed by removing the kind guard — the test fails, and passes again with it restored.

## Verification

- `cargo test --lib` — 253 passed, 0 failed
- `cargo clippy --lib` — warning-free
- `flutter analyze` — 7 issues, byte-identical to the count on `main` (all pre-existing)
- `flutter test` — 229 passed
- `./scripts/frb-generate.sh` — re-run; the generated bindings are gitignored and no longer list the removed symbols

## Follow-up, deliberately not in this diff

`subscribe_gift_wraps` and `handle_global_gift_wrap` are now misnomers — they handle kind-14 daemon traffic and have nothing to do with gift wrap. Renaming them touches many call sites and would bury this diff; worth its own mechanical PR.
