### PR TITLE
fix(#327): make the rated trade state reachable

### DIFF
--- a/lib/features/rate/providers/rating_providers.dart
+++ b/lib/features/rate/providers/rating_providers.dart
@@ -3,18 +3,23 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mostro/src/rust/api/reputation.dart' as reputation_api;
 import 'package:mostro/src/rust/api/types.dart';
 
-/// The rating the local user submitted for [tradeId], or `null` when they
-/// have not rated that trade yet.
+/// The rating held for [tradeId], or `null` when neither side has rated.
+///
+/// The Rust store is in-memory by design (ratings live in the daemon's kind
+/// 38383 tags, not in the local DB), so this resolves to `null` again after a
+/// restart and the rate prompt comes back.
+final tradeRatingProvider = FutureProvider.autoDispose
+    .family<RatingInfo?, String>((ref, tradeId) async {
+  return reputation_api.getRatingForTrade(tradeId: tradeId);
+});
+
+/// Whether the local user has rated their counterpart on [tradeId].
 ///
 /// `getRatingForTrade` falls back to the counterpart's rating when the local
 /// user has not submitted one, so `isMine` is what separates "I rated them"
 /// from "they rated me" — only the former resolves the rate prompt.
-///
-/// The Rust store is in-memory by design (ratings live in the daemon's kind
-/// 38383 tags, not in the local DB), so this resolves to `null` again after a
-/// restart and the prompt comes back.
-final myTradeRatingProvider = FutureProvider.autoDispose
-    .family<RatingInfo?, String>((ref, tradeId) async {
-  final rating = await reputation_api.getRatingForTrade(tradeId: tradeId);
-  return rating != null && rating.isMine ? rating : null;
+final ratedByMeProvider =
+    Provider.autoDispose.family<bool, String>((ref, tradeId) {
+  final rating = ref.watch(tradeRatingProvider(tradeId)).valueOrNull;
+  return rating != null && rating.isMine;
 });

--- a/lib/features/rate/providers/rating_providers.dart
+++ b/lib/features/rate/providers/rating_providers.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:mostro/src/rust/api/reputation.dart' as reputation_api;
+import 'package:mostro/src/rust/api/types.dart';
+
+/// The rating the local user submitted for [tradeId], or `null` when they
+/// have not rated that trade yet.
+///
+/// `getRatingForTrade` falls back to the counterpart's rating when the local
+/// user has not submitted one, so `isMine` is what separates "I rated them"
+/// from "they rated me" — only the former resolves the rate prompt.
+///
+/// The Rust store is in-memory by design (ratings live in the daemon's kind
+/// 38383 tags, not in the local DB), so this resolves to `null` again after a
+/// restart and the prompt comes back.
+final myTradeRatingProvider = FutureProvider.autoDispose
+    .family<RatingInfo?, String>((ref, tradeId) async {
+  final rating = await reputation_api.getRatingForTrade(tradeId: tradeId);
+  return rating != null && rating.isMine ? rating : null;
+});

--- a/lib/features/rate/screens/rate_counterpart_screen.dart
+++ b/lib/features/rate/screens/rate_counterpart_screen.dart
@@ -6,6 +6,7 @@ import 'package:mostro/core/app_theme.dart';
 import 'package:mostro/core/automation/automation_id.dart';
 import 'package:mostro/core/automation/automation_ids.dart';
 import 'package:mostro/core/daemon_errors.dart';
+import 'package:mostro/features/rate/providers/rating_providers.dart';
 import 'package:mostro/features/rate/widgets/star_rating.dart';
 import 'package:mostro/l10n/app_localizations.dart';
 import 'package:mostro/src/rust/api/reputation.dart' as reputation_api;
@@ -46,6 +47,9 @@ class _RateCounterpartScreenState
         tradeId: widget.orderId,
         score: _rating,
       );
+      // The screen underneath buckets a settled trade as "rate me" until a
+      // local rating exists, so refresh it before popping back (#327).
+      ref.invalidate(myTradeRatingProvider(widget.orderId));
       if (mounted) context.pop();
     } catch (e) {
       if (!mounted) return;

--- a/lib/features/rate/screens/rate_counterpart_screen.dart
+++ b/lib/features/rate/screens/rate_counterpart_screen.dart
@@ -49,7 +49,7 @@ class _RateCounterpartScreenState
       );
       // The screen underneath buckets a settled trade as "rate me" until a
       // local rating exists, so refresh it before popping back (#327).
-      ref.invalidate(myTradeRatingProvider(widget.orderId));
+      ref.invalidate(tradeRatingProvider(widget.orderId));
       if (mounted) context.pop();
     } catch (e) {
       if (!mounted) return;

--- a/lib/features/rate/screens/rate_counterpart_screen.dart
+++ b/lib/features/rate/screens/rate_counterpart_screen.dart
@@ -47,10 +47,14 @@ class _RateCounterpartScreenState
         tradeId: widget.orderId,
         score: _rating,
       );
