### PR TITLE
fix(perf): stop logging at info level once per ingested order

### DIFF
--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -3097,7 +3097,9 @@ fn admin_pubkey_from_payload(
 /// rejects it (`InvalidPeer`, #326). This mirrors the v1 client, which keys the
 /// trade index by daemon UUID and never by order content.
 async fn bridge_fingerprint_trade_index(order_id: &str, trade_idx: u32) {
-    if get_trade_key_index(order_id).await.is_none() {
+    // "No binding yet" is the case this function exists to handle, so the
+    // warning variant would fire on the normal path.
+    if lookup_trade_key_index(order_id).await.is_none() {
         store_trade_key_index(order_id, trade_idx).await;
     }
 }
@@ -3116,7 +3118,7 @@ async fn ingest_order_event(event: &nostr_sdk::Event) {
     );
     match parse_order_event(event, None) {
         Some(mut info) => {
-            log::info!(
+            log::debug!(
                 "[orders] parsed order id={} kind={:?} status={:?}",
                 info.id,
                 info.kind,
@@ -3134,7 +3136,10 @@ async fn ingest_order_event(event: &nostr_sdk::Event) {
                     &info.payment_method,
                 );
                 log::debug!("[orders] fingerprint check order={} ck={ck}", info.id);
-                if let Some(trade_idx) = get_trade_key_index(&ck).await {
+                // A miss is the expected case here: every order from another
+                // user fails this lookup, so the warning variant would fire
+                // once per ingested event.
+                if let Some(trade_idx) = lookup_trade_key_index(&ck).await {
                     info.is_mine = true;
                     // Bridge content fingerprint → daemon UUID so subsequent
                     // actions (cancel) can look up the trade key by real order ID.


### PR DESCRIPTION
Phase 1, PR 1.1 of the optimization plan (#348).

## Problem

Two log sites fire once per ingested Kind 38383 event:

- `orders.rs:3119` logs every parsed order at **info**.
- `get_trade_key_index` (`orders.rs:71`) logs a **warning** on every miss, and the `is_mine` fingerprint check calls it for every order — so it misses, and warns, for every order that belongs to somebody else.

Release builds default to the `Info` level, and each record is formatted, secret-scrubbed (`logging.rs:216-247`), pushed into a `Mutex<VecDeque>` and broadcast to a Dart log stream. With a few thousand orders in the book, every refresh pays that cost thousands of times, on the ingest hot path.

## Change

- The per-event parse log drops to `debug!`.
- The two lookups whose miss is the *expected* outcome now call `lookup_trade_key_index`, the non-warning variant that already exists in the file for exactly this reason:
  - the `is_mine` fingerprint check (a miss means "not my order", the common case),
  - `bridge_fingerprint_trade_index` (a miss means "no binding yet", which is the case the function exists to handle).

`get_trade_key_index` keeps the warning for the callers where a missing binding really is an error (take, release, cancel, rate — where it would cause a signature failure on the daemon side).

The batch summary already logged before ingest in `refetch_active_node_orders` ("refetched N current orders") remains, and is now the info-level record of that work.

No public function signatures change, nothing in `crate::api` changes shape, so no FRB regeneration is needed.

## Test plan

- [x] `cargo test` — 293 passed, 0 failed
- [x] `cargo clippy --all-targets` — no new warnings (the 23 remaining are pre-existing, in `escrow_mode.rs` test code)
- [ ] Manual: open the log view, pull-to-refresh the order book, confirm one "refetched N current orders" line instead of N per-order lines