### PR TITLE
fix(#259): serialize daemon message dispatch and take persistence per order id

### DIFF
--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -830,6 +830,16 @@ pub async fn take_order(
         peer_days: None,
     };
 
+    // The other side of the race guarded in `dispatch_mostro_message`: this
+    // block is the "retake is accepted and persists its state" step. Taking the
+    // same per-order lock keeps it from landing between a daemon handler's
+    // check and its write, and keeps that handler from landing between ours
+    // (#259).
+    //
+    // Acquired here, *after* the daemon reply above, and never around the wait
+    // itself: that reply is delivered by `dispatch_mostro_message`, which takes
+    // this very lock — holding it while waiting would deadlock the take.
+    let _order_guard = lock_order(&order_id).await;
     store_trade_key_index(&order_id, trade_index).await;
     if status.is_some() || amount_sats.is_some() {
         // Keep the public order book in sync with the reply so the order

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -4660,6 +4660,69 @@ mod tests {
         assert!(map.contains_key(&live));
     }
 
+    /// The #259 race, driven through the real dispatcher: a `Canceled` for a
+    /// generation that is being replaced must not land in the middle of the
+    /// retake persisting its own state.
+    ///
+    /// The retake side is represented by the lock `take_order` holds around its
+    /// persistence block, because `take_order` itself needs a relay pool and a
+    /// live daemon. The dispatcher is the code under test and runs unmodified,
+    /// against a real `UnwrappedMessage`.
+    ///
+    /// The assertion is on the *order* of the two effects rather than on a
+    /// timeout: unserialized, the dispatcher reaches `emit_trade_update` during
+    /// the sleep below and its Canceled is observed before the retake's write.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_cancel_cannot_land_inside_a_concurrent_retake() {
+        use crate::api::types::OrderStatus;
+        use crate::rt::time::{sleep, Duration};
+        use mostro_core::message::{Action, Message};
+
+        let order_uuid = uuid::Uuid::new_v4();
+        let order_id = order_uuid.to_string();
+        // Pending, so the terminal-status gate lets the Canceled through and
+        // the arm runs its full sequence.
+        order_book().upsert_order(dummy_order_info(&order_id)).await;
+
+        let mut rx = trade_updates_tx().subscribe();
+
+        let sender =
+            nostr_sdk::PublicKey::from_hex(&active_mostro_pubkey()).expect("valid mostro pubkey");
+        let unwrapped = mostro_core::nip59::UnwrappedMessage {
+            message: Message::new_order(Some(order_uuid), None, None, Action::Canceled, None),
+            signature: None,
+            sender,
+            identity: sender,
+            created_at: nostr_sdk::Timestamp::from(0u64),
+        };
+
+        // The retake enters its persistence block...
+        let retake = lock_order(&order_id).await;
+
+        // ...and the Canceled for the previous generation arrives while it runs.
+        let dispatching = tokio::spawn(async move {
+            dispatch_mostro_message(unwrapped, "test-cancel-retake", "ff00ff02", 1).await;
+        });
+
+        // Give the dispatcher every chance to run to completion.
+        sleep(Duration::from_millis(100)).await;
+
+        // The retake completes its own sequence and releases.
+        emit_trade_update(&order_id, OrderStatus::Active);
+        drop(retake);
+        dispatching.await.expect("dispatch joined");
+
+        // Effects for this order, in order: the retake's write, then the
+        // Canceled. Reversed is exactly the corruption #259 is about.
+        let mut seen = Vec::new();
+        while let Ok(update) = rx.try_recv() {
+            if update.order_id == order_id {
+                seen.push(update.status);
+            }
+        }
+        assert_eq!(seen, vec![OrderStatus::Active, OrderStatus::Canceled]);
+    }
+
 }
 
 #[cfg(test)]

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -65,6 +65,18 @@ async fn store_trade_key_index(order_id: &str, index: u32) {
 /// Callers must treat `None` as an error rather than silently using index 0,
 /// which would cause signature verification failures on the daemon side.
 async fn get_trade_key_index(order_id: &str) -> Option<u32> {
+    let found = lookup_trade_key_index(order_id).await;
+    if found.is_none() {
+        log::warn!("[orders] trade key not found for order={order_id}");
+    }
+    found
+}
+
+/// `get_trade_key_index` without the not-found warning, for callers where a
+/// missing binding is an expected state rather than an error (the dispatch
+/// generation gate: a create's confirmation arrives before any binding
+/// exists for the daemon id).
+async fn lookup_trade_key_index(order_id: &str) -> Option<u32> {
     // Fast path: in-memory cache.
     if let Some(idx) = trade_key_map()
         .read()
@@ -86,7 +98,6 @@ async fn get_trade_key_index(order_id: &str) -> Option<u32> {
             Err(e) => log::warn!("[orders] DB trade key lookup failed for order={order_id}: {e}"),
         }
     }
-    log::warn!("[orders] trade key not found for order={order_id}");
     None
 }
 
@@ -1397,6 +1408,38 @@ async fn dispatch_mostro_message(
         Some(order_id) => Some(lock_order(&order_id.to_string()).await),
         None => None,
     };