+      // submitRating awaits a real relay publish, so the screen may have
+      // been disposed by now — and ref, like context, must not be touched
+      // after that.
+      if (!mounted) return;
       // The screen underneath buckets a settled trade as "rate me" until a
       // local rating exists, so refresh it before popping back (#327).
       ref.invalidate(tradeRatingProvider(widget.orderId));
-      if (mounted) context.pop();
+      context.pop();
     } catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -18,6 +18,7 @@ import 'package:mostro/features/chat/providers/chat_providers.dart';
 import 'package:mostro/features/disputes/providers/disputes_providers.dart';
 import 'package:mostro/features/home/providers/home_order_providers.dart';
 import 'package:mostro/features/order/providers/trade_state_provider.dart';
+import 'package:mostro/features/rate/providers/rating_providers.dart';
 import 'package:mostro/features/trades/providers/trades_providers.dart';
 import 'package:mostro/features/trades/widgets/dispute_confirmation_dialog.dart';
 import 'package:mostro/features/trades/widgets/release_confirmation_dialog.dart';
@@ -511,9 +512,18 @@ class _TradeDetailScreenState extends ConsumerState<TradeDetailScreen> {
     // Use TradeStatus.loading while the provider hasn't resolved so the UI
     // doesn't flash the pending CTA before the real status is known.
     final tradeStatusAsync = ref.watch(tradeStatusProvider(widget.orderId));
-    final status = tradeStatusAsync.hasValue
+    final orderStatus = tradeStatusAsync.hasValue
         ? _mapOrderStatus(tradeStatusAsync.value!)
         : TradeStatus.loading;
+
+    // The protocol has no "rated" order status — a settled trade stays
+    // settled once the rating is sent — so `rated` is only reachable by
+    // overlaying the local rating on top of the mapping above (#327).
+    final ratedByMe =
+        ref.watch(myTradeRatingProvider(widget.orderId)).valueOrNull != null;
+    final status = orderStatus == TradeStatus.pendingRating && ratedByMe
+        ? TradeStatus.rated
+        : orderStatus;
 
     // Look up order details from the live order book.
     final allOrders = ref.watch(orderBookProvider).valueOrNull ?? [];

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -518,11 +518,25 @@ class _TradeDetailScreenState extends ConsumerState<TradeDetailScreen> {
 
     // The protocol has no "rated" order status — a settled trade stays
     // settled once the rating is sent — so `rated` is only reachable by
-    // overlaying the local rating on top of the mapping above (#327).
-    final ratedByMe = ref.watch(ratedByMeProvider(widget.orderId));
-    final status = orderStatus == TradeStatus.pendingRating && ratedByMe
-        ? TradeStatus.rated
-        : orderStatus;
+    // overlaying the local rating on top of the mapping above (#327). The
+    // lookup only matters (and is only watched) once the trade settles, and
+    // while its first fetch is unresolved the screen holds `loading` for
+    // the same reason as above — never flash a CTA that may change on the
+    // next frame. A refresh keeps the previous value, so resolving a fresh
+    // rating does not bounce through the spinner.
+    final TradeStatus status;
+    if (orderStatus != TradeStatus.pendingRating) {
+      status = orderStatus;
+    } else {
+      final ratingAsync = ref.watch(tradeRatingProvider(widget.orderId));
+      if (ratingAsync.isLoading && !ratingAsync.hasValue) {
+        status = TradeStatus.loading;
+      } else if (ref.watch(ratedByMeProvider(widget.orderId))) {
+        status = TradeStatus.rated;
+      } else {
+        status = TradeStatus.pendingRating;
+      }
+    }
 
     // Look up order details from the live order book.
     final allOrders = ref.watch(orderBookProvider).valueOrNull ?? [];

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -519,8 +519,7 @@ class _TradeDetailScreenState extends ConsumerState<TradeDetailScreen> {
     // The protocol has no "rated" order status — a settled trade stays
     // settled once the rating is sent — so `rated` is only reachable by
     // overlaying the local rating on top of the mapping above (#327).
-    final ratedByMe =
-        ref.watch(myTradeRatingProvider(widget.orderId)).valueOrNull != null;
+    final ratedByMe = ref.watch(ratedByMeProvider(widget.orderId));
     final status = orderStatus == TradeStatus.pendingRating && ratedByMe
         ? TradeStatus.rated
         : orderStatus;

--- a/test/features/trades/trade_detail_screen_test.dart
+++ b/test/features/trades/trade_detail_screen_test.dart
@@ -24,24 +24,30 @@ import '../../support/provider_harness.dart';
 /// `_loadExpiresAt`/Rust-bridge calls fail silently without `RustLib.init()`
 /// (the same as `test/widget_test.dart`'s smoke test), which is fine since
 /// none of the assertions here depend on live order details.
-Future<void> _pumpTradeDetail(
+///
+/// Returns the container so a test can drive a provider after the first
+/// frame — what [ratingFetch] is for: it is re-read on every refresh, so a
+/// test can change what the rating lookup answers and invalidate it.
+Future<ProviderContainer> _pumpTradeDetail(
   WidgetTester tester, {
   required String orderId,
   required bool isBuyer,
   required OrderStatus status,
   RatingInfo? rating,
   bool ratingUnresolved = false,
+  Future<RatingInfo?> Function()? ratingFetch,
   Locale locale = const Locale('en'),
 }) async {
   final container = createContainer(overrides: [
     tradeRoleProvider.overrideWith((ref) => {orderId: isBuyer}),
     tradeStatusProvider(orderId).overrideWith((ref) => Stream.value(status)),
     orderBookProvider.overrideWith((ref) => Stream.value(const [])),
-    // A pending Completer future keeps the rating lookup in its first
-    // loading state, pinning the no-CTA-flash guard.
-    tradeRatingProvider(orderId).overrideWith((ref) => ratingUnresolved
-        ? Completer<RatingInfo?>().future
-        : Future.value(rating)),
+    tradeRatingProvider(orderId).overrideWith((ref) {
+      // A pending Completer future keeps the rating lookup in its first
+      // loading state, pinning the no-CTA-flash guard.
+      if (ratingUnresolved) return Completer<RatingInfo?>().future;
+      return ratingFetch != null ? ratingFetch() : Future.value(rating);
+    }),
   ]);
 
   await tester.pumpWidget(
@@ -70,6 +76,8 @@ Future<void> _pumpTradeDetail(
   // `pumpAndSettle()` time out.
   await tester.pump();
   await tester.pump();
+
+  return container;
 }
 
 /// Builds the rating the Rust store would hand back for a trade.
@@ -457,6 +465,63 @@ void main() {
 
       expect(_filledButtonWithText('Rate your counterpart'), findsNothing);
       expect(find.text('Rated'), findsNothing);
+    });
+
+    /// The post-submission link: RateCounterpartScreen invalidates
+    /// `tradeRatingProvider` after a successful `submitRating`, and the
+    /// detail screen underneath — still mounted, since the rate screen is
+    /// pushed on top of it — must re-read and resolve the prompt without
+    /// being rebuilt from scratch.
+    ///
+    /// The invalidation is driven directly rather than by tapping SUBMIT on
+    /// the real screen: `submitRating` calls the bridge with no injectable
+    /// seam, and this harness runs without `RustLib.init()`, so its success
+    /// path is unreachable from a widget test.
+    testWidgets('a rating submitted while mounted resolves the prompt',
+        (tester) async {
+      const orderId = 'order-rate-5';
+      // The refetch the invalidation triggers, held open so the refreshing
+      // frames are observable instead of racing to the result.
+      final refresh = Completer<RatingInfo?>();
+      var first = true;
+
+      final container = await _pumpTradeDetail(
+        tester,
+        orderId: orderId,
+        isBuyer: false,
+        status: OrderStatus.settledHoldInvoice,
+        ratingFetch: () {
+          if (first) {
+            first = false;
+            return Future<RatingInfo?>.value(null);
+          }
+          return refresh.future;
+        },
+      );
+
+      expect(_filledButtonWithText('Rate your counterpart'), findsOneWidget);
+      expect(find.text('Rated'), findsNothing);
+
+      // What _submit does once the daemon accepts the rating.
+      container.invalidate(tradeRatingProvider(orderId));
+      // Riverpod recomputes lazily, so read once to enter the refreshing
+      // state before the frame — otherwise the pump below just re-renders
+      // the pre-invalidation frame and asserts nothing.
+      container.read(tradeRatingProvider(orderId));
+      await tester.pump();
+
+      // Mid-refresh the previous answer still stands, so the prompt holds
+      // its ground: only the *first* lookup may show the spinner, or every
+      // rating would bounce the screen through `loading`.
+      expect(_filledButtonWithText('Rate your counterpart'), findsOneWidget);
+
+      refresh.complete(_rating(isMine: true));
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('Rated'), findsOneWidget);
+      expect(find.text('Thank you for your rating!'), findsOneWidget);
+      expect(_filledButtonWithText('Rate your counterpart'), findsNothing);
     });
   });
 

--- a/test/features/trades/trade_detail_screen_test.dart
+++ b/test/features/trades/trade_detail_screen_test.dart
@@ -5,9 +5,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mostro/core/app_theme.dart';
 import 'package:mostro/features/home/providers/home_order_providers.dart';
 import 'package:mostro/features/order/providers/trade_state_provider.dart';
+import 'package:mostro/features/rate/providers/rating_providers.dart';
 import 'package:mostro/features/trades/screens/trade_detail_screen.dart';
 import 'package:mostro/l10n/app_localizations.dart';
 import 'package:mostro/l10n/app_localizations_en.dart';
+import 'package:mostro/shared/utils/platform_int64.dart';
+import 'package:mostro/src/rust/api/types.dart';
 
 import '../../support/provider_harness.dart';
 
@@ -24,12 +27,14 @@ Future<void> _pumpTradeDetail(
   required String orderId,
   required bool isBuyer,
   required OrderStatus status,
+  RatingInfo? rating,
   Locale locale = const Locale('en'),
 }) async {
   final container = createContainer(overrides: [
     tradeRoleProvider.overrideWith((ref) => {orderId: isBuyer}),
     tradeStatusProvider(orderId).overrideWith((ref) => Stream.value(status)),
     orderBookProvider.overrideWith((ref) => Stream.value(const [])),
+    tradeRatingProvider(orderId).overrideWith((ref) async => rating),
   ]);
 
   await tester.pumpWidget(
@@ -60,10 +65,31 @@ Future<void> _pumpTradeDetail(
   await tester.pump();
 }
 
+/// Builds the rating the Rust store would hand back for a trade.
+///
+/// [isMine] is the field under test: `true` is the local user rating their
+/// counterpart, `false` the counterpart rating them.
+RatingInfo _rating({required bool isMine, int score = 5}) => RatingInfo(
+      tradeId: 'trade',
+      score: score,
+      isMine: isMine,
+      createdAt: intToPlatformInt64(1000),
+    );
+
 /// Matches an outlined secondary-row button by its visible label text.
 Finder _outlinedButtonWithText(String label) => find.ancestor(
       of: find.text(label),
       matching: find.byType(OutlinedButton),
+    );
+
+/// Matches the primary CTA by its visible label text.
+///
+/// The label alone is ambiguous: the timeline repeats it as the step name.
+/// Matched by predicate, not `byType`: `FilledButton.icon` builds a private
+/// subclass, which `find.byType(FilledButton)` does not accept.
+Finder _filledButtonWithText(String label) => find.ancestor(
+      of: find.text(label),
+      matching: find.byWidgetPredicate((widget) => widget is FilledButton),
     );
 
 /// Matches any `PopupMenuButton`, regardless of its generic type argument.
@@ -354,6 +380,59 @@ void main() {
       // Flush the button's own 4s error cooldown timer so it does not
       // outlive this test.
       await tester.pump(const Duration(seconds: 4));
+    });
+  });
+
+  /// #327: the daemon never reports a "rated" order status — a settled trade
+  /// stays settled once the rating is sent — so the screen resolves the rate
+  /// prompt by overlaying the locally held rating.
+  group('TradeDetailScreen rated state', () {
+    testWidgets('settled + not rated yet: the rate prompt is shown',
+        (tester) async {
+      await _pumpTradeDetail(
+        tester,
+        orderId: 'order-rate-1',
+        isBuyer: false,
+        status: OrderStatus.settledHoldInvoice,
+        rating: null,
+      );
+
+      expect(find.text('Rate'), findsOneWidget);
+      expect(_filledButtonWithText('Rate your counterpart'), findsOneWidget);
+      expect(find.text('Rated'), findsNothing);
+    });
+
+    testWidgets('settled + rated by me: the prompt is replaced by Close',
+        (tester) async {
+      await _pumpTradeDetail(
+        tester,
+        orderId: 'order-rate-2',
+        isBuyer: true,
+        status: OrderStatus.success,
+        rating: _rating(isMine: true),
+      );
+
+      expect(find.text('Rated'), findsOneWidget);
+      expect(find.text('Thank you for your rating!'), findsOneWidget);
+      expect(_filledButtonWithText('Rate your counterpart'), findsNothing);
+      expect(_outlinedButtonWithText('CLOSE'), findsOneWidget);
+    });
+
+    /// The store falls back to the counterpart's rating when the local user
+    /// has not submitted one, so a rating alone must not resolve the prompt —
+    /// being rated is not the same as having rated.
+    testWidgets('settled + rated by the counterpart only: prompt stays',
+        (tester) async {
+      await _pumpTradeDetail(
+        tester,
+        orderId: 'order-rate-3',
+        isBuyer: false,
+        status: OrderStatus.settledHoldInvoice,
+        rating: _rating(isMine: false),
+      );
+
+      expect(_filledButtonWithText('Rate your counterpart'), findsOneWidget);
+      expect(find.text('Rated'), findsNothing);
     });
   });
 

