### PR TITLE
fix(order): allow premium outside the default range when creating an order

### DIFF
--- a/lib/features/order/screens/add_order_screen.dart
+++ b/lib/features/order/screens/add_order_screen.dart
@@ -124,10 +124,10 @@ class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
         }
         ref.read(isMarketPriceProvider.notifier).state = true;
         // Reuse the source order's premium as-is; it already passed validation.
-        ref.read(premiumValueProvider.notifier).state = source.premium.clamp(
-          -kPremiumMaxMagnitude,
-          kPremiumMaxMagnitude,
-        );
+        // Kept a whole percent to match the integer premium Mostro expects.
+        ref.read(premiumValueProvider.notifier).state = source.premium
+            .clamp(-kPremiumMaxMagnitude, kPremiumMaxMagnitude)
+            .roundToDouble();
         ref.read(fixedSatsProvider.notifier).state = '';
       case OrderPreset.conservative:
         ref.read(isMarketPriceProvider.notifier).state = true;

--- a/lib/features/order/screens/add_order_screen.dart
+++ b/lib/features/order/screens/add_order_screen.dart
@@ -123,8 +123,11 @@ class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
           ref.read(selectedPaymentMethodsProvider.notifier).state = methods;
         }
         ref.read(isMarketPriceProvider.notifier).state = true;
-        ref.read(premiumValueProvider.notifier).state =
-            source.premium.clamp(-10.0, 10.0);
+        // Reuse the source order's premium as-is; it already passed validation.
+        ref.read(premiumValueProvider.notifier).state = source.premium.clamp(
+          -kPremiumMaxMagnitude,
+          kPremiumMaxMagnitude,
+        );
         ref.read(fixedSatsProvider.notifier).state = '';
       case OrderPreset.conservative:
         ref.read(isMarketPriceProvider.notifier).state = true;

--- a/lib/features/order/widgets/price_section.dart
+++ b/lib/features/order/widgets/price_section.dart
@@ -9,8 +9,15 @@ import 'package:mostro/l10n/app_localizations.dart';
 /// Whether Market or Fixed price mode is selected.
 final isMarketPriceProvider = StateProvider<bool>((_) => true);
 
-/// Premium slider value (-10% to +10%).
+/// Premium slider value. Default slider range is [-10%, +10%], but the input
+/// accepts (and the slider expands to fit) values up to [-999%, +999%].
 final premiumValueProvider = StateProvider<double>((_) => 0.0);
+
+/// Default premium slider bound. The slider grows past this to fit a typed value.
+const double kPremiumSliderDefault = 10.0;
+
+/// Hard limit for a manually entered premium magnitude.
+const double kPremiumMaxMagnitude = 999.0;
 
 /// Fixed sats amount (only used in Fixed price mode).
 final fixedSatsProvider = StateProvider<String>((_) => '');
