### PR TITLE
docs(readme): add Linux desktop toolchain to prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Make sure the following tools are installed on your system:
 | wasm-pack | latest | `cargo install wasm-pack` |
 | Rust nightly + `rust-src` (web only) | — | `rustup toolchain install nightly && rustup component add rust-src --toolchain nightly` |
 | flutter_rust_bridge CLI | 2.11.1 | `cargo install flutter_rust_bridge_codegen --version 2.11.1 --locked` |
-| Linux desktop toolchain (Linux only) | — | `sudo apt-get install clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev lld` |
+| Linux desktop toolchain (Debian/Ubuntu) | — | `sudo apt-get install clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-dev lld` |
 | Xcode (macOS / iOS only) | 15+ | Mac App Store |
 | Android Studio / NDK (Android only) | latest | [developer.android.com](https://developer.android.com/studio) |
 

--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ Make sure the following tools are installed on your system:
 | wasm-pack | latest | `cargo install wasm-pack` |
 | Rust nightly + `rust-src` (web only) | — | `rustup toolchain install nightly && rustup component add rust-src --toolchain nightly` |
 | flutter_rust_bridge CLI | 2.11.1 | `cargo install flutter_rust_bridge_codegen --version 2.11.1 --locked` |
+| Linux desktop toolchain (Linux only) | — | `sudo apt-get install clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev lld` |
 | Xcode (macOS / iOS only) | 15+ | Mac App Store |
 | Android Studio / NDK (Android only) | latest | [developer.android.com](https://developer.android.com/studio) |
 


### PR DESCRIPTION
The base Linux desktop toolchain (clang/cmake/ninja/GTK) required by Flutter was not documented.

The native-assets build drives the linker through \`clang\` and looks for it inside clang's own toolchain directory. When the default \`clang\` is a versioned LLVM install whose \`bin\` dir has no linker, the build fails with \`Failed to find any of [ld.lld, ld]\`. Adding \`lld\` covers that case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Linux desktop development prerequisites to the setup guide, including required build tools and libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->