--- a/test/features/trades/trade_detail_screen_test.dart
+++ b/test/features/trades/trade_detail_screen_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -28,13 +30,18 @@ Future<void> _pumpTradeDetail(
   required bool isBuyer,
   required OrderStatus status,
   RatingInfo? rating,
+  bool ratingUnresolved = false,
   Locale locale = const Locale('en'),
 }) async {
   final container = createContainer(overrides: [
     tradeRoleProvider.overrideWith((ref) => {orderId: isBuyer}),
     tradeStatusProvider(orderId).overrideWith((ref) => Stream.value(status)),
     orderBookProvider.overrideWith((ref) => Stream.value(const [])),
-    tradeRatingProvider(orderId).overrideWith((ref) async => rating),
+    // A pending Completer future keeps the rating lookup in its first
+    // loading state, pinning the no-CTA-flash guard.
+    tradeRatingProvider(orderId).overrideWith((ref) => ratingUnresolved
+        ? Completer<RatingInfo?>().future
+        : Future.value(rating)),
   ]);
 
   await tester.pumpWidget(
@@ -432,6 +439,23 @@ void main() {
       );
 
       expect(_filledButtonWithText('Rate your counterpart'), findsOneWidget);
+      expect(find.text('Rated'), findsNothing);
+    });
+
+    /// The screen holds `loading` while the first rating lookup is in
+    /// flight, for the same reason it does while the order status is
+    /// unresolved: never flash a CTA that may change on the next frame.
+    testWidgets('settled + rating lookup unresolved: neither CTA is shown',
+        (tester) async {
+      await _pumpTradeDetail(
+        tester,
+        orderId: 'order-rate-4',
+        isBuyer: false,
+        status: OrderStatus.settledHoldInvoice,
+        ratingUnresolved: true,
+      );
+
+      expect(_filledButtonWithText('Rate your counterpart'), findsNothing);
       expect(find.text('Rated'), findsNothing);
     });
   });


