### PR TITLE
fix: persist rated_at marker so the rated state survives a restart

### DIFF
--- a/lib/features/rate/providers/rating_providers.dart
+++ b/lib/features/rate/providers/rating_providers.dart
@@ -5,9 +5,11 @@ import 'package:mostro/src/rust/api/types.dart';
 
 /// The rating held for [tradeId], or `null` when neither side has rated.
 ///
-/// The Rust store is in-memory by design (ratings live in the daemon's kind
-/// 38383 tags, not in the local DB), so this resolves to `null` again after a
-/// restart and the rate prompt comes back.
+/// The Rust store is in-memory (ratings live in the daemon's kind 38383 tags,
+/// not in the local DB), but the local user's own rating is backed by a durable
+/// `rated_at` marker on the trade row (issue #339): on a restart the in-memory
+/// store rehydrates from it, so a trade the user already rated still resolves as
+/// rated and the rate prompt does not come back.
 final tradeRatingProvider = FutureProvider.autoDispose
     .family<RatingInfo?, String>((ref, tradeId) async {
   return reputation_api.getRatingForTrade(tradeId: tradeId);

--- a/rust/src/api/identity.rs
+++ b/rust/src/api/identity.rs
@@ -746,6 +746,9 @@ mod tests {
         ) -> Result<()> {
             unimplemented!()
         }
+        async fn mark_trade_rated(&self, _order_id: &str, _rated_at: i64) -> Result<()> {
+            unimplemented!()
+        }
         async fn save_queued_message(
             &self,
             _msg: &crate::queue::outbox::QueuedMessage,

--- a/rust/src/api/messages.rs
+++ b/rust/src/api/messages.rs
@@ -1918,6 +1918,7 @@ mod tests {
             peer_rating: None,
             peer_reviews: None,
             peer_days: None,
+            rated_at: None,
         };
         assert!(chat_still_relevant(&base));
 

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -610,6 +610,7 @@ pub async fn create_order(params: NewOrderParams) -> Result<OrderInfo> {
         peer_rating: None,
         peer_reviews: None,
         peer_days: None,
+        rated_at: None,
     };
     if let Some(db) = crate::db::app_db::db() {
         if let Err(e) = db.save_trade(&trade).await {
@@ -843,6 +844,7 @@ pub async fn take_order(
         peer_rating: None,
         peer_reviews: None,
         peer_days: None,
+        rated_at: None,
     };
 
     // The other side of the race guarded in `dispatch_mostro_message`: this

--- a/rust/src/api/reputation.rs
+++ b/rust/src/api/reputation.rs
@@ -16,6 +16,7 @@ use tokio::sync::{broadcast, RwLock};
 use tokio::sync::broadcast::error::RecvError;
 
 use crate::api::types::{RatingInfo, RatingReceivedEvent};
+use crate::db::Storage;
 
 // ── Rating store ──────────────────────────────────────────────────────────────
 
@@ -97,6 +98,66 @@ impl RatingStore {
             .or_insert_with(|| TradeRatings { mine: None, peer: None });
         entry.peer = Some(info);
     }
+
+    /// `true` when the local user's rating slot for `trade_id` is already
+    /// populated in memory — the fast path that lets callers skip the DB.
+    async fn has_mine(&self, trade_id: &str) -> bool {
+        self.ratings
+            .read()
+            .await
+            .get(trade_id)
+            .is_some_and(|r| r.mine.is_some())
+    }
+
+    /// Populate the local user's rating slot from a durable marker loaded off
+    /// disk, without the `AlreadyRated` guard. Silent no-op if a slot is
+    /// already present, so a live in-memory rating is never clobbered.
+    async fn hydrate_mine(&self, info: RatingInfo) {
+        let mut store = self.ratings.write().await;
+        let entry = store
+            .entry(info.trade_id.clone())
+            .or_insert_with(|| TradeRatings { mine: None, peer: None });
+        if entry.mine.is_none() {
+            entry.mine = Some(info);
+        }
+    }
+}
+
+/// Bring the durable "I rated this trade" marker (issue #339) into the
+/// in-memory store when the local user rated it in a previous session.
+///
+/// No-op when the slot is already in memory (the fast path), when persistence
+/// is not wired yet, or when the trade was never rated. The persisted marker
+/// is authoritative on load; the memory store stays the cache in front of it.
+///
+/// The score itself is not persisted — the rated state shows only a label, and
+/// the sole consumer that matters (`ratedByMeProvider`) reads `is_mine` — so a
+/// hydrated rating carries a placeholder score of `0`. Callers must not treat a
+/// hydrated `is_mine` rating's score as the note that was actually given.
+async fn hydrate_mine_from_db(trade_id: &str) {
+    let store = rating_store();
+    if store.has_mine(trade_id).await {
+        return;
+    }
+    let Some(db) = crate::db::app_db::db() else {
+        return;
+    };
+    match db.get_trade_by_order_id(trade_id).await {
+        Ok(Some(trade)) => {
+            if let Some(rated_at) = trade.rated_at {
+                store
+                    .hydrate_mine(RatingInfo {
+                        trade_id: trade_id.to_string(),
+                        score: 0,
+                        is_mine: true,
+                        created_at: rated_at,
+                    })
+                    .await;
+            }
+        }
+        Ok(None) => {}
+        Err(e) => log::warn!("[reputation] hydrate_mine_from_db(trade={trade_id}): {e}"),
+    }
 }
 
 // ── Global singleton ──────────────────────────────────────────────────────────
@@ -134,6 +195,11 @@ pub async fn submit_rating(trade_id: String, score: u8) -> Result<()> {
     if store.privacy_mode.load(Ordering::SeqCst) {
         bail!("PrivacyModeEnabled: cannot submit rating while privacy mode is active");
     }
+
+    // Pull any prior-session rating into memory first, so the guard below fires
+    // AlreadyRated across a restart too — otherwise the empty in-memory store
+    // would let a second RateUser event go out on the wire (issue #339).
+    hydrate_mine_from_db(&trade_id).await;
 
     // Reserve the slot atomically before attempting any outbound send.
     // This prevents two concurrent submit_rating calls from both reaching
@@ -178,9 +244,22 @@ pub async fn submit_rating(trade_id: String, score: u8) -> Result<()> {
         .await;
 
         match dispatch_result {
-            Ok(()) => log::info!(
-                "[reputation] rate_user published trade={trade_id} score={score}"
-            ),
+            Ok(()) => {
+                log::info!(
+                    "[reputation] rate_user published trade={trade_id} score={score}"
+                );
+                // Persist the durable marker so the rated state and the guard
+                // above survive a restart (issue #339). Best-effort: the rating
+                // already went out on the wire, so a DB miss must not fail it —
+                // the in-memory slot still holds it for the rest of the session.
+                if let Some(db) = crate::db::app_db::db() {
+                    if let Err(e) = db.mark_trade_rated(&trade_id, unix_now()).await {
+                        log::warn!(
+                            "[reputation] mark_trade_rated(trade={trade_id}) failed: {e}"
+                        );
+                    }
+                }
+            }
             Err(e) => {
                 // Rollback: remove the reservation so the caller can retry.
                 store.remove_mine(&trade_id).await;
@@ -226,6 +305,10 @@ pub fn set_privacy_mode(enabled: bool) {
 ///
 /// Returns `None` if no rating exists for the given trade.
 pub async fn get_rating_for_trade(trade_id: String) -> Result<Option<RatingInfo>> {
+    // Rehydrate from the durable marker so a trade rated in a previous session
+    // still resolves as rated after a restart (issue #339); no-op once the slot
+    // is in memory.
+    hydrate_mine_from_db(&trade_id).await;
     Ok(rating_store().get(&trade_id).await)
 }
 
@@ -420,5 +503,129 @@ mod tests {
         // Submitting my rating a second time is still rejected.
         let err = submit_rating(trade_id, 3).await.unwrap_err();
         assert!(err.to_string().contains("AlreadyRated"));
+    }
+
+    /// `hydrate_mine` seeds an empty slot (the restart case: a marker loaded
+    /// off disk populates a fresh in-memory store) but never clobbers a rating
+    /// already held for the session — the live score wins over the placeholder.
+    #[tokio::test]
+    async fn hydrate_mine_seeds_but_never_clobbers() {
+        let store = rating_store();
+        let trade_id = format!("t-{}", uuid::Uuid::new_v4());
+
+        // Empty slot: hydration seeds it (score 0 placeholder, is_mine).
+        assert!(!store.has_mine(&trade_id).await);
+        store
+            .hydrate_mine(RatingInfo {
+                trade_id: trade_id.clone(),
+                score: 0,
+                is_mine: true,
+                created_at: 1_700_000_000,
+            })
+            .await;
+        assert!(store.has_mine(&trade_id).await);
+        let info = store.get(&trade_id).await.unwrap();
+        assert!(info.is_mine);
+        assert_eq!(info.created_at, 1_700_000_000);
+
+        // A subsequent hydrate (e.g. a redundant DB read) is a silent no-op —
+        // it must not overwrite the slot already present.
+        store
+            .hydrate_mine(RatingInfo {
+                trade_id: trade_id.clone(),
+                score: 5,
+                is_mine: true,
+                created_at: 42,
+            })
+            .await;
+        let info = store.get(&trade_id).await.unwrap();
+        assert_eq!(info.created_at, 1_700_000_000, "hydrate must not clobber");
+    }
+
+    /// End-to-end restart coverage (issue #339): a `rated_at` marker persisted
+    /// by a previous session — with `RATING_STORE` empty, as it is on a fresh
+    /// launch — resolves the trade as rated (AC1) and blocks a second rating
+    /// (AC2). Uses a real store via `init_db`, following the `escrow.rs`
+    /// precedent; a fresh order id keeps the shared process-wide DB and rating
+    /// store uncontaminated by (and from) the other tests in this binary.
+    #[tokio::test]
+    async fn persisted_marker_survives_restart_and_blocks_second_rating() {
+        use crate::api::types::*;
+
+        let _guard = privacy_lock().lock().unwrap();
+        set_privacy_mode(false);
+
+        // A real store — the point of the test. `init_db` is a process-wide
+        // OnceCell: first caller wins and the rest share it, so leave the file.
+        let path = std::env::temp_dir()
+            .join(format!("mostro_reputation_rated_{}.db", std::process::id()));
+        let _ = crate::db::app_db::init_db(path.to_str().unwrap()).await;
+        let db = crate::db::app_db::db().expect("a real store is the point");
+
+        // Fresh order id → empty RATING_STORE slot (the restart condition) and
+        // a DB row no other test touches.
+        let order_id = format!("order-{}", uuid::Uuid::new_v4());
+
+        let trade = TradeInfo {
+            id: format!("row-{}", uuid::Uuid::new_v4()),
+            order: OrderInfo {
+                id: order_id.clone(),
+                kind: OrderKind::Sell,
+                status: OrderStatus::SettledHoldInvoice,
+                amount_sats: None,
+                fiat_amount: Some(100.0),
+                fiat_amount_min: None,
+                fiat_amount_max: None,
+                fiat_code: "CUP".into(),
+                payment_method: "bank".into(),
+                premium: 0.0,
+                creator_pubkey: "maker".into(),
+                created_at: 1,
+                expires_at: None,
+                is_mine: false,
+                rating: 0.0,
+                total_reviews: 0,
+                days_active: 0,
+            },
+            role: TradeRole::Buyer,
+            counterparty_pubkey: String::new(),
+            current_step: TradeStep::Buyer(BuyerStep::OrderTaken),
+            hold_invoice: None,
+            buyer_invoice: None,
+            trade_key_index: 1,
+            cooperative_cancel_state: None,
+            timeout_at: None,
+            started_at: 1,
+            completed_at: Some(1),
+            outcome: Some(TradeOutcome::Success),
+            peer_rating: None,
+            peer_reviews: None,
+            peer_days: None,
+            rated_at: None,
+        };
+        db.save_trade(&trade).await.unwrap();
+
+        // Simulate a previous session having rated: write the durable marker
+        // straight to the row, WITHOUT touching RATING_STORE (that is what a
+        // restart wipes).
+        let ts = 1_700_000_000;
+        db.mark_trade_rated(&order_id, ts).await.unwrap();
+
+        // AC1: with an empty in-memory store, the trade still resolves as rated.
+        let info = get_rating_for_trade(order_id.clone())
+            .await
+            .unwrap()
+            .expect("marker rehydrates the rating");
+        assert!(info.is_mine, "a rehydrated marker is the local user's rating");
+        assert_eq!(info.created_at, ts);
+
+        // AC2: a second rating is refused across the restart — the guard fires
+        // before any trade-key lookup or dispatch, so this is deterministic
+        // without relays.
+        let err = submit_rating(order_id, 4).await.unwrap_err();
+        assert!(
+            err.to_string().contains("AlreadyRated"),
+            "persisted marker must block a second rating, got: {err}"
+        );
     }
 }

--- a/rust/src/api/types.rs
+++ b/rust/src/api/types.rs
@@ -273,6 +273,19 @@ pub struct TradeInfo {
     pub peer_reviews: Option<u32>,
     #[serde(default)]
     pub peer_days: Option<u32>,
+    /// Durable "the local user rated this trade" marker (unix seconds), set
+    /// after `submit_rating` publishes (issue #339).
+    ///
+    /// Whether we rated a counterparty is local knowledge: the daemon's kind
+    /// 38383 tag carries the peer's *aggregate* reputation, and its one-shot
+    /// `rate-received` is not re-sent on reconnect — so nothing on the wire can
+    /// rebuild it. Persisting the timestamp here lets the rated state survive a
+    /// restart and keeps the duplicate-rating guard armed. The score itself is
+    /// deliberately not stored — the rated UI shows only a label, not the note.
+    /// `#[serde(default)]` keeps trade rows written before this field existed
+    /// deserializable.
+    #[serde(default)]
+    pub rated_at: Option<i64>,
 }
 
 /// A trade lifecycle change pushed from Rust so the UI does not have to poll

--- a/rust/src/db/indexeddb.rs
+++ b/rust/src/db/indexeddb.rs
@@ -309,6 +309,11 @@ impl Storage for IndexedDbStorage {
         log::warn!("update_trade_peer_reputation: IndexedDB backend not implemented — peer reputation will not persist");
         Ok(())
     }
+
+    async fn mark_trade_rated(&self, _order_id: &str, _rated_at: i64) -> Result<()> {
+        log::warn!("mark_trade_rated: IndexedDB backend not implemented — rated marker will not persist");
+        Ok(())
+    }
 }
 
 /// The active-node settings key (shared with the SQLite backend).

--- a/rust/src/db/mod.rs
+++ b/rust/src/db/mod.rs
@@ -201,4 +201,11 @@ pub trait Storage: Send + Sync {
         reviews: u32,
         days: u32,
     ) -> Result<()>;
+
+    /// Set the durable "local user rated this trade" marker (`rated_at`, unix
+    /// seconds) on the trade identified by `order.id` (issue #339). Written
+    /// after `submit_rating` publishes so the rated state and the
+    /// duplicate-rating guard survive a restart. No-op when no matching trade
+    /// exists.
+    async fn mark_trade_rated(&self, order_id: &str, rated_at: i64) -> Result<()>;
 }

--- a/rust/src/db/sqlite.rs
+++ b/rust/src/db/sqlite.rs
@@ -624,6 +624,20 @@ impl Storage for SqliteStorage {
             .await?;
         Ok(())
     }
+
+    async fn mark_trade_rated(&self, order_id: &str, rated_at: i64) -> Result<()> {
+        // Bind via json(?) so SQLite stores the timestamp as a JSON number, not
+        // a string — a string would fail to deserialize back into Option<i64>.
+        let sql = "UPDATE trades SET data = json_set(\
+             data, '$.rated_at', json(?)) \
+             WHERE json_extract(data, '$.order.id') = ?";
+        sqlx::query(sql)
+            .bind(rated_at.to_string())
+            .bind(order_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -719,6 +733,7 @@ mod tests {
             peer_rating: None,
             peer_reviews: None,
             peer_days: None,
+            rated_at: None,
         };
         storage.save_trade(&trade("row-a", "order-a")).await.unwrap();
         storage.save_trade(&trade("row-b", "order-b")).await.unwrap();
@@ -788,6 +803,7 @@ mod tests {
             peer_rating: None,
             peer_reviews: None,
             peer_days: None,
+            rated_at: None,
         };
         storage.save_trade(&trade("row-a", "order-a")).await.unwrap();
         storage.save_trade(&trade("row-b", "order-b")).await.unwrap();
@@ -831,6 +847,85 @@ mod tests {
         assert_eq!(b.peer_rating, Some(0.0));
         assert_eq!(b.peer_reviews, Some(0));
         assert_eq!(b.peer_days, Some(0));
+
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// The durable rated marker (issue #339) round-trips as a JSON number, is
+    /// scoped to a single order id, and is absent until written.
+    #[tokio::test]
+    async fn mark_trade_rated_round_trips_by_order_id() {
+        use crate::api::types::*;
+
+        let path = temp_db_path();
+        let storage = SqliteStorage::open(path.to_str().unwrap()).await.unwrap();
+
+        let trade = |row_id: &str, order_id: &str| TradeInfo {
+            id: row_id.into(),
+            order: OrderInfo {
+                id: order_id.into(),
+                kind: OrderKind::Sell,
+                status: OrderStatus::WaitingBuyerInvoice,
+                amount_sats: None,
+                fiat_amount: Some(100.0),
+                fiat_amount_min: None,
+                fiat_amount_max: None,
+                fiat_code: "CUP".into(),
+                payment_method: "bank".into(),
+                premium: 0.0,
+                creator_pubkey: "maker".into(),
+                created_at: 1,
+                expires_at: None,
+                is_mine: false,
+                rating: 0.0,
+                total_reviews: 0,
+                days_active: 0,
+            },
+            role: TradeRole::Buyer,
+            counterparty_pubkey: String::new(),
+            current_step: TradeStep::Buyer(BuyerStep::OrderTaken),
+            hold_invoice: None,
+            buyer_invoice: None,
+            trade_key_index: 1,
+            cooperative_cancel_state: None,
+            timeout_at: None,
+            started_at: 1,
+            completed_at: None,
+            outcome: None,
+            peer_rating: None,
+            peer_reviews: None,
+            peer_days: None,
+            rated_at: None,
+        };
+        storage.save_trade(&trade("row-a", "order-a")).await.unwrap();
+        storage.save_trade(&trade("row-b", "order-b")).await.unwrap();
+
+        // Absent until written.
+        let a = storage
+            .get_trade_by_order_id("order-a")
+            .await
+            .unwrap()
+            .expect("order-a survives");
+        assert_eq!(a.rated_at, None);
+
+        storage.mark_trade_rated("order-a", 1_700_000_000).await.unwrap();
+
+        // Stored as a JSON number that deserializes back into Option<i64>.
+        let a = storage
+            .get_trade_by_order_id("order-a")
+            .await
+            .unwrap()
+            .expect("order-a survives");
+        assert_eq!(a.rated_at, Some(1_700_000_000));
+
+        // The sibling row is untouched — the update is scoped by order id.
+        let b = storage
+            .get_trade_by_order_id("order-b")
+            .await
+            .unwrap()
+            .expect("order-b survives");
+        assert_eq!(b.rated_at, None);
 
         drop(storage);
         let _ = std::fs::remove_file(&path);

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -5994,6 +5994,7 @@ impl SseDecode for crate::api::types::TradeInfo {
         let mut var_peerRating = <Option<f64>>::sse_decode(deserializer);
         let mut var_peerReviews = <Option<u32>>::sse_decode(deserializer);
         let mut var_peerDays = <Option<u32>>::sse_decode(deserializer);
+        let mut var_ratedAt = <Option<i64>>::sse_decode(deserializer);
         return crate::api::types::TradeInfo {
             id: var_id,
             order: var_order,
@@ -6011,6 +6012,7 @@ impl SseDecode for crate::api::types::TradeInfo {
             peer_rating: var_peerRating,
             peer_reviews: var_peerReviews,
             peer_days: var_peerDays,
+            rated_at: var_ratedAt,
         };
     }
 }
@@ -7546,6 +7548,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::types::TradeInfo {
             self.peer_rating.into_into_dart().into_dart(),
             self.peer_reviews.into_into_dart().into_dart(),
             self.peer_days.into_into_dart().into_dart(),
+            self.rated_at.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -8920,6 +8923,7 @@ impl SseEncode for crate::api::types::TradeInfo {
         <Option<f64>>::sse_encode(self.peer_rating, serializer);
         <Option<u32>>::sse_encode(self.peer_reviews, serializer);
         <Option<u32>>::sse_encode(self.peer_days, serializer);
+        <Option<i64>>::sse_encode(self.rated_at, serializer);
     }
 }
 

--- a/specs/004-mostro-p2p-client/data-model.md
+++ b/specs/004-mostro-p2p-client/data-model.md
@@ -116,6 +116,7 @@ trade at a time (v2.0 scope constraint).
 | started_at | Timestamp | When trade began |
 | completed_at | Timestamp? | When trade finished (null if active) |
 | outcome | Enum? | `Success`, `Canceled`, `Expired`, `DisputeWon`, `DisputeLost` |
+| rated_at | Timestamp? | When the local user rated the counterparty; durable marker written by `db.mark_trade_rated` after `submit_rating` publishes (issue #339). "Did I rate this trade" is local knowledge nothing on the wire can rebuild, so the in-memory `RATING_STORE` rehydrates from this on restart — the store stays the cache, this is authoritative on load. The score itself is not persisted (the rated UI shows only a label) |
 
 Trade rows are history: they are updated in place (`status`,
 `hold_invoice`, `amount_sats` — see `update_trade_fields`) but never


### PR DESCRIPTION
Closes #339.

## Problem
Whether the local user rated a trade lived only in `RATING_STORE` (an in-memory `OnceLock`). Nothing on the wire can rebuild it the daemon's kind 38383 tag carries the counterparty's *aggregate* reputation, `rate-received` is not re-sent on reconnect, and the restore payload has no ratings. So after a restart the rate prompt came back on an already-rated trade, and a second rating was actually published (the duplicate guard lives in the same empty-on-restart map).

## Fix
Persist a durable `rated_at` timestamp on the trade row, written by `db.mark_trade_rated` after `submit_rating` publishes. `RATING_STORE` stays the in-memory fast path and rehydrates from the marker on load the store remains "in-memory by design"; the marker is authoritative on load. This mirrors the existing `DISPUTE_STORE` + persisted `dispute_admin` pubkey pattern (#256): a learned-once local fact persisted separately while the store stays a cache.

- `submit_rating` hydrates **before** the duplicate guard, so a second rating is refused across a restart (AC2).
- `get_rating_for_trade` hydrates before answering, so the trade resolves as rated after a restart (AC1).
- The score itself is not persisted the rated UI shows only a label.
- IndexedDB (web) is a warn-and-Ok stub; trades aren't persisted on web yet (#233).

## Manual verification
Completed and rated an order in the running app: `rated_at` flipped from absent → a unix timestamp on exactly that trade's row (scoped correctly; sibling rows untouched); pre-existing rows without the key deserialize fine via `#[serde(default)]`.

## Docs
- Corrected the now-false doc comment in `rating_providers.dart` that described the fixed bug.
- Added `rated_at` to the Trade table in `specs/004/data-model.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ratings now remain marked after app restarts, preventing previously rated trades from prompting for another rating.
  * Duplicate-rating protection is preserved when rating data is restored.

* **Documentation**
  * Updated the trade data model to document the persisted rating timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->