+
+    // Generation gate, read UNDER the lock so it cannot interleave with a
+    // retake's rebind: a message addressed to a trade key OLDER than the one
+    // currently bound to this order belongs to a superseded attempt — e.g.
+    // the trailing Canceled of a take that was replaced — and its writes are
+    // stale by definition, lock or no lock. Strictly-older only: a retake's
+    // first reply arrives on the NEW key while the binding still holds the
+    // old index (`take_order` rebinds after this very reply resolves its
+    // waiter), and the identity counter only grows, so a later attempt
+    // always carries a higher index. No binding fails open — a create's
+    // confirmation precedes any binding for the daemon id, and the nonce
+    // gates below own correlation. BondSlashed is exempt: it never writes
+    // order state, and a trailing slash notice addressed to the slashed
+    // (superseded) generation is by-design delivery (#197).
+    if kind.action != Action::BondSlashed {
+        if let Some(order_id) = &kind.id {
+            let oid = order_id.to_string();
+            if let Some(bound) = lookup_trade_key_index(&oid).await {
+                if trade_index < bound {
+                    crate::api::logging::blog_info("daemon-msg", format!(
+                        "drop {:?} order={}: addressed to superseded trade key \
+                         (idx {} < bound {})",
+                        kind.action,
+                        crate::api::logging::short_id(&oid),
+                        trade_index,
+                        bound,
+                    ));
+                    return;
+                }
+            }
+        }
+    }
 
     // Reconcile local UUID → daemon UUID if needed.  Daemon actions
     // arrive with the daemon's order ID, but if the create's acknowledgement
@@ -4721,6 +4764,89 @@ mod tests {
             }
         }
         assert_eq!(seen, vec![OrderStatus::Active, OrderStatus::Canceled]);
+    }
+
+    /// Builds the `UnwrappedMessage` for a daemon `Canceled` of `order_uuid`,
+    /// signed-by-sender semantics included, for driving the real dispatcher.
+    fn canceled_message(order_uuid: uuid::Uuid) -> mostro_core::nip59::UnwrappedMessage {
+        use mostro_core::message::{Action, Message};
+        let sender =
+            nostr_sdk::PublicKey::from_hex(&active_mostro_pubkey()).expect("valid mostro pubkey");
+        mostro_core::nip59::UnwrappedMessage {
+            message: Message::new_order(Some(order_uuid), None, None, Action::Canceled, None),
+            signature: None,
+            sender,
+            identity: sender,
+            created_at: nostr_sdk::Timestamp::from(0u64),
+        }
+    }
+
+    /// A message addressed to a superseded trade-key generation is dropped
+    /// whole: after a retake rebinds the order to a newer key, the trailing
+    /// `Canceled` of the replaced attempt arrives on the OLD key and must not
+    /// touch the retaken trade — even with no concurrent handler to collide
+    /// with (the case the lock alone cannot catch).
+    #[tokio::test]
+    async fn a_late_cancel_for_a_superseded_generation_is_dropped() {
+        use crate::api::types::OrderStatus;
+
+        let order_uuid = uuid::Uuid::new_v4();
+        let order_id = order_uuid.to_string();
+        // The retaken trade: bound to generation 7, active, not terminal —
+        // so a drop is attributable to the generation gate alone.
+        let mut info = dummy_order_info(&order_id);
+        info.status = OrderStatus::Active;
+        order_book().upsert_order(info).await;
+        store_trade_key_index(&order_id, 7).await;
+
+        let mut rx = trade_updates_tx().subscribe();
+
+        // The replaced attempt's Canceled, addressed to generation 3.
+        dispatch_mostro_message(canceled_message(order_uuid), "test-gen-stale", "ff00ff03", 3)
+            .await;
+
+        let status = order_book()
+            .get_order(&order_id)
+            .await
+            .expect("order still cached")
+            .status;
+        assert_eq!(status, OrderStatus::Active);
+
+        let mut leaked = false;
+        while let Ok(update) = rx.try_recv() {
+            if update.order_id == order_id {
+                leaked = true;
+            }
+        }
+        assert!(!leaked, "superseded-generation Canceled must emit nothing");
+    }
+
+    /// Strictly-older only: a message on a key NEWER than the bound one must
+    /// pass. That is a retake's first reply racing its own rebind — dropping
+    /// it would time out every legitimate retake.
+    #[tokio::test]
+    async fn a_message_for_a_newer_generation_passes_the_gate() {
+        use crate::api::types::OrderStatus;
+
+        let order_uuid = uuid::Uuid::new_v4();
+        let order_id = order_uuid.to_string();
+        // Pending: the stale binding of the previous attempt (generation 7)
+        // is still in place; the new attempt's messages arrive on 9.
+        order_book().upsert_order(dummy_order_info(&order_id)).await;
+        store_trade_key_index(&order_id, 7).await;
+
+        let mut rx = trade_updates_tx().subscribe();
+
+        dispatch_mostro_message(canceled_message(order_uuid), "test-gen-newer", "ff00ff04", 9)
+            .await;
+
+        let mut seen = Vec::new();
+        while let Ok(update) = rx.try_recv() {
+            if update.order_id == order_id {
+                seen.push(update.status);
+            }
+        }
+        assert_eq!(seen, vec![OrderStatus::Canceled]);
     }
 
 }

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -100,6 +100,56 @@ pub(crate) async fn publish_event(event_json: &str) -> Result<()> {
     publish_event_json(event_json).await
 }
 