### PR DESCRIPTION
`TradeStatus.rated` had a label, a headline, an instruction, a timeline step and its own CTA branch, but nothing could ever produce it: `_mapOrderStatus` buckets `settledHoldInvoice` / `success` / `completedByAdmin` / `settledByAdmin` as `pendingRating` unconditionally, so the rate prompt persisted after a successful rating. The bridge methods that hold the answer (`getRatingForTrade`) were exposed and unused — they appeared only in the generated `lib/src/rust/api/reputation.dart`, with zero call sites in feature code.

## What changed

- `lib/features/rate/providers/rating_providers.dart` (new)
  - `tradeRatingProvider` — the rating the Rust store holds for a trade.
  - `ratedByMeProvider` — whether the local user rated their counterpart.
- `trade_detail_screen.dart` — overlays that predicate on the mapped order status: `pendingRating` + rated-by-me resolves to `rated`.
- `rate_counterpart_screen.dart` — invalidates `tradeRatingProvider` after a  successful `submitRating`, so the screen underneath resolves on pop instead  of on the next rebuild.

No Rust changes, no bridge surface change, no new l10n keys — every string and widget the `rated` state needs already existed.

## Why `isMine` matters

`RatingStore::get` falls back to the counterpart's rating when the local user has not submitted one, so a non-null `RatingInfo` does not mean "I rated" — it can mean "they rated me". Only `is_mine` resolves the prompt. That is why the predicate lives in its own provider and has a dedicated test.

## Tests

Three cases in `test/features/trades/trade_detail_screen_test.dart`, driven through the real provider chain:

- settled, no rating → prompt stays
- settled, rated by me → `Rated` + `CLOSE`, prompt gone
- settled, rated by the counterpart only → prompt stays

`flutter analyze` clean; `flutter test` 246 passing.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trade details now indicate when you have already rated a settled trade.
  * Rating status distinguishes between ratings you submitted and ratings received from the other party.
  * The rating prompt is replaced with a close action after you submit your rating.

* **Bug Fixes**
  * Trade details now refresh rating status immediately after a rating is submitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->