### PR TITLE
fix(db): index the trade lookups that run once per order event

### DIFF
--- a/rust/src/db/schema.rs
+++ b/rust/src/db/schema.rs
@@ -60,6 +60,15 @@ CREATE TABLE IF NOT EXISTS trades (
     completed_at    INTEGER
 );
 
+-- `trades.id` is a fresh UUID for takers, so every lookup by order id has to
+-- reach inside the JSON blob. The expression here must stay byte-identical to
+-- the one in the six `WHERE json_extract(data, '$.order.id') = ?` queries in
+-- sqlite.rs, or SQLite silently falls back to a full scan that re-parses every
+-- row — on the ingest path that runs once per non-pending order event.
+CREATE INDEX IF NOT EXISTS idx_trades_order_id
+    ON trades(json_extract(data, '$.order.id'));
+CREATE INDEX IF NOT EXISTS idx_trades_status ON trades(status);
+
 -- Chat history + durable replay dedup (issue #246). `trade_id` here is the
 -- **order id** — the identity chat keys are derived from — which for taken
 -- orders differs from the `trades.id` UUID, so deliberately NO foreign key

--- a/rust/src/db/schema.rs
+++ b/rust/src/db/schema.rs
@@ -67,7 +67,6 @@ CREATE TABLE IF NOT EXISTS trades (
 -- row — on the ingest path that runs once per non-pending order event.
 CREATE INDEX IF NOT EXISTS idx_trades_order_id
     ON trades(json_extract(data, '$.order.id'));
-CREATE INDEX IF NOT EXISTS idx_trades_status ON trades(status);
 
 -- Chat history + durable replay dedup (issue #246). `trade_id` here is the
 -- **order id** — the identity chat keys are derived from — which for taken

--- a/rust/src/db/sqlite.rs
+++ b/rust/src/db/sqlite.rs
@@ -652,6 +652,60 @@ mod tests {
         std::env::temp_dir().join(format!("mostro_test_{}_{n}.db", std::process::id()))
     }
 
+    /// `EXPLAIN QUERY PLAN` rows, joined into one string for assertion.
+    async fn query_plan(storage: &SqliteStorage, sql: &str) -> String {
+        let rows: Vec<(i64, i64, i64, String)> =
+            sqlx::query_as(&format!("EXPLAIN QUERY PLAN {sql}"))
+                .bind("order-plan-1")
+                .fetch_all(&storage.pool)
+                .await
+                .unwrap();
+        rows.into_iter()
+            .map(|(_, _, _, detail)| detail)
+            .collect::<Vec<_>>()
+            .join(" | ")
+    }
+
+    /// The six trade lookups all filter on the same json_extract expression.
+    /// Without a matching expression index SQLite full-scans `trades` and
+    /// re-parses every JSON blob — once per non-pending order event.
+    #[tokio::test]
+    async fn trade_lookup_by_order_id_uses_an_index() {
+        let path = temp_db_path();
+        let storage = SqliteStorage::open(path.to_str().unwrap()).await.unwrap();
+
+        let plan = query_plan(
+            &storage,
+            "SELECT data FROM trades WHERE json_extract(data, '$.order.id') = ? LIMIT 1",
+        )
+        .await;
+
+        assert!(
+            plan.contains("idx_trades_order_id"),
+            "expected the order-id expression index, got: {plan}"
+        );
+
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// The 30-minute stale sweep filters trades by status.
+    #[tokio::test]
+    async fn trade_lookup_by_status_uses_an_index() {
+        let path = temp_db_path();
+        let storage = SqliteStorage::open(path.to_str().unwrap()).await.unwrap();
+
+        let plan = query_plan(&storage, "SELECT data FROM trades WHERE status = ?").await;
+
+        assert!(
+            plan.contains("idx_trades_status"),
+            "expected the status index, got: {plan}"
+        );
+
+        drop(storage);
+        let _ = std::fs::remove_file(&path);
+    }
+
     #[tokio::test]
     async fn message_exists_is_durable_replay_dedup() {
         use crate::api::types::*;

--- a/rust/src/db/sqlite.rs
+++ b/rust/src/db/sqlite.rs
@@ -689,22 +689,6 @@ mod tests {
         let _ = std::fs::remove_file(&path);
     }
 
-    /// The 30-minute stale sweep filters trades by status.
-    #[tokio::test]
-    async fn trade_lookup_by_status_uses_an_index() {
-        let path = temp_db_path();
-        let storage = SqliteStorage::open(path.to_str().unwrap()).await.unwrap();
-
-        let plan = query_plan(&storage, "SELECT data FROM trades WHERE status = ?").await;
-
-        assert!(
-            plan.contains("idx_trades_status"),
-            "expected the status index, got: {plan}"
-        );
-
-        drop(storage);
-        let _ = std::fs::remove_file(&path);
-    }
 
     #[tokio::test]
     async fn message_exists_is_durable_replay_dedup() {


### PR DESCRIPTION
Phase 1, PR 1.2 of the optimization plan (#348).

## Problem

Because `trades.id` is a fresh UUID for takers, every lookup by order id has to reach inside the JSON blob:

```sql
WHERE json_extract(data, '$.order.id') = ?
```

Six queries in `sqlite.rs` use that predicate — `get_trade_by_order_id`, `delete_trade_by_order_id`, `update_trade_order_id`, `update_trade_fields`, `update_trade_peer_reputation`, `mark_trade_rated` — and **none of them had an index**, so each was a full table scan that re-parsed every row's JSON.

This is not a cold path. `local_trade_status` (`orders.rs:2246`) runs one of these for **every non-pending Kind 38383 event**, and the reputation path adds another per rated trade, so the cost scales with both order-book size and trade history.

## Change

One `CREATE INDEX IF NOT EXISTS` added to `SQLITE_INIT_SQL`: `idx_trades_order_id`, an expression index on `json_extract(data, '$.order.id')`.

SQLite only uses an expression index when the query's expression matches the indexed one exactly, so there's a comment in `schema.rs` tying the two together; if someone reformats the predicate in `sqlite.rs`, the index silently stops applying. That is what the test is there to catch.

`SQLITE_INIT_SQL` already runs unconditionally on every `SqliteStorage::open()` and every statement in it is idempotent, so existing databases pick the index up on next launch — no migration step, no `SCHEMA_VERSION` bump needed (nothing keys off it at runtime).

## Dropped after review (fb6900f)

An earlier revision also added `idx_trades_status`. Review on #348 caught that it was unreachable, and that is confirmed: the 30-minute stale sweep calls `db.list_trades()`, which is `SELECT id, data FROM trades ORDER BY started_at DESC` with no `WHERE`, and filters status in Rust afterwards (`orders.rs:2637-2648`). No query in the crate filters on `trades.status` at all, so that index bought nothing while costing an extra B-tree write on every trade insert and update.

Pushing the sweep's filter into SQL would make a status index worth having, but it changes what the sweep does and belongs in its own PR.

## Test plan

- [x] New test asserts via `EXPLAIN QUERY PLAN` that the order-id predicate hits its index. Confirmed it fails first (`expected the order-id expression index, got: SCAN trades`) and passes after.
- [x] `cargo test` — 294 passed, 0 failed
- [x] `cargo clippy --all-targets` — no new warnings