+// ── Per-order dispatch serialization ─────────────────────────────────────────
+
+/// One mutex per `order_id`, guarding the validate-then-mutate sequences that
+/// daemon-message dispatch and `take_order` run over the order book, the trade
+/// row and the session.
+///
+/// Those sequences check first (terminal-status gate, local-status lookup) and
+/// mutate several `await`s later. Without serialization a delivery that passed
+/// the check can be overtaken by a retake of the same order id while it is
+/// suspended: the retake persists its own book / DB / session state, then the
+/// suspended handler resumes and writes the previous generation's outcome over
+/// it (#259).
+///
+/// The registry is a *synchronous* mutex holding `Arc`s of asynchronous ones,
+/// and is never held across an `await`. What callers hold across awaits is the
+/// per-order guard, which is a `tokio::sync::Mutex` for exactly that reason.
+static ORDER_LOCKS: OnceLock<std::sync::Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>> =
+    OnceLock::new();
+
+fn order_locks() -> &'static std::sync::Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>> {
+    ORDER_LOCKS.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
+}
+
+/// Acquire the per-order lock for `order_id`, waiting for any in-flight
+/// handler of the same order to finish.
+///
+/// Entries the registry is the last owner of are dropped while the map is
+/// held, so the map tracks orders with live work rather than every order ever
+/// dispatched. A poisoned registry falls back to a private lock: losing
+/// serialization for one message beats panicking the dispatch task.
+///
+/// Callers must not hold this guard while waiting on a daemon reply — the
+/// reply is delivered by `dispatch_mostro_message`, which takes the same lock.
+async fn lock_order(order_id: &str) -> tokio::sync::OwnedMutexGuard<()> {
+    let lock = {
+        let Ok(mut map) = order_locks().lock() else {
+            log::warn!(
+                "[orders] order-lock registry poisoned — order={order_id} runs unserialized"
+            );
+            return Arc::new(tokio::sync::Mutex::new(())).lock_owned().await;
+        };
+        map.retain(|_, lock| Arc::strong_count(lock) > 1);
+        Arc::clone(
+            map.entry(order_id.to_string())
+                .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(()))),
+        )
+    };
+    lock.lock_owned().await
+}
+
 /// Filter parameters for the order list.
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct OrderFilters {
@@ -1322,6 +1372,21 @@ async fn dispatch_mostro_message(
         "action={:?} order_id={:?} trade_index={:?} trade_pubkey={} payload={}",
         kind.action, kind.id, kind.trade_index, &trade_pubkey_hex[..8], payload_desc
     ));
+
+    // Everything below is serialized against other handlers of this order id:
+    // the reconcile block, the waiter interception and the per-action arms all
+    // check local state first and mutate it several `await`s later, so without
+    // the guard a retake of the same order can be accepted in between and have
+    // the suspended handler write the previous generation's outcome over its
+    // book entry, trade row and session (#259).
+    //
+    // Held until this function returns, and taken here rather than at the top
+    // because the order id only exists once the message kind is parsed.
+    // Messages with no order id own no order state, so they take no lock.
+    let _order_guard = match &kind.id {
+        Some(order_id) => Some(lock_order(&order_id.to_string()).await),
+        None => None,
+    };
 
     // Reconcile local UUID → daemon UUID if needed.  Daemon actions
     // arrive with the daemon's order ID, but if the create's acknowledgement
@@ -4519,6 +4584,70 @@ mod tests {
         )
         .await;
         // If we reach here without panicking the test passes.
+    }
+
+    // ── #259 per-order dispatch serialization ─────────────────────────────────
+
+    /// Handlers of the same order never overlap, so a validate-then-mutate
+    /// sequence cannot be interleaved by another handler of that order id.
+    #[tokio::test]
+    async fn handlers_of_the_same_order_run_one_at_a_time() {
+        use std::sync::atomic::AtomicUsize;
+
+        let order_id = uuid::Uuid::new_v4().to_string();
+        let inside = Arc::new(AtomicUsize::new(0));
+        let overlaps = Arc::new(AtomicUsize::new(0));
+
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let order_id = order_id.clone();
+            let inside = Arc::clone(&inside);
+            let overlaps = Arc::clone(&overlaps);
+            handles.push(tokio::spawn(async move {
+                let _guard = lock_order(&order_id).await;
+                if inside.fetch_add(1, Ordering::SeqCst) != 0 {
+                    overlaps.fetch_add(1, Ordering::SeqCst);
+                }
+                // Yield while holding the guard: this is the suspension point
+                // a competing handler used to slip through.
+                tokio::task::yield_now().await;
+                inside.fetch_sub(1, Ordering::SeqCst);
+            }));
+        }
+        for handle in handles {
+            handle.await.expect("task joined");
+        }
+
+        assert_eq!(overlaps.load(Ordering::SeqCst), 0);
+    }
+
+    /// Serialization is per order, not global: one stalled handler must not
+    /// stop every other trade. This deadlocks if the lock is ever made global.
+    #[tokio::test]
+    async fn distinct_orders_do_not_block_each_other() {
+        let first = uuid::Uuid::new_v4().to_string();
+        let second = uuid::Uuid::new_v4().to_string();
+
+        let held = lock_order(&first).await;
+        let _other = lock_order(&second).await;
+        drop(held);
+    }
+
+    /// The registry tracks live work, not every order ever dispatched: entries
+    /// no handler holds any more are dropped on the next acquisition.
+    #[tokio::test]
+    async fn the_registry_drops_locks_no_handler_holds() {
+        let stale: Vec<String> = (0..16).map(|_| uuid::Uuid::new_v4().to_string()).collect();
+        for order_id in &stale {
+            drop(lock_order(order_id).await);
+        }
+
+        let live = uuid::Uuid::new_v4().to_string();
+        let _guard = lock_order(&live).await;
+
+        let map = order_locks().lock().expect("registry");
+        assert!(stale.iter().all(|order_id| !map.contains_key(order_id)));
+        assert!(map.contains_key(&live));
     }
 
 }

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -21,7 +21,7 @@ use crate::mostro::pending::{
     pending_local_uuid_for, pending_requests, purge_pending_request, remove_pending_request,
     take_matching_add_invoice, take_matching_request, take_matching_restore,
     take_matching_take, take_pending_create_by_content_key, DaemonReply, PendingRequest,
-    PendingRequestKind,
+    PendingRequestKind, Wake,
 };
 use crate::nostr::order_events::parse_order_event;
 