@@ -59,6 +66,15 @@ class _PriceSectionState extends ConsumerState<PriceSection> {
     final isMarket = ref.watch(isMarketPriceProvider);
     final premium = ref.watch(premiumValueProvider);
     final l10n = AppLocalizations.of(context);
+
+    // Slider bounds default to ±10% but expand to fit a manually entered value.
+    final sliderMin =
+        premium < -kPremiumSliderDefault ? premium : -kPremiumSliderDefault;
+    final sliderMax =
+        premium > kPremiumSliderDefault ? premium : kPremiumSliderDefault;
+    // Keep the 0.5% granularity of the default range.
+    final sliderDivisions =
+        ((sliderMax - sliderMin) * 2).round().clamp(1, 4000);
 
     // Sync controller from provider via listener (not in build body).
     ref.listen<double>(premiumValueProvider, _syncControllerFromProvider);
@@ -153,7 +169,10 @@ class _PriceSectionState extends ConsumerState<PriceSection> {
                               final parsed = double.tryParse(v);
                               if (parsed != null) {
                                 ref.read(premiumValueProvider.notifier).state =
-                                    parsed.clamp(-10.0, 10.0);
+                                    parsed.clamp(
+                                  -kPremiumMaxMagnitude,
+                                  kPremiumMaxMagnitude,
+                                );
                               }
                             },
                             onTapOutside: (_) {
@@ -181,10 +200,10 @@ class _PriceSectionState extends ConsumerState<PriceSection> {
                   ],
                 ),
                 Slider(
-                  value: premium,
-                  min: -10,
-                  max: 10,
-                  divisions: 40,
+                  value: premium.clamp(sliderMin, sliderMax),
+                  min: sliderMin,
+                  max: sliderMax,
+                  divisions: sliderDivisions,
                   activeColor: purple,
                   label: '${premium >= 0 ? '+' : ''}${premium.toStringAsFixed(1)}%',
                   onChanged: (v) =>
@@ -194,14 +213,14 @@ class _PriceSectionState extends ConsumerState<PriceSection> {
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
                     Text(
-                      '-10%',
+                      '${sliderMin.round()}%',
                       style: TextStyle(
                         color: colors?.textSubtle,
                         fontSize: 11,
                       ),
                     ),
                     Text(
-                      '+10%',
+                      '+${sliderMax.round()}%',
                       style: TextStyle(
                         color: colors?.textSubtle,
                         fontSize: 11,

--- a/lib/features/order/widgets/price_section.dart
+++ b/lib/features/order/widgets/price_section.dart
@@ -157,7 +157,7 @@ class _PriceSectionState extends ConsumerState<PriceSection> {
                               TextInputFormatter.withFunction(
                                 (oldValue, newValue) {
                                   if (newValue.text.isEmpty) return newValue;
-                                  return RegExp(r'^-?\d{0,3}$')
+                                  return RegExp(r'^[+-]?\d{0,3}$')
                                           .hasMatch(newValue.text)
                                       ? newValue
                                       : oldValue;
@@ -196,6 +196,13 @@ class _PriceSectionState extends ConsumerState<PriceSection> {
                                           kPremiumMaxMagnitude.toInt(),
                                         )
                                         .toDouble();
+                              } else {
+                                // Empty or lone sign ('-'/'+'): keep the current
+                                // premium and restore the field text from it.
+                                _syncControllerFromProvider(
+                                  null,
+                                  ref.read(premiumValueProvider),
+                                );
                               }
                             },
                             onTapOutside: (_) {

--- a/lib/features/order/widgets/price_section.dart
+++ b/lib/features/order/widgets/price_section.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:mostro/core/app_theme.dart';
@@ -9,8 +10,9 @@ import 'package:mostro/l10n/app_localizations.dart';
 /// Whether Market or Fixed price mode is selected.
 final isMarketPriceProvider = StateProvider<bool>((_) => true);
 
-/// Premium slider value. Default slider range is [-10%, +10%], but the input
-/// accepts (and the slider expands to fit) values up to [-999%, +999%].
+/// Premium slider value. Whole percent only (Mostro rounds the premium to an
+/// integer). Default slider range is [-10%, +10%], but the input accepts (and
+/// the slider expands to fit) values up to [-999%, +999%].
 final premiumValueProvider = StateProvider<double>((_) => 0.0);
 
 /// Default premium slider bound. The slider grows past this to fit a typed value.
@@ -34,11 +36,17 @@ class _PriceSectionState extends ConsumerState<PriceSection> {
   late final TextEditingController _premiumController;
   bool _editingPremium = false;
 
+  // Slider bounds captured when a drag starts and held until it ends, so the
+  // scale does not shrink under the user's finger while dragging a value that
+  // sits outside the default ±10% range back toward zero. Null when idle.
+  double? _dragMin;
+  double? _dragMax;
+
   @override
   void initState() {
     super.initState();
     _premiumController = TextEditingController(
-      text: ref.read(premiumValueProvider).toStringAsFixed(1),
+      text: ref.read(premiumValueProvider).round().toString(),
     );
   }
 
@@ -50,7 +58,7 @@ class _PriceSectionState extends ConsumerState<PriceSection> {
 
   void _syncControllerFromProvider(double? prev, double next) {
     if (_editingPremium) return;
-    final newText = next.toStringAsFixed(1);
+    final newText = next.round().toString();
     if (_premiumController.text != newText) {
       _premiumController.text = newText;
     }
@@ -68,13 +76,14 @@ class _PriceSectionState extends ConsumerState<PriceSection> {
     final l10n = AppLocalizations.of(context);
 
     // Slider bounds default to ±10% but expand to fit a manually entered value.
-    final sliderMin =
-        premium < -kPremiumSliderDefault ? premium : -kPremiumSliderDefault;
-    final sliderMax =
-        premium > kPremiumSliderDefault ? premium : kPremiumSliderDefault;
-    // Keep the 0.5% granularity of the default range.
+    // While a drag is active the frozen bounds win, so the scale stays stable.
+    final sliderMin = _dragMin ??
+        (premium < -kPremiumSliderDefault ? premium : -kPremiumSliderDefault);
+    final sliderMax = _dragMax ??
+        (premium > kPremiumSliderDefault ? premium : kPremiumSliderDefault);
+    // Whole-percent steps (Mostro rounds the premium to an integer).
     final sliderDivisions =
-        ((sliderMax - sliderMin) * 2).round().clamp(1, 4000);
+        (sliderMax - sliderMin).round().clamp(1, 2000);
 
     // Sync controller from provider via listener (not in build body).
     ref.listen<double>(premiumValueProvider, _syncControllerFromProvider);
@@ -141,8 +150,20 @@ class _PriceSectionState extends ConsumerState<PriceSection> {
                             controller: _premiumController,
                             keyboardType: const TextInputType.numberWithOptions(
                               signed: true,
-                              decimal: true,
                             ),
+                            // Whole percent only: optional sign + up to 3
+                            // digits. Blocks '.' / ',' so no decimals slip in.
+                            inputFormatters: [
+                              TextInputFormatter.withFunction(
+                                (oldValue, newValue) {
+                                  if (newValue.text.isEmpty) return newValue;
+                                  return RegExp(r'^-?\d{0,3}$')
+                                          .hasMatch(newValue.text)
+                                      ? newValue
+                                      : oldValue;
+                                },
+                              ),
+                            ],
                             textAlign: TextAlign.center,
                             style: TextStyle(
                               color: purple,
@@ -166,13 +187,15 @@ class _PriceSectionState extends ConsumerState<PriceSection> {
                                 setState(() => _editingPremium = true),
                             onSubmitted: (v) {
                               setState(() => _editingPremium = false);
-                              final parsed = double.tryParse(v);
+                              final parsed = int.tryParse(v);
                               if (parsed != null) {
                                 ref.read(premiumValueProvider.notifier).state =
-                                    parsed.clamp(
-                                  -kPremiumMaxMagnitude,
-                                  kPremiumMaxMagnitude,
-                                );
+                                    parsed
+                                        .clamp(
+                                          -kPremiumMaxMagnitude.toInt(),
+                                          kPremiumMaxMagnitude.toInt(),
+                                        )
+                                        .toDouble();
                               }
                             },
                             onTapOutside: (_) {
@@ -205,9 +228,18 @@ class _PriceSectionState extends ConsumerState<PriceSection> {
                   max: sliderMax,
                   divisions: sliderDivisions,
                   activeColor: purple,
-                  label: '${premium >= 0 ? '+' : ''}${premium.toStringAsFixed(1)}%',
-                  onChanged: (v) =>
-                      ref.read(premiumValueProvider.notifier).state = v,
+                  label: '${premium >= 0 ? '+' : ''}${premium.round()}%',
+                  onChangeStart: (_) => setState(() {
+                    _dragMin = sliderMin;
+                    _dragMax = sliderMax;
+                  }),
+                  onChanged: (v) => ref
+                      .read(premiumValueProvider.notifier)
+                      .state = v.roundToDouble(),
+                  onChangeEnd: (_) => setState(() {
+                    _dragMin = null;
+                    _dragMax = null;
+                  }),
                 ),
                 Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/lib/features/order/widgets/price_section.dart
+++ b/lib/features/order/widgets/price_section.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -42,6 +44,11 @@ class _PriceSectionState extends ConsumerState<PriceSection> {
   double? _dragMin;
   double? _dragMax;
 
+  // Applies a typed premium a short while after the user stops typing, so the
+  // slider tracks the field live without needing Enter (matches v1 behaviour).
+  Timer? _premiumDebounce;
+  static const Duration _premiumDebounceDelay = Duration(seconds: 2);
+
   @override
   void initState() {
     super.initState();
@@ -52,6 +59,7 @@ class _PriceSectionState extends ConsumerState<PriceSection> {
 
   @override
   void dispose() {
+    _premiumDebounce?.cancel();
     _premiumController.dispose();
     super.dispose();
   }
@@ -61,6 +69,32 @@ class _PriceSectionState extends ConsumerState<PriceSection> {
     final newText = next.round().toString();
     if (_premiumController.text != newText) {
       _premiumController.text = newText;
+    }
+  }
+
+  /// Parse [v] and push it (clamped to ±[kPremiumMaxMagnitude]) to the premium
+  /// provider. Returns false when [v] is empty or a lone sign so callers can
+  /// decide whether to restore the field. Does not touch the controller text,
+  /// so it is safe to call mid-typing.
+  bool _applyPremiumText(String v) {
+    final parsed = int.tryParse(v);
+    if (parsed == null) return false;
+    ref.read(premiumValueProvider.notifier).state = parsed
+        .clamp(
+          -kPremiumMaxMagnitude.toInt(),
+          kPremiumMaxMagnitude.toInt(),
+        )
+        .toDouble();
+    return true;
+  }
+
+  /// Finish editing the field: commit [v], or restore the text from the current
+  /// premium when [v] does not parse. Cancels any pending live update.
+  void _endPremiumEditing(String v) {
+    _premiumDebounce?.cancel();
+    setState(() => _editingPremium = false);
+    if (!_applyPremiumText(v)) {
+      _syncControllerFromProvider(null, ref.read(premiumValueProvider));
     }
   }
 
@@ -185,34 +219,21 @@ class _PriceSectionState extends ConsumerState<PriceSection> {
                             ),
                             onTap: () =>
                                 setState(() => _editingPremium = true),
-                            onSubmitted: (v) {
-                              setState(() => _editingPremium = false);
-                              final parsed = int.tryParse(v);
-                              if (parsed != null) {
-                                ref.read(premiumValueProvider.notifier).state =
-                                    parsed
-                                        .clamp(
-                                          -kPremiumMaxMagnitude.toInt(),
-                                          kPremiumMaxMagnitude.toInt(),
-                                        )
-                                        .toDouble();
-                              } else {
-                                // Empty or lone sign ('-'/'+'): keep the current
-                                // premium and restore the field text from it.
-                                _syncControllerFromProvider(
-                                  null,
-                                  ref.read(premiumValueProvider),
-                                );
-                              }
-                            },
-                            onTapOutside: (_) {
-                              setState(() => _editingPremium = false);
-                              // Sync controller to current provider value.
-                              _syncControllerFromProvider(
-                                null,
-                                ref.read(premiumValueProvider),
+                            onChanged: (v) {
+                              // Live update like v1: apply the typed value a
+                              // couple of seconds after the user stops typing,
+                              // so the slider follows without needing Enter.
+                              // The controller is left untouched here, so the
+                              // cursor and in-progress text are never disturbed.
+                              _premiumDebounce?.cancel();
+                              _premiumDebounce = Timer(
+                                _premiumDebounceDelay,
+                                () => _applyPremiumText(v),
                               );
                             },
+                            onSubmitted: _endPremiumEditing,
+                            onTapOutside: (_) =>
+                                _endPremiumEditing(_premiumController.text),
                           ),
                         ),
                         const SizedBox(width: 4),

--- a/test/features/order/widgets/price_section_test.dart
+++ b/test/features/order/widgets/price_section_test.dart
@@ -84,6 +84,20 @@ void main() {
     );
 
     testWidgets(
+      'applies a typed value after the debounce without pressing enter',
+      (tester) async {
+        final container = await _pump(tester, premium: 0.0);
+        await tester.enterText(find.byType(TextField), '50');
+        // No submit action: the value must land on its own once the debounce
+        // window elapses, and the slider expands to fit it.
+        expect(container.read(premiumValueProvider), 0.0);
+        await tester.pump(const Duration(seconds: 2));
+        expect(container.read(premiumValueProvider), 50.0);
+        expect(sliderMax(tester), 50.0);
+      },
+    );
+
+    testWidgets(
       'accepts a value typed with an explicit plus sign',
       (tester) async {
         final container = await _pump(tester, premium: 0.0);

--- a/test/features/order/widgets/price_section_test.dart
+++ b/test/features/order/widgets/price_section_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro/core/app_theme.dart';
+import 'package:mostro/features/order/widgets/price_section.dart';
+import 'package:mostro/l10n/app_localizations.dart';
+import '../../../support/provider_harness.dart';
+
+/// Pump [PriceSection] in Market mode with the premium provider seeded to
+/// [premium]. A tall surface keeps the layout from overflowing the viewport.
+Future<ProviderContainer> _pump(
+  WidgetTester tester, {
+  required double premium,
+}) async {
+  tester.view.physicalSize = const Size(1200, 3000);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+  final container = createContainer(
+    overrides: [premiumValueProvider.overrideWith((ref) => premium)],
+  );
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(
+        theme: buildDarkTheme(),
+        locale: const Locale('en'),
+        localizationsDelegates: const [
+          AppLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: const Scaffold(
+          resizeToAvoidBottomInset: false,
+          body: PriceSection(),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return container;
+}
+
+void main() {
+  group('PriceSection premium slider', () {
+    double sliderMax(WidgetTester tester) =>
+        tester.widget<Slider>(find.byType(Slider)).max;
+
+    testWidgets(
+      'expands to fit a value entered above the default range',
+      (tester) async {
+        await _pump(tester, premium: 20.0);
+        // Slider grows to the entered value instead of clamping to +10%.
+        expect(sliderMax(tester), 20.0);
+      },
+    );
+
+    testWidgets(
+      'accepts a whole-percent value typed into the field',
+      (tester) async {
+        final container = await _pump(tester, premium: 0.0);
+        await tester.enterText(find.byType(TextField), '7');
+        await tester.testTextInput.receiveAction(TextInputAction.done);
+        await tester.pumpAndSettle();
+        expect(container.read(premiumValueProvider), 7.0);
+      },
+    );
+
+    testWidgets(
+      'rejects a decimal typed into the field',
+      (tester) async {
+        final container = await _pump(tester, premium: 3.0);
+        // The formatter drops '.' / ',', so a decimal never reaches state and
+        // the premium stays a whole number.
+        await tester.enterText(find.byType(TextField), '5.5');
+        await tester.testTextInput.receiveAction(TextInputAction.done);
+        await tester.pumpAndSettle();
+        final value = container.read(premiumValueProvider);
+        expect(value, value.roundToDouble());
+        expect(value, isNot(5.5));
+      },
+    );
+
+    testWidgets(
+      'keeps expanded bounds stable while dragging 20 toward 0',
+      (tester) async {
+        final container = await _pump(tester, premium: 20.0);
+        expect(sliderMax(tester), 20.0);
+
+        // Grab the thumb near the right edge (value == max == 20) and drag left.
+        final rect = tester.getRect(find.byType(Slider));
+        final gesture = await tester.startGesture(
+          Offset(rect.right - 24, rect.center.dy),
+        );
+        await tester.pump();
+
+        // Drag toward zero in steps; the frozen max must not shrink under the
+        // finger on any intermediate rebuild (the regression this guards). The
+        // total distance is enough to cross back into the default range.
+        for (var i = 0; i < 12; i++) {
+          await gesture.moveBy(const Offset(-60, 0));
+          await tester.pump();
+          expect(
+            sliderMax(tester),
+            20.0,
+            reason: 'max must stay frozen during the drag',
+          );
+        }
+
+        // The value actually moved down while dragging (thumb is not pinned).
+        expect(container.read(premiumValueProvider), lessThan(20.0));
+
+        await gesture.up();
+        await tester.pumpAndSettle();
+
+        // Once the gesture ends the bounds recompute; the value landed inside
+        // the default range, so the slider collapses back to +10%.
+        expect(container.read(premiumValueProvider), lessThanOrEqualTo(10.0));
+        expect(sliderMax(tester), kPremiumSliderDefault);
+      },
+    );
+  });
+}

--- a/test/features/order/widgets/price_section_test.dart
+++ b/test/features/order/widgets/price_section_test.dart
@@ -84,6 +84,32 @@ void main() {
     );
 
     testWidgets(
+      'accepts a value typed with an explicit plus sign',
+      (tester) async {
+        final container = await _pump(tester, premium: 0.0);
+        await tester.enterText(find.byType(TextField), '+20');
+        await tester.testTextInput.receiveAction(TextInputAction.done);
+        await tester.pumpAndSettle();
+        expect(container.read(premiumValueProvider), 20.0);
+      },
+    );
+
+    testWidgets(
+      'restores the field and keeps the premium on invalid submission',
+      (tester) async {
+        final container = await _pump(tester, premium: 3.0);
+        // A lone sign does not parse: the premium must stay put and the field
+        // must snap back to it instead of keeping the invalid text.
+        await tester.enterText(find.byType(TextField), '-');
+        await tester.testTextInput.receiveAction(TextInputAction.done);
+        await tester.pumpAndSettle();
+        expect(container.read(premiumValueProvider), 3.0);
+        final field = tester.widget<TextField>(find.byType(TextField));
+        expect(field.controller?.text, '3');
+      },
+    );
+
+    testWidgets(
       'keeps expanded bounds stable while dragging 20 toward 0',
       (tester) async {
         final container = await _pump(tester, premium: 20.0);


### PR DESCRIPTION
The premium input on the create-order screen hard-clamped to the default range of -10% to +10%, silently rejecting any value outside it, typing 20 became 10.

Accept values from -999% to +999% and expand the slider dynamically to fit a manually entered value. 

The default slider range stays -10% to +10%.

Changes Flutter only

Closes #316

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Premium values can be entered and adjusted as whole percentages up to ±999%, including an optional plus sign.
  * Typed premium values are applied shortly after editing stops.
  * The premium slider expands for values beyond its default range and preserves stable bounds while dragging.
  * Slider labels and displayed values are rounded to whole percentages.

* **Bug Fixes**
  * Decimal premium entries are rejected, with invalid submissions recovering correctly.
  * Express preset premiums are consistently limited to the supported ±999% range.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->