### PR TITLE
fix(order): prevent fixed price on range orders

### DIFF
--- a/lib/features/order/screens/add_order_screen.dart
+++ b/lib/features/order/screens/add_order_screen.dart
@@ -51,6 +51,7 @@ class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
           ref.read(settingsProvider).defaultFiatCode ?? 'USD';
       ref.read(selectedFiatCodeProvider.notifier).state = defaultFiat;
       ref.read(isMarketPriceProvider.notifier).state = true;
+      ref.read(isRangeOrderProvider.notifier).state = false;
       ref.read(premiumValueProvider.notifier).state = 0.0;
       ref.read(fixedSatsProvider.notifier).state = '';
       ref.read(selectedOrderPresetProvider.notifier).state =
@@ -64,6 +65,19 @@ class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
     _minController.dispose();
     _maxController.dispose();
     super.dispose();
+  }
+
+  /// Toggles range mode. A range order can't carry a fixed sats price (Mostro
+  /// prices it at market with a premium), so entering range mode forces Market
+  /// and clears any fixed sats the user had typed. PriceSection watches
+  /// [isRangeOrderProvider] to lock its toggle to Market while range is on.
+  void _onRangeChanged(bool isRange) {
+    setState(() => _isRange = isRange);
+    ref.read(isRangeOrderProvider.notifier).state = isRange;
+    if (isRange) {
+      ref.read(isMarketPriceProvider.notifier).state = true;
+      ref.read(fixedSatsProvider.notifier).state = '';
+    }
   }
 
   bool _checkValid(
@@ -99,6 +113,7 @@ class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
         if (source == null) return;
         final isRange =
             source.fiatAmountMin != null && source.fiatAmountMax != null;
+        ref.read(isRangeOrderProvider.notifier).state = isRange;
         setState(() {
           _isRange = isRange;
           if (isRange) {
@@ -266,7 +281,7 @@ class _AddOrderScreenState extends ConsumerState<AddOrderScreen> {
                     Switch(
                       value: _isRange,
                       activeThumbColor: green,
-                      onChanged: (v) => setState(() => _isRange = v),
+                      onChanged: _onRangeChanged,
                     ),
                   ],
                 ),

--- a/lib/features/order/widgets/price_section.dart
+++ b/lib/features/order/widgets/price_section.dart
@@ -15,6 +15,12 @@ final premiumValueProvider = StateProvider<double>((_) => 0.0);
 /// Fixed sats amount (only used in Fixed price mode).
 final fixedSatsProvider = StateProvider<String>((_) => '');
 
+/// Whether the order being created is a range order (min/max fiat amount).
+/// Range orders are incompatible with a fixed sats price — Mostro prices them
+/// at market with a premium — so PriceSection locks the toggle to Market and
+/// disables Fixed while this is true.
+final isRangeOrderProvider = StateProvider<bool>((_) => false);
+
 /// Price type toggle + premium/fixed sats input.
 class PriceSection extends ConsumerStatefulWidget {
   const PriceSection({super.key});
@@ -57,6 +63,7 @@ class _PriceSectionState extends ConsumerState<PriceSection> {
     final purple = colors?.purpleButton ?? const Color(0xFF8359C2);
     final inputBg = colors?.backgroundInput ?? const Color(0xFF252A3A);
     final isMarket = ref.watch(isMarketPriceProvider);
+    final isRange = ref.watch(isRangeOrderProvider);
     final premium = ref.watch(premiumValueProvider);
     final l10n = AppLocalizations.of(context);
 
@@ -82,8 +89,11 @@ class _PriceSectionState extends ConsumerState<PriceSection> {
             Switch(
               value: isMarket,
               activeThumbColor: green,
-              onChanged: (v) =>
-                  ref.read(isMarketPriceProvider.notifier).state = v,
+              // Range orders must use market price (Mostro applies a premium to
+              // the variable amount), so Fixed is locked out while in range.
+              onChanged: isRange
+                  ? null
+                  : (v) => ref.read(isMarketPriceProvider.notifier).state = v,
             ).withAutomationId(AutomationIds.orderCreatePriceType),
             IconButton(
               onPressed: () => _showPriceInfo(context),
@@ -95,6 +105,27 @@ class _PriceSectionState extends ConsumerState<PriceSection> {
           ],
         ),
         const SizedBox(height: AppSpacing.sm),
+
+        // Range orders can't use a fixed price — explain why Fixed is disabled.
+        if (isRange) ...[
+          Padding(
+            padding: const EdgeInsets.only(bottom: AppSpacing.sm),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Icon(Icons.info_outline,
+                    size: 14, color: colors?.textSubtle),
+                const SizedBox(width: AppSpacing.xs),
+                Expanded(
+                  child: Text(
+                    l10n.fixedPriceRangeNotAvailable,
+                    style: TextStyle(fontSize: 12, color: colors?.textSubtle),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
 
         if (isMarket) ...[
           // Premium slider with editable field

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -614,6 +614,7 @@
   "priceTypeInfoTooltip": "Info zum Preistyp",
   "premiumSectionLabel": "Aufschlag",
   "amountInSatsHint": "Betrag in Sats",
+  "fixedPriceRangeNotAvailable": "Festpreis ist für Bereichsangebote nicht verfügbar. Deaktiviere den Bereich, um einen Festpreis zu verwenden.",
   "priceTypesDialogTitle": "Preistypen",
   "priceTypesDialogContent": "Marktpreis: Der Preis deiner Order folgt dem Marktkurs mit einem angewendeten Aufschlag/Abschlag-Prozentsatz.\n\nFestpreis: Du legst einen genauen Preis in Satoshis fest.",
   "startFromPreset": "MIT EINER VORLAGE STARTEN",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1324,6 +1324,8 @@
   "@premiumSectionLabel": {"description": "Label of the premium slider section"},
   "amountInSatsHint": "Amount in sats",
   "@amountInSatsHint": {"description": "Hint for the fixed sats amount input"},
+  "fixedPriceRangeNotAvailable": "Fixed price isn't available for range orders. Turn off the range to use a fixed price.",
+  "@fixedPriceRangeNotAvailable": {"description": "Explains why the fixed-price toggle is disabled while a range order is being created"},
   "priceTypesDialogTitle": "Price Types",
   "@priceTypesDialogTitle": {"description": "Title of the price types info dialog"},
   "priceTypesDialogContent": "Market Price: Your order price follows the market rate with a premium/discount percentage applied.\n\nFixed Price: You set an exact price in satoshis.",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -614,6 +614,7 @@
   "priceTypeInfoTooltip": "Info del tipo de precio",
   "premiumSectionLabel": "Prima",
   "amountInSatsHint": "Monto en sats",
+  "fixedPriceRangeNotAvailable": "El precio fijo no está disponible para órdenes por rango. Desactiva el rango para usar un precio fijo.",
   "priceTypesDialogTitle": "Tipos de precio",
   "priceTypesDialogContent": "Precio de mercado: el precio de tu orden sigue la tasa del mercado con un porcentaje de prima/descuento aplicado.\n\nPrecio fijo: estableces un precio exacto en satoshis.",
   "startFromPreset": "EMPEZAR DESDE UN PRESET",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -614,6 +614,7 @@
   "priceTypeInfoTooltip": "Infos sur le type de prix",
   "premiumSectionLabel": "Prime",
   "amountInSatsHint": "Montant en sats",
+  "fixedPriceRangeNotAvailable": "Le prix fixe n'est pas disponible pour les ordres à fourchette. Désactivez la fourchette pour utiliser un prix fixe.",
   "priceTypesDialogTitle": "Types de prix",
   "priceTypesDialogContent": "Prix du marché : le prix de votre ordre suit le taux du marché avec un pourcentage de prime/remise appliqué.\n\nPrix fixe : vous définissez un prix exact en satoshis.",
   "startFromPreset": "PARTIR D'UN PRÉRÉGLAGE",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -614,6 +614,7 @@
   "priceTypeInfoTooltip": "Info sul tipo di prezzo",
   "premiumSectionLabel": "Premio",
   "amountInSatsHint": "Importo in sats",
+  "fixedPriceRangeNotAvailable": "Il prezzo fisso non è disponibile per gli ordini a intervallo. Disattiva l'intervallo per usare un prezzo fisso.",
   "priceTypesDialogTitle": "Tipi di prezzo",
   "priceTypesDialogContent": "Prezzo di mercato: il prezzo del tuo ordine segue il tasso di mercato con una percentuale di premio/sconto applicata.\n\nPrezzo fisso: imposti un prezzo esatto in satoshi.",
   "startFromPreset": "INIZIA DA UN PRESET",


### PR DESCRIPTION
Closes #322

Range orders have a variable amount and must be priced at market, so combining a range with a fixed sats price made the daemon reject the order with a CantDo error at submit time.

Mirror mobile v1: enabling range now forces Market price, clears any entered fixed sats, and disables the Fixed toggle with an explanatory note. Adds the localized string across en/es/fr/de/it.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Range orders now automatically use Market pricing.
  - Fixed pricing is disabled while range mode is active.
  - Enabling range mode clears any entered fixed-price value.
  - Added localized guidance explaining how to use fixed pricing with range orders in English, German, Spanish, French, and Italian.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->