@@ -498,7 +498,7 @@ pub async fn create_order(params: NewOrderParams) -> Result<OrderInfo> {
     // record carries everything the dispatcher needs to consume the daemon's
     // reply: the waiter channel, and the correlation/bridging state that must
     // only ever be touched by a reply echoing this attempt's request_id.
-    let (conf_tx, conf_rx) = tokio::sync::oneshot::channel::<DaemonReply>();
+    let (conf_tx, conf_rx) = tokio::sync::oneshot::channel::<Wake>();
     if let Ok(mut map) = pending_requests().lock() {
         map.insert(
             trade_pk_hex.clone(),
@@ -553,13 +553,13 @@ pub async fn create_order(params: NewOrderParams) -> Result<OrderInfo> {
     // Resolve the daemon's verdict. The order only exists once the daemon
     // confirms it; a timeout means "no response", not an optimistic success.
     let daemon_id = match confirmation {
-        Ok(Ok(DaemonReply::Confirmed { daemon_id })) => {
+        Ok(Ok(Wake { reply: DaemonReply::Confirmed { daemon_id }, .. })) => {
             crate::api::logging::blog_info("orders", format!(
                 "create_order confirmed by daemon: {daemon_id}"
             ));
             daemon_id
         }
-        Ok(Ok(DaemonReply::Rejected { reason, message })) => {
+        Ok(Ok(Wake { reply: DaemonReply::Rejected { reason, message }, .. })) => {
             crate::api::logging::blog_warn("orders", format!(
                 "create_order rejected: {reason} — {message}"
             ));
@@ -732,7 +732,7 @@ pub async fn take_order(
     // Register the pending record BEFORE subscribing/publishing (same
     // ordering as create_order) so the reply cannot race the bookkeeping.
     let trade_pk_hex = sender_keys.public_key().to_hex();
-    let (conf_tx, conf_rx) = tokio::sync::oneshot::channel::<DaemonReply>();
+    let (conf_tx, conf_rx) = tokio::sync::oneshot::channel::<Wake>();
     if let Ok(mut map) = pending_requests().lock() {
         map.insert(
             trade_pk_hex.clone(),
@@ -772,29 +772,33 @@ pub async fn take_order(
         detach_request_waiter(&trade_pk_hex, request_id);
     }
 
-    let (status, amount_sats, hold_invoice) = match reply {
-        Ok(Ok(DaemonReply::TakeAccepted {
-            action,
-            status,
-            amount_sats,
-            hold_invoice,
+    let (status, amount_sats, hold_invoice, handed_guard) = match reply {
+        Ok(Ok(Wake {
+            reply:
+                DaemonReply::TakeAccepted {
+                    action,
+                    status,
+                    amount_sats,
+                    hold_invoice,
+                },
+            order_guard,
         })) => {
             crate::api::logging::blog_info("orders", format!(
                 "take_order confirmed by daemon: order={order_id} reply={action:?}"
             ));
-            (status, amount_sats, hold_invoice)
+            (status, amount_sats, hold_invoice, order_guard)
         }
-        Ok(Ok(DaemonReply::Rejected { reason, message })) => {
+        Ok(Ok(Wake { reply: DaemonReply::Rejected { reason, message }, .. })) => {
             crate::api::logging::blog_warn("orders", format!(
                 "take_order rejected: {reason} — {message}"
             ));
             return Err(anyhow::anyhow!("{message}"));
         }
-        Ok(Ok(DaemonReply::Confirmed { .. })) => {
+        Ok(Ok(Wake { reply: DaemonReply::Confirmed { .. }, .. })) => {
             // Only the create flow sends Confirmed; a take record can never
             // receive it. Treat defensively as an acceptance without data.
             log::warn!("[orders] take_order received a create-style confirmation");
-            (None, None, None)
+            (None, None, None, None)
         }
         _ => {
             // No daemon response within the timeout. Do not persist or show
@@ -847,10 +851,18 @@ pub async fn take_order(
     // check and its write, and keeps that handler from landing between ours
     // (#259).
     //
-    // Acquired here, *after* the daemon reply above, and never around the wait
-    // itself: that reply is delivered by `dispatch_mostro_message`, which takes
-    // this very lock — holding it while waiting would deadlock the take.
-    let _order_guard = lock_order(&order_id).await;
+    // Normally the guard arrives WITH the reply: the dispatcher that consumed
+    // it hands its own guard through the waiter channel, so no other handler
+    // of this order can slot in between the reply and this persistence (a
+    // queued one would otherwise win the FIFO mutex over this woken task).
+    // Acquired here only as the fallback for a reply that carried no guard
+    // (no order id on the reply), and never around the wait itself: the reply
+    // is delivered by `dispatch_mostro_message`, which takes this very lock —
+    // holding it while waiting would deadlock the take.
+    let _order_guard = match handed_guard {
+        Some(guard) => guard,
+        None => lock_order(&order_id).await,
+    };
     store_trade_key_index(&order_id, trade_index).await;
     if status.is_some() || amount_sats.is_some() {
         // Keep the public order book in sync with the reply so the order
@@ -946,7 +958,7 @@ pub async fn send_invoice(
     // the take (and the global feed covers cold starts), so no new
     // subscription is needed here.
     let trade_pk_hex = sender_keys.public_key().to_hex();
-    let (conf_tx, conf_rx) = tokio::sync::oneshot::channel::<DaemonReply>();
+    let (conf_tx, conf_rx) = tokio::sync::oneshot::channel::<Wake>();
     if let Ok(mut map) = pending_requests().lock() {
         map.insert(
             trade_pk_hex.clone(),
@@ -987,7 +999,7 @@ pub async fn send_invoice(
     }
 
     match reply {
-        Ok(Ok(DaemonReply::Rejected { reason, message })) => {
+        Ok(Ok(Wake { reply: DaemonReply::Rejected { reason, message }, .. })) => {
             crate::api::logging::blog_warn("orders", format!(
                 "add_invoice rejected: {reason} — {message}"
             ));
@@ -1404,7 +1416,7 @@ async fn dispatch_mostro_message(
     // Held until this function returns, and taken here rather than at the top
     // because the order id only exists once the message kind is parsed.
     // Messages with no order id own no order state, so they take no lock.
-    let _order_guard = match &kind.id {
+    let mut order_guard = match &kind.id {
         Some(order_id) => Some(lock_order(&order_id.to_string()).await),
         None => None,
     };
@@ -1503,7 +1515,18 @@ async fn dispatch_mostro_message(
                     kind.action,
                     &trade_pubkey_hex[..8]
                 ));
-                let _ = tx.send(reply);
+                // Hand THIS dispatcher's per-order guard to the woken
+                // take_order along with the reply, so its persistence runs in
+                // the same critical section that consumed the reply. Released
+                // here, a second daemon message already queued on the mutex
+                // would beat the woken task to it (tokio's Mutex is FIFO) and
+                // run its arm against a trade row and session that do not
+                // exist yet. A failed send (the waiter timed out) returns the
+                // Wake, dropping the guard right here.
+                let _ = tx.send(crate::mostro::pending::Wake {
+                    reply,
+                    order_guard: order_guard.take(),
+                });
             } else {
                 // Genuine reply after the 10s timeout: the caller already
                 // returned NoDaemonResponse and persisted nothing, so there
@@ -1530,7 +1553,7 @@ async fn dispatch_mostro_message(
                     kind.action,
                     &trade_pubkey_hex[..8]
                 ));
-                let _ = tx.send(DaemonReply::Acknowledged);
+                let _ = tx.send(Wake::from(DaemonReply::Acknowledged));
             } else {
                 crate::api::logging::blog_info("daemon-msg", format!(
                     "{:?}: late acknowledgement for timed-out add-invoice on trade={}",
@@ -1570,9 +1593,9 @@ async fn dispatch_mostro_message(
                     if let Some(tx) = pending.tx {
                         // create_order is still waiting — the caller handles
                         // UUID adoption and persistence.
-                        let _ = tx.send(DaemonReply::Confirmed {
+                        let _ = tx.send(Wake::from(DaemonReply::Confirmed {
                             daemon_id: daemon_id.clone(),
-                        });
+                        }));
                         crate::api::logging::blog_info("daemon-msg", format!(
                             "NewOrder: notified waiting create_order daemon={daemon_id}"
                         ));
@@ -1610,7 +1633,7 @@ async fn dispatch_mostro_message(
                 Some(mostro_core::message::Payload::RestoreData(info)) => {
                     if let Some(pending) = take_matching_restore(trade_pubkey_hex) {
                         if let Some(tx) = pending.tx {
-                            let _ = tx.send(DaemonReply::Restored(info.clone()));
+                            let _ = tx.send(Wake::from(DaemonReply::Restored(info.clone())));
                             crate::api::logging::blog_info("daemon-msg", format!(
                                 "RestoreData: notified waiting restore_session ({} orders, {} disputes)",
                                 info.restore_orders.len(),
@@ -2072,7 +2095,7 @@ async fn dispatch_mostro_message(
                     crate::api::logging::blog_warn("daemon-msg", format!(
                         "CantDo: reason={reason} — notifying waiting caller"
                     ));
-                    let _ = tx.send(DaemonReply::Rejected { reason, message });
+                    let _ = tx.send(Wake::from(DaemonReply::Rejected { reason, message }));
                 } else {
                     // Genuine rejection after the 10s timeout: the caller
                     // already returned NoDaemonResponse and persisted nothing,
@@ -3594,7 +3617,7 @@ pub async fn restore_session() -> Result<mostro_core::message::RestoreSessionInf
     // Register the pending-restore record BEFORE publishing so the reply can't
     // race the map. Correlated by trade pubkey only (RestoreSession carries no
     // request_id) -> take_matching_restore.
-    let (conf_tx, conf_rx) = tokio::sync::oneshot::channel::<DaemonReply>();
+    let (conf_tx, conf_rx) = tokio::sync::oneshot::channel::<Wake>();
     // If the lock is poisoned we can't register the pending record, so the
     // reply could never be correlated — bail rather than publish an event
     // that would strand the caller for the full timeout only to report
@@ -3635,7 +3658,7 @@ pub async fn restore_session() -> Result<mostro_core::message::RestoreSessionInf
     }
 
     match confirmation {
-        Ok(Ok(DaemonReply::Restored(info))) => {
+        Ok(Ok(Wake { reply: DaemonReply::Restored(info), .. })) => {
             // #217: raise trade_key_index past every recovered trade before
             // returning, so the next derive_trade_key() can't reuse a key a
             // recovered trade already owns. Monotonic and idempotent. A persist
@@ -3647,7 +3670,7 @@ pub async fn restore_session() -> Result<mostro_core::message::RestoreSessionInf
             }
             Ok(info)
         }
-        Ok(Ok(DaemonReply::Rejected { reason, message })) => {
+        Ok(Ok(Wake { reply: DaemonReply::Rejected { reason, message }, .. })) => {
             crate::api::logging::blog_warn("orders", format!(
                 "restore_session rejected: {reason} — {message}"
             ));
@@ -3772,8 +3795,8 @@ mod tests {
         );
     }
 
-    fn insert_pending_create(key: &str, request_id: u64) -> tokio::sync::oneshot::Receiver<DaemonReply> {
-        let (tx, rx) = tokio::sync::oneshot::channel::<DaemonReply>();
+    fn insert_pending_create(key: &str, request_id: u64) -> tokio::sync::oneshot::Receiver<Wake> {
+        let (tx, rx) = tokio::sync::oneshot::channel::<Wake>();
         pending_requests().lock().unwrap().insert(
             key.to_string(),
             PendingRequest {
@@ -3796,8 +3819,8 @@ mod tests {
         }
     }
 
-    fn insert_pending_take(key: &str, request_id: u64) -> tokio::sync::oneshot::Receiver<DaemonReply> {
-        let (tx, rx) = tokio::sync::oneshot::channel::<DaemonReply>();
+    fn insert_pending_take(key: &str, request_id: u64) -> tokio::sync::oneshot::Receiver<Wake> {
+        let (tx, rx) = tokio::sync::oneshot::channel::<Wake>();
         pending_requests().lock().unwrap().insert(
             key.to_string(),
             PendingRequest {
@@ -3820,7 +3843,7 @@ mod tests {
         let order_key = "test-order-pubkey";
 
         // A pending Restore record (request_id 0, nonce-less).
-        let (rtx, _rrx) = tokio::sync::oneshot::channel::<DaemonReply>();
+        let (rtx, _rrx) = tokio::sync::oneshot::channel::<Wake>();
         pending_requests().lock().unwrap().insert(
             restore_key.to_string(),
             PendingRequest {
@@ -3863,9 +3886,9 @@ mod tests {
         // Genuine reply: record consumed exactly once, waiter still attached.
         let pending = take_matching_request(key, Some(7)).expect("must match");
         let tx = pending.tx.expect("waiter must still be attached");
-        let _ = tx.send(DaemonReply::Confirmed {
+        let _ = tx.send(Wake::from(DaemonReply::Confirmed {
             daemon_id: "d".to_string(),
-        });
+        }));
         assert!(!pending_requests().lock().unwrap().contains_key(key));
         assert!(take_matching_request(key, Some(7)).is_none());
     }
@@ -3946,7 +3969,7 @@ mod tests {
         let ai_key = "test-ai-addinvoice-pubkey";
         let _rx_t = insert_pending_take(take_key, 51);
 
-        let (tx, _rx) = tokio::sync::oneshot::channel::<DaemonReply>();
+        let (tx, _rx) = tokio::sync::oneshot::channel::<Wake>();
         pending_requests().lock().unwrap().insert(
             ai_key.to_string(),
             PendingRequest {
@@ -4847,6 +4870,90 @@ mod tests {
             }
         }
         assert_eq!(seen, vec![OrderStatus::Canceled]);
+    }
+
+    /// Whether the per-order lock for `order_id` can be acquired right now.
+    fn order_lock_is_free(order_id: &str) -> bool {
+        match order_locks().lock().unwrap().get(order_id).cloned() {
+            Some(lock) => lock.try_lock().is_ok(),
+            None => true,
+        }
+    }
+
+    /// The take reply that resolves a waiting `take_order` hands the
+    /// dispatcher's per-order guard through the waiter channel: after
+    /// `dispatch_mostro_message` returns, the lock is still held — it rides
+    /// inside the unread `Wake` — so a second daemon message queued on the
+    /// mutex cannot run before the woken take persists. Dropping the `Wake`
+    /// (as `take_order`'s persistence block eventually does) releases it.
+    #[tokio::test]
+    async fn a_take_reply_hands_the_order_lock_to_the_waiter() {
+        use mostro_core::message::{Action, Message};
+
+        let order_uuid = uuid::Uuid::new_v4();
+        let order_id = order_uuid.to_string();
+        let trade_pk = "test-handoff-take-pubkey";
+        let mut rx = insert_pending_take(trade_pk, 91);
+
+        let sender =
+            nostr_sdk::PublicKey::from_hex(&active_mostro_pubkey()).expect("valid mostro pubkey");
+        let unwrapped = mostro_core::nip59::UnwrappedMessage {
+            message: Message::new_order(
+                Some(order_uuid),
+                Some(91),
+                None,
+                Action::AddInvoice,
+                None,
+            ),
+            signature: None,
+            sender,
+            identity: sender,
+            created_at: nostr_sdk::Timestamp::from(0u64),
+        };
+        dispatch_mostro_message(unwrapped, "test-handoff-live", trade_pk, 4).await;
+
+        // Dispatch returned, but the lock traveled into the channel: held.
+        assert!(!order_lock_is_free(&order_id), "guard must ride in the Wake");
+
+        let wake = rx.try_recv().expect("reply delivered");
+        assert!(wake.order_guard.is_some(), "take reply must carry the guard");
+        drop(wake);
+        assert!(order_lock_is_free(&order_id), "dropping the Wake releases");
+    }
+
+    /// A takeover whose waiter already timed out (receiver dropped) must not
+    /// leave the handed guard stranded: the failed send returns the `Wake`,
+    /// and dropping it inside the dispatcher releases the lock.
+    #[tokio::test]
+    async fn a_dead_take_waiter_releases_the_handed_lock() {
+        use mostro_core::message::{Action, Message};
+
+        let order_uuid = uuid::Uuid::new_v4();
+        let order_id = order_uuid.to_string();
+        let trade_pk = "test-handoff-dead-pubkey";
+        drop(insert_pending_take(trade_pk, 92));
+
+        let sender =
+            nostr_sdk::PublicKey::from_hex(&active_mostro_pubkey()).expect("valid mostro pubkey");
+        let unwrapped = mostro_core::nip59::UnwrappedMessage {
+            message: Message::new_order(
+                Some(order_uuid),
+                Some(92),
+                None,
+                Action::AddInvoice,
+                None,
+            ),
+            signature: None,
+            sender,
+            identity: sender,
+            created_at: nostr_sdk::Timestamp::from(0u64),
+        };
+        dispatch_mostro_message(unwrapped, "test-handoff-dead", trade_pk, 4).await;
+
+        assert!(
+            order_lock_is_free(&order_id),
+            "a failed handoff must release the lock, not strand it"
+        );
     }
 
 }

--- a/rust/src/mostro/pending.rs
+++ b/rust/src/mostro/pending.rs
@@ -49,6 +49,32 @@ pub(crate) enum DaemonReply {
     Restored(mostro_core::message::RestoreSessionInfo),
 }
 
+/// What travels over a pending request's waiter channel: the daemon's reply,
+/// plus — for a take — the per-order lock handed from the dispatcher to the
+/// woken `take_order`.
+///
+/// The guard rides INSIDE the channel value on purpose: every path that loses
+/// the value releases the lock by dropping it — a waiter that already timed
+/// out fails the send and the returned `Wake` drops here, a reply that lands
+/// in the buffer of a receiver dropped moments later drops with it. Nothing
+/// ever parks a held guard where no destructor will reach it.
+pub(crate) struct Wake {
+    pub(crate) reply: DaemonReply,
+    /// `Some` only on the reply that resolves a take: the dispatcher's
+    /// per-order guard, so no other handler of the order can slot in between
+    /// the consumed reply and the take's persistence (#259). Every other
+    /// flow sends `None` — creates own no row yet worth guarding this way,
+    /// and an add-invoice reply is persisted by the dispatch arms themselves,
+    /// which still hold the guard.
+    pub(crate) order_guard: Option<tokio::sync::OwnedMutexGuard<()>>,
+}
+
+impl From<DaemonReply> for Wake {
+    fn from(reply: DaemonReply) -> Self {
+        Self { reply, order_guard: None }
+    }
+}
+
 /// What kind of outgoing request a pending record tracks.
 pub(crate) enum PendingRequestKind {
     Create {
@@ -92,7 +118,7 @@ pub(crate) struct PendingRequest {
     /// only this sender and leaves the rest of the record, so a genuine late
     /// reply still reconciles trade-key and id bindings instead of being
     /// indistinguishable from a stale replay.
-    pub(crate) tx: Option<tokio::sync::oneshot::Sender<DaemonReply>>,
+    pub(crate) tx: Option<tokio::sync::oneshot::Sender<Wake>>,
 }
 
 /// Maps `trade_pubkey_hex` → the pending daemon request for that trade key.
@@ -429,8 +455,8 @@ mod tests {
     fn insert_pending_create(
         key: &str,
         request_id: u64,
-    ) -> tokio::sync::oneshot::Receiver<DaemonReply> {
-        let (tx, rx) = tokio::sync::oneshot::channel::<DaemonReply>();
+    ) -> tokio::sync::oneshot::Receiver<Wake> {
+        let (tx, rx) = tokio::sync::oneshot::channel::<Wake>();
         pending_requests().lock().unwrap().insert(
             key.to_string(),
             PendingRequest {
@@ -456,8 +482,8 @@ mod tests {
     fn insert_pending_take(
         key: &str,
         request_id: u64,
-    ) -> tokio::sync::oneshot::Receiver<DaemonReply> {
-        let (tx, rx) = tokio::sync::oneshot::channel::<DaemonReply>();
+    ) -> tokio::sync::oneshot::Receiver<Wake> {
+        let (tx, rx) = tokio::sync::oneshot::channel::<Wake>();
         pending_requests().lock().unwrap().insert(
             key.to_string(),
             PendingRequest {
@@ -480,7 +506,7 @@ mod tests {
         let order_key = "test-order-pubkey";
 
         // A pending Restore record (request_id 0, nonce-less).
-        let (rtx, _rrx) = tokio::sync::oneshot::channel::<DaemonReply>();
+        let (rtx, _rrx) = tokio::sync::oneshot::channel::<Wake>();
         pending_requests().lock().unwrap().insert(
             restore_key.to_string(),
             PendingRequest {
@@ -523,9 +549,9 @@ mod tests {
         // Genuine reply: record consumed exactly once, waiter still attached.
         let pending = take_matching_request(key, Some(7)).expect("must match");
         let tx = pending.tx.expect("waiter must still be attached");
-        let _ = tx.send(DaemonReply::Confirmed {
+        let _ = tx.send(Wake::from(DaemonReply::Confirmed {
             daemon_id: "d".to_string(),
-        });
+        }));
         assert!(!pending_requests().lock().unwrap().contains_key(key));
         assert!(take_matching_request(key, Some(7)).is_none());
     }
@@ -606,7 +632,7 @@ mod tests {
         let ai_key = "test-ai-addinvoice-pubkey";
         let _rx_t = insert_pending_take(take_key, 51);
 
-        let (tx, _rx) = tokio::sync::oneshot::channel::<DaemonReply>();
+        let (tx, _rx) = tokio::sync::oneshot::channel::<Wake>();
         pending_requests().lock().unwrap().insert(
             ai_key.to_string(),
             PendingRequest {

--- a/specs/004-mostro-p2p-client/contracts/orders.md
+++ b/specs/004-mostro-p2p-client/contracts/orders.md
@@ -348,6 +348,19 @@ Invariants:
 - **The registry tracks live work, not history**: entries no handler holds
   any more are dropped on the next acquisition, so it does not grow with
   every order ever dispatched.
+- **A generation gate backs the lock**, read under it so it cannot
+  interleave with a retake's rebind: a message addressed to a trade key
+  *older* than the one currently bound to its order (`trade_keys` binding)
+  belongs to a superseded attempt and is dropped whole — the lock
+  serializes concurrent handlers, the gate rejects the late ones.
+  Strictly-older only: a retake's first reply arrives on the NEW key while
+  the binding still holds the old index (`take_order` rebinds only after
+  that reply resolves its waiter), and the identity counter only grows, so
+  newer-than-bound is always legitimate. No binding fails open (a create's
+  confirmation precedes any binding for the daemon id). `BondSlashed` is
+  exempt: it never writes order state, and a trailing slash notice
+  addressed to the slashed (superseded) generation is by-design delivery
+  (#197).
 
 ### Daemon cancellation semantics
 

--- a/specs/004-mostro-p2p-client/contracts/orders.md
+++ b/specs/004-mostro-p2p-client/contracts/orders.md
@@ -88,6 +88,8 @@ or a direct progression message. Only on a correlated reply is the trade
 created: the TradeInfo is built from the reply's real data (status,
 calculated `amount_sats`, `hold_invoice`), persisted to My Trades, the
 order book entry is synced, and the trade session/subscriptions start.
+That persistence half runs under the per-order lock (see *Per-order
+serialization*), acquired after the reply and never around the wait for it.
 On rejection or timeout **nothing is persisted** — no phantom trade.
 
 **Errors**: `OrderNotFound`, `CannotTakeOwnOrder`, `OrderAlreadyTaken`,
@@ -316,6 +318,36 @@ Every arm above that syncs a status also emits a `TradeUpdate` (see
 persistence attempt — DB failures are logged, never suppress the
 emission, and leave the row behind the book. `Canceled` included, which
 emits whether it wiped the row or kept it as history.
+
+### Per-order serialization
+
+`dispatch_mostro_message` and `take_order`'s persistence block both check
+local state and mutate the order book, the trade row and the session
+several `await`s later. Those two halves are **one operation per
+`order_id`**, held under a per-order mutex (#259).
+
+Without it, a delivery that passed its check can be overtaken by a retake
+of the same order while it is suspended: the retake persists its own
+state, then the suspended handler resumes and writes the previous
+generation's outcome over it. The `Canceled` arm is the reachable case —
+it has mutated book and DB with no generation check of its own.
+
+Invariants:
+
+- **The lock is keyed by `order_id`, never global.** One stalled handler
+  must not stop every other trade.
+- **`dispatch_mostro_message` takes it once the message kind is parsed**,
+  covering the local→daemon id reconcile, the waiter interception and
+  every per-action arm. A message carrying no order id owns no order state
+  and takes no lock.
+- **No caller may hold it while waiting for a daemon reply.** That reply is
+  delivered by `dispatch_mostro_message`, which takes the same lock, so
+  `take_order` acquires it only *after* its wait resolves — around the
+  persistence block alone. Holding it across the wait deadlocks the take
+  until its 10 s timeout.
+- **The registry tracks live work, not history**: entries no handler holds
+  any more are dropped on the next acquisition, so it does not grow with
+  every order ever dispatched.
 
 ### Daemon cancellation semantics
 

--- a/specs/004-mostro-p2p-client/contracts/orders.md
+++ b/specs/004-mostro-p2p-client/contracts/orders.md
@@ -345,6 +345,17 @@ Invariants:
   `take_order` acquires it only *after* its wait resolves — around the
   persistence block alone. Holding it across the wait deadlocks the take
   until its 10 s timeout.
+- **The take reply hands the guard off.** The dispatcher that resolves a
+  waiting `take_order` sends its own guard through the waiter channel
+  (`Wake.order_guard`), so consumed-reply → persistence is one critical
+  section: released instead, a second daemon message already queued on the
+  FIFO mutex would beat the woken task and run its arm against a trade row
+  and session that do not exist yet. The guard rides *inside* the channel
+  value, so every losing path releases it by dropping — a timed-out
+  waiter's failed send, a receiver dropped with the reply unread. Only the
+  take reply carries a guard: an add-invoice's effects are persisted by
+  the dispatch arms themselves (still holding it), and a create's gap is
+  owned by the reconcile block and the Kind 38383 fingerprint path.
 - **The registry tracks live work, not history**: entries no handler holds
   any more are dropped on the next acquisition, so it does not grow with
   every order ever dispatched.


### PR DESCRIPTION
`dispatch_mostro_message` checks local state (terminal-status gate, local-status lookup) and mutates the order book, the trade row and the session several `await`s later. Validation and mutation are not one operation, so a delivery that passed the gate can be overtaken by a retake of the same order id while suspended: the retake persists its state, the suspended handler resumes and writes the previous generation's outcome over it.

Both halves now run under a per-order mutex, keyed by `order_id` so one stalled handler cannot stop every other trade.

- `dispatch_mostro_message` takes the lock once the message kind is parsed, covering the local→daemon id reconcile, the waiter  interception and every per-action arm. Messages with no order id own no order state and take no lock.
- `take_order` takes it around its persistence block only — after the  daemon reply, never around the wait for it. That reply is delivered by  `dispatch_mostro_message`, which takes the same lock, so holding it across the wait would deadlock the take until its 10 s timeout. The  constraint is documented at `lock_order` and in the contract.
- The registry drops entries no handler holds any more, so it tracks live work rather than every order ever dispatched.

## Verification

The regression test drives the real `dispatch_mostro_message` with a `Canceled` while the lock is held on a retake's behalf, and asserts the two effects land in order. With the guard removed it fails with `[Canceled, Active]` instead of `[Active, Canceled]` — the previous generation's outcome written over the new one.

`cargo clippy --locked -- -D warnings`, `cargo test --lib` (284 pass) and `cargo check --target wasm32-unknown-unknown` are clean. No Dart changes: `./scripts/frb-generate.sh` leaves `lib/src/rust/` untouched, since everything added is private.

## Out of scope

This closes the interleaving window (steps 1-3 of the issue). A `Canceled` for a superseded generation that arrives genuinely late,
overlapping nothing, is still applied — catching that needs the generation check on `Session.trade_key_index` that #258 introduces on the session side. The two are complementary.

Closes #259

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved order processing reliability by preventing conflicting actions on the same order from running simultaneously.
  - Ensured cancellations and retakes are handled safely during concurrent activity.
  - Preserved parallel processing for unrelated orders.

- **Documentation**
  - Documented order-processing serialization, lock behavior, and cleanup guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->