### PR TITLE
docs(specs): sync and reorganize tasks.md for 004 and 005

### DIFF
--- a/specs/004-mostro-p2p-client/tasks.md
+++ b/specs/004-mostro-p2p-client/tasks.md
@@ -19,6 +19,26 @@
 - `[~]` — Partial: code exists but blocked on missing infrastructure (noted in description)
 - `[ ]` — Not started
 
+## Open work at a glance
+
+Most of what follows (T001–T145) is `[x]` — the phases read as a
+completed build log, not a live backlog. What's actually still open lives
+in three clusters of `[~]` partial tasks (code exists, but the backend or
+the UI wiring doesn't):
+
+- **IndexedDB / web storage** (Phase 1 — Setup): T010 — only messages,
+  settings and the active Mostro pubkey are implemented; orders, trades,
+  relays, identity, queued messages and trade keys return "IndexedDB not
+  yet implemented", so the web target cannot persist a trade (#233).
+- **File attachments** (Phase 10 — P2P Chat): T079, T080, T081 — Blossom
+  upload/download (T070) has no Dart caller yet.
+- **Dispute admin chat** (Phase 12 — Dispute System): T088, T090, T091,
+  T092, T093 — the Rust side (T085/T086) is ready; the screens are stubs
+  with no bridge subscription.
+
+Plus one task with no entry at all: **restore from mnemonic** — see T148
+below.
+
 ---
 
 ## Phase 1: Setup (Project Initialization)
@@ -45,12 +65,12 @@
 
 - [x] T008 Implement all shared types in `rust/src/api/types.rs`: all enums (`OrderKind`, `OrderStatus` with 15 states, `TradeRole`, `BuyerStep`, `SellerStep`, `TradeStep`, `TradeOutcome`, `MessageType`, `DisputeStatus`, `RelayStatus`, `ConnectionState`, `WalletStatus`, `ThemeMode`, `FileType`, `DownloadStatus`, `QueuedMessageStatus`, `CooperativeCancelState`) and all structs (`OrderInfo`, `TradeInfo`, `ChatMessage`, `AttachmentInfo`, `RelayInfo`, `IdentityInfo`, `NymIdentity`, `AppState`, `LogEntry`) per `contracts/types.md`. Mark `flutter_rust_bridge` annotations. Note: `PaymentFailed` is NOT a status — it is an Action notification only.
 - [x] T009 Implement storage trait in `rust/src/db/mod.rs` defining async CRUD interface for all entities (Identity, Order, Trade, Message, Relay, Dispute, Settings, MessageQueue, NwcWallet, FileAttachment, Rating). Implement SQLite backend in `rust/src/db/sqlite.rs` using `sqlx` with full schema migrations for all 11 entities per `data-model.md`.
-- [x] T010 [P] Implement IndexedDB storage backend in `rust/src/db/indexeddb.rs` using `indexed_db_futures`, feature-gated with `#[cfg(target_arch = "wasm32")]`. Must implement the same trait as `sqlite.rs` and support all 11 entities.
+- [~] T010 [P] Implement IndexedDB storage backend in `rust/src/db/indexeddb.rs` using `indexed_db_futures`, feature-gated with `#[cfg(target_arch = "wasm32")]`. Must implement the same trait as `sqlite.rs` and support all 11 entities. **Partial**: only messages (save/list/mark-read/exists), settings and the active Mostro pubkey are backed by real object stores; orders, trades, relays, identity, queued messages and trade keys still return `IndexedDB not yet implemented` — see #233.
 
 > **Transport v2 note**: T011/T012/T039/T040/T049/T066/T071/T085/T137 below describe the original NIP-59 gift-wrap (Kind 1059) transport implemented in 004. Messages to the Mostro daemon were later migrated to transport v2 (NIP-44, signed Kind 14), and peer/dispute chat followed in #246, moving to the Kind 14 chat envelope. Kind 1059 is gone from both directions, so these task descriptions are a record of what 004 built, not of what ships. These task records are kept as-is for history.
 
-- [x] T011 [P] Implement NIP-59 Gift Wrap encode/decode in `rust/src/nostr/gift_wrap.rs` using `nostr-sdk`: create unsigned rumor event, encrypt into Seal (Kind 13, NIP-44), wrap into Gift Wrap (Kind 1059, ephemeral key). Export `wrap_message(content, recipient_pubkey, sender_key)` and `unwrap_message(gift_wrap_event, recipient_key)`.
-- [x] T012 [P] Implement relay pool with Kind 1059 + Kind 38383 subscriptions in `rust/src/nostr/relay_pool.rs` using `nostr-sdk`. Multi-relay connection manager: connect, disconnect, add/remove relays, subscribe to order events (Kind 38383) and gift-wrap DMs (Kind 1059 targeting user's trade keys), emit events via channels.
+- [x] T011 [P] Implement NIP-59 Gift Wrap encode/decode in `rust/src/nostr/gift_wrap.rs` using `nostr-sdk`: create unsigned rumor event, encrypt into Seal (Kind 13, NIP-44), wrap into Gift Wrap (Kind 1059, ephemeral key). Export `wrap_message(content, recipient_pubkey, sender_key)` and `unwrap_message(gift_wrap_event, recipient_key)`. _(Superseded — see the Transport v2 note above.)_
+- [x] T012 [P] Implement relay pool with Kind 1059 + Kind 38383 subscriptions in `rust/src/nostr/relay_pool.rs` using `nostr-sdk`. Multi-relay connection manager: connect, disconnect, add/remove relays, subscribe to order events (Kind 38383) and gift-wrap DMs (Kind 1059 targeting user's trade keys), emit events via channels. _(Superseded — see the Transport v2 note above.)_
 - [x] T013 [P] Implement offline message queue in `rust/src/queue/outbox.rs`: persist queued Nostr events to DB (entity: `MessageQueue`), retry on reconnection up to 10 attempts, prune `Sent` items after 24 hours, expose `queue_message(event_json, target_relays)` and `flush_queue()`.
 - [x] T014 Implement app design system tokens in `lib/core/app_theme.dart`: colors (`mostroGreen #8CC63F`, `purpleButton #7856AF`, `sellRed #FF8A8A`, `errorRed #EF6A6A`, dark background, card background, text primary/secondary, input background), typography scale, spacing constants, component styles for buttons (filled/outline), cards, chips/badges. Dark and light theme variants. Matches `DESIGN_SYSTEM.md` exactly.
 - [x] T015 [P] Implement GoRouter route definitions scaffold in `lib/core/app_routes.dart` with all 23 routes: `/walkthrough`, `/`, `/add_order`, `/take_sell/:orderId`, `/take_buy/:orderId`, `/pay_invoice/:orderId`, `/add_invoice/:orderId`, `/trade_detail/:orderId`, `/order_book`, `/chat_list`, `/chat_room/:orderId`, `/key_management`, `/settings`, `/about`, `/notifications`, `/relays`, `/wallet_settings`, `/connect_wallet`, `/rate_user/:orderId`, `/dispute_details/:disputeId`, `/notification_settings`, `/logs`, `/dispute_chat/:disputeId`. All routes are stubs returning placeholder `Scaffold` at this stage; redirect logic added in US1 phase.
@@ -457,6 +477,26 @@ configuration.
 - [x] T147 Add `_BackupConfirmRow` stateful widget inside `lib/features/account/screens/account_screen.dart`: checkbox + label "I have written down my words and backed them up securely". Once checked, calls `onConfirm` callback and becomes disabled (checked state is final). Uses `AppSpacing.md` top padding, `InkWell` for tap area. Add l10n key `backupConfirmCheckbox` = "I have written down my words and backed them up securely" to all 5 ARB files (`app_en.arb`, `app_es.arb`, `app_it.arb`, `app_fr.arb`, `app_de.arb`) and update `_BackupConfirmRow` to use `AppLocalizations.of(context).backupConfirmCheckbox` instead of a hard-coded string.
 
 **Checkpoint**: Acceptance test from plan.md Phase 20 checklist: (a) fresh install → Show → all 12 `•••` before tap; (b) tap Show → 12 words visible + checkbox visible (not confirmed yet); (c) close and reopen Account → red dot still on bell; (d) tick checkbox → red dot gone + backup reminder gone from Notifications; (e) Generate New User → red dot reappears.
+
+---
+
+## Phase 21: Restore Sessions & Trades from Mnemonic
+
+**Purpose**: Track the recovery flow contract that already exists in
+`contracts/identity.md` (`import_from_mnemonic(recover: true)`) but has no
+implementation task in this file. Currently, reinstalling the app with an
+existing mnemonic loses all trades, sessions, and disputes — see epic #142
+and its sub-issues (#216, #218, #219, #220, #221, #222) for the current,
+actively maintained breakdown of this work.
+
+- [ ] T148 Implement the recovery flow per `contracts/identity.md`
+      `import_from_mnemonic(words, recover: true)`: send `Action.restore`
+      to the Mostro daemon via NIP-44 (Kind 14), receive order/dispute IDs,
+      request details for each, sync the trade key index, and reconstruct
+      the local DB from daemon responses. Recovery only applies outside
+      privacy mode. **This task is a pointer, not a plan** — see epic #142
+      for the up-to-date task breakdown; do not duplicate work already
+      scoped there.
 
 ---
 

--- a/specs/005-transport-v2-migration/tasks.md
+++ b/specs/005-transport-v2-migration/tasks.md
@@ -13,28 +13,38 @@
 
 **Organization**: Two phases = two PRs. Phase 2 depends on Phase 1.
 
+**Status: done.** Merged in #111 and verified end-to-end on a v2 node. The
+plan below is kept as a historical record — do not use it as a map of the
+current code. It has since been superseded by further refactors: `mostro-core`
+is now `0.14.1` (past the `0.13.1` this plan targeted), `gift_wrap.rs` no
+longer exists (`wrap_mostro_message`/`unwrap_mostro_message` now live in
+`rust/src/nostr/transport.rs`), and T011's "leave gift wrap on peer/dispute
+chat untouched" no longer holds — that chat also moved off gift wrap
+entirely (kind-14 chat envelope) in #246/#254.
+
 ## Phase 1 — mostro-core bump (PR #1: `chore/mostro-core-0.13`)
 
-- [ ] T001 Set `mostro-core = "0.13.1"` in `rust/Cargo.toml`; update `Cargo.lock`.
-- [ ] T002 Fix `map_core_status` in `rust/src/api/orders.rs`: add explicit arm
+- [x] T001 Set `mostro-core = "0.13.1"` in `rust/Cargo.toml`; update `Cargo.lock`.
+- [x] T002 Fix `map_core_status` in `rust/src/api/orders.rs`: add explicit arm
       `S::WaitingTakerBond | S::WaitingMakerBond => return None` (no wildcard).
-- [ ] T003 Run `cargo build && cargo test && cargo clippy`; resolve any residual
+- [x] T003 Run `cargo build && cargo test && cargo clippy`; resolve any residual
       fallout surfaced by the compiler. **Checkpoint**: green, app still on gift wrap.
 
 ## Phase 2 — transport switch (PR #2: `feat/transport-v2`)
 
-- [ ] T004 `gift_wrap.rs::wrap_mostro_message` → `wrap_message_with(Transport::Nip44Direct,
+- [x] T004 `gift_wrap.rs::wrap_mostro_message` → `wrap_message_with(Transport::Nip44Direct,
       …, WrapOptions { pow, expiration: None, signed: true })`.
-- [ ] T005 `gift_wrap.rs::unwrap_mostro_message` → `unwrap_incoming(event, trade_keys)`.
-- [ ] T006 [P] `relay_pool.rs::subscribe_order_and_dm_feeds` dm_filter → kind 14 +
+- [x] T005 `gift_wrap.rs::unwrap_mostro_message` → `unwrap_incoming(event, trade_keys)`.
+- [x] T006 [P] `relay_pool.rs::subscribe_order_and_dm_feeds` dm_filter → kind 14 +
       `.author(mostro_pubkey)`.
-- [ ] T007 [P] `orders.rs::subscribe_gift_wraps` filter → kind 14 + `.author(...)`
+- [x] T007 [P] `orders.rs::subscribe_gift_wraps` filter → kind 14 + `.author(...)`
       (resolve `mostro_pubkey` via `config::active_mostro_pubkey()`).
-- [ ] T008 [P] `orders.rs` global bulk `gw_filter` → kind 14 + `.author(...)`.
-- [ ] T009 Update the three receive handlers in `orders.rs` (per-trade, global,
+- [x] T008 [P] `orders.rs` global bulk `gw_filter` → kind 14 + `.author(...)`.
+- [x] T009 Update the three receive handlers in `orders.rs` (per-trade, global,
       event loop): kind-14 check + reject `event.pubkey != mostro_pubkey`.
-- [ ] T010 Update `gift_wrap.rs` tests: assert kind 14 + author = trade key.
-- [ ] T011 Leave local `wrap`/`unwrap` (peer/dispute chat, kind 1059) untouched —
-      regression-verify peer chat still works.
-- [ ] T012 `cargo test && cargo clippy` green; manual E2E order lifecycle vs the v2
+- [x] T010 Update `gift_wrap.rs` tests: assert kind 14 + author = trade key.
+- [x] T011 Leave local `wrap`/`unwrap` (peer/dispute chat, kind 1059) untouched —
+      regression-verify peer chat still works. _(Superseded: this chat later
+      moved off gift wrap too, see status note above.)_
+- [x] T012 `cargo test && cargo clippy` green; manual E2E order lifecycle vs the v2
       node. **Checkpoint**: full trade flow works on protocol v2.


### PR DESCRIPTION
## Summary

Two docs chores from #122, both covering `specs/*/tasks.md` files that had drifted from reality.

### specs/005-transport-v2-migration/tasks.md

All 12 tasks were still `[ ]` even though the transport migration merged in #111 and was verified end-to-end. Marked all 12 done, and added a status note at the top: the plan is now a historical record, not a map of the current code. Verified against current code, it's been superseded further than the issue assumed — mostro-core is now 0.14.1 (past the 0.13.1 target), gift_wrap.rs no longer exists (wrap_mostro_message/unwrap_mostro_message now live in rust/src/nostr/transport.rs), and T011's "leave gift wrap on peer/dispute chat untouched" no longer holds, since that chat also moved off gift wrap entirely in #246/#254.

### specs/004-mostro-p2p-client/tasks.md

Three changes:

- Added an "Open work at a glance" summary near the top. Almost the entire file (T001-T145) is done, so phases 18/19/20 aren't really historical work mixed into an active backlog, they're just appended sequentially at the end. The real open work is two small clusters of partial tasks: file attachments (T079, T080, T081) and dispute admin chat (T088, T090-T093), both cases where the Rust side is ready but nothing in Dart calls it yet.
- Corrected an existing transport-v2 note that had gone stale in the same way as the 005 file: it claimed peer chat still uses NIP-59 gift wrap, which is no longer true after #246/#254.
- Added a pointer task (T148, Phase 21) for the mnemonic-restore flow: it has a contract in contracts/identity.md (import_from_mnemonic with recover=true) but no task ever tracked it, per @grunch's note on #142. Scoped as a pointer to the epic (#142 and its sub-issues), not a new task breakdown, so it doesn't duplicate work already planned there.

Docs-only change, no code touched.

Closes #122

## Test plan

- Read both files fully before editing to confirm the actual state (checked boxes, phase structure, existing notes) rather than assuming the issue's description was still accurate
- Cross-checked the corrected claims against the current code (mostro-core version, file layout, chat transport) the same way as in #123
- N/A, no Rust/Dart code changed, so cargo fmt/clippy/test and flutter analyze/test do not apply
