### PR TITLE
fix(perf): make daemon-message dedup a hash lookup

### DIFF
--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -319,12 +319,38 @@ const DEDUP_MAX_ENTRIES: usize = 512;
 /// the per-trade and the global subscription is only handled once.
 ///
 /// `seen` answers the membership question; `order` exists only to know which
-/// id to drop when the window is full. The two must be mutated together or the
-/// set grows without bound.
+/// id to drop when the window is full. Both hold the same `Arc<str>`, so a new
+/// id is allocated once, and `record` is the only thing that writes them —
+/// split those two writes across call sites and `seen` grows without bound.
+///
+/// `frb(ignore)` because this module is part of `crate::api`, which
+/// flutter_rust_bridge scans: without it the codegen emits bindings for this
+/// private, non-bridgeable type and the wasm build stops compiling.
 #[derive(Default)]
+#[flutter_rust_bridge::frb(ignore)]
 struct DedupWindow {
-    seen: std::collections::HashSet<String>,
-    order: std::collections::VecDeque<String>,
+    seen: std::collections::HashSet<Arc<str>>,
+    order: std::collections::VecDeque<Arc<str>>,
+}
+
+impl DedupWindow {
+    /// Returns `true` if `event_id` is already in the window. Otherwise records
+    /// it — evicting the oldest id when the window is full — and returns
+    /// `false`.
+    fn record(&mut self, event_id: &str) -> bool {
+        if self.seen.contains(event_id) {
+            return true;
+        }
+        let id: Arc<str> = Arc::from(event_id);
+        self.seen.insert(Arc::clone(&id));
+        self.order.push_back(id);
+        if self.order.len() > DEDUP_MAX_ENTRIES {
+            if let Some(evicted) = self.order.pop_front() {
+                self.seen.remove(&evicted);
+            }
+        }
+        false
+    }
 }
 
 static PROCESSED_GW: OnceLock<std::sync::Mutex<DedupWindow>> = OnceLock::new();
@@ -333,20 +359,10 @@ static PROCESSED_GW: OnceLock<std::sync::Mutex<DedupWindow>> = OnceLock::new();
 /// Otherwise records it and returns `false`.
 fn is_duplicate_daemon_message(event_id: &str) -> bool {
     let window = PROCESSED_GW.get_or_init(|| std::sync::Mutex::new(DedupWindow::default()));
-    let mut guard = match window.lock() {
-        Ok(g) => g,
-        Err(_) => return false,
-    };
-    if !guard.seen.insert(event_id.to_string()) {
-        return true;
+    match window.lock() {
+        Ok(mut guard) => guard.record(event_id),
+        Err(_) => false,
     }
-    guard.order.push_back(event_id.to_string());
-    if guard.order.len() > DEDUP_MAX_ENTRIES {
-        if let Some(evicted) = guard.order.pop_front() {
-            guard.seen.remove(&evicted);
-        }
-    }
-    false
 }
 
 static ORDER_BOOK: OnceCell<OrderBook> = OnceCell::const_new();
@@ -3723,22 +3739,37 @@ mod tests {
     /// The window must recognize a repeat, and must forget an id once
     /// `DEDUP_MAX_ENTRIES` newer ones have arrived — otherwise it would grow
     /// without bound.
+    ///
+    /// Driven against a local window rather than `is_duplicate_daemon_message`:
+    /// that one shares a process-global static with every other test in this
+    /// binary, so asserting on it would both depend on and destroy state the
+    /// rest of the suite may touch.
     #[test]
     fn daemon_message_dedup_recognizes_repeats_and_evicts_oldest() {
-        // Prefixed so this test cannot collide with the shared global window.
-        let id = |n: usize| format!("dedup-test-{n:06}");
+        let mut window = DedupWindow::default();
+        let id = |n: usize| format!("{n:064x}");
 
-        assert!(!is_duplicate_daemon_message(&id(0)));
-        assert!(is_duplicate_daemon_message(&id(0)));
+        assert!(!window.record(&id(0)));
+        assert!(window.record(&id(0)));
 
         // One more than capacity, so id(0) is pushed out of the window.
         for n in 1..=DEDUP_MAX_ENTRIES {
-            is_duplicate_daemon_message(&id(n));
+            window.record(&id(n));
         }
 
         assert!(
-            !is_duplicate_daemon_message(&id(0)),
+            !window.record(&id(0)),
             "the oldest id should have been evicted once the window filled"
+        );
+        assert_eq!(
+            window.seen.len(),
+            window.order.len(),
+            "the set and the eviction queue drifted apart"
+        );
+        assert!(
+            window.order.len() <= DEDUP_MAX_ENTRIES,
+            "window grew past its bound: {}",
+            window.order.len()
         );
     }
 

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -310,28 +310,41 @@ use tokio::sync::OnceCell;
 
 // ── Daemon-message deduplication ─────────────────────────────────────────────
 
-/// Tracks recently processed daemon-message event IDs to avoid duplicate processing
-/// when both the per-trade and global subscriptions receive the same event.
-static PROCESSED_GW: OnceLock<std::sync::Mutex<std::collections::VecDeque<String>>> = OnceLock::new();
+/// Sized for the global feed's history replay on reused keys: a mass replay
+/// longer than this window would evict ids that a slower relay may still
+/// redeliver within the same session.
+const DEDUP_MAX_ENTRIES: usize = 512;
+
+/// Recently processed daemon-message event IDs, so an event delivered by both
+/// the per-trade and the global subscription is only handled once.
+///
+/// `seen` answers the membership question; `order` exists only to know which
+/// id to drop when the window is full. The two must be mutated together or the
+/// set grows without bound.
+#[derive(Default)]
+struct DedupWindow {
+    seen: std::collections::HashSet<String>,
+    order: std::collections::VecDeque<String>,
+}
+
+static PROCESSED_GW: OnceLock<std::sync::Mutex<DedupWindow>> = OnceLock::new();
 
 /// Returns `true` if this event ID was already processed (duplicate).
 /// Otherwise records it and returns `false`.
 fn is_duplicate_daemon_message(event_id: &str) -> bool {
-    // Sized for the global feed's history replay on reused keys: a mass
-    // replay longer than this window would evict ids that a slower relay
-    // may still redeliver within the same session.
-    const MAX_ENTRIES: usize = 512;
-    let deque = PROCESSED_GW.get_or_init(|| std::sync::Mutex::new(std::collections::VecDeque::new()));
-    let mut guard = match deque.lock() {
+    let window = PROCESSED_GW.get_or_init(|| std::sync::Mutex::new(DedupWindow::default()));
+    let mut guard = match window.lock() {
         Ok(g) => g,
         Err(_) => return false,
     };
-    if guard.iter().any(|id| id == event_id) {
+    if !guard.seen.insert(event_id.to_string()) {
         return true;
     }
-    guard.push_back(event_id.to_string());
-    if guard.len() > MAX_ENTRIES {
-        guard.pop_front();
+    guard.order.push_back(event_id.to_string());
+    if guard.order.len() > DEDUP_MAX_ENTRIES {
+        if let Some(evicted) = guard.order.pop_front() {
+            guard.seen.remove(&evicted);
+        }
     }
     false
 }
@@ -3706,6 +3719,28 @@ mod tests {
     use super::*;
     use crate::api::types::TradeRole;
     use crate::mostro::session::session_manager;
+
+    /// The window must recognize a repeat, and must forget an id once
+    /// `DEDUP_MAX_ENTRIES` newer ones have arrived — otherwise it would grow
+    /// without bound.
+    #[test]
+    fn daemon_message_dedup_recognizes_repeats_and_evicts_oldest() {
+        // Prefixed so this test cannot collide with the shared global window.
+        let id = |n: usize| format!("dedup-test-{n:06}");
+
+        assert!(!is_duplicate_daemon_message(&id(0)));
+        assert!(is_duplicate_daemon_message(&id(0)));
+
+        // One more than capacity, so id(0) is pushed out of the window.
+        for n in 1..=DEDUP_MAX_ENTRIES {
+            is_duplicate_daemon_message(&id(n));
+        }
+
+        assert!(
+            !is_duplicate_daemon_message(&id(0)),
+            "the oldest id should have been evicted once the window filled"
+        );
+    }
 
     #[test]
     fn the_solver_pubkey_is_read_from_a_peer_payload() {


### PR DESCRIPTION
Phase 1, PR 1.4 of the optimization plan (#348).

## Problem

`is_duplicate_daemon_message` (`orders.rs:319`) held a `VecDeque<String>` of up to 512 hex event ids and answered "have I seen this?" with:

```rust
if guard.iter().any(|id| id == event_id) {
```

That is a linear scan of up to 512 64-character string comparisons, taken **under the mutex**, once per kind 14 event — on both call sites, the per-trade subscription (`orders.rs:1249`) and the global daemon feed (`orders.rs:3043`). The window is at its fullest exactly when it matters most: during a history replay, which is the case the window exists for.

## Change

Membership moves to a `HashSet<String>`. The `VecDeque` stays, but its only job now is recording insertion order so eviction drops the right id:

```rust
struct DedupWindow {
    seen: HashSet<String>,
    order: VecDeque<String>,
}
```

Same 512-entry window, same semantics, O(1) instead of O(n). The `MAX_ENTRIES` constant moves out to `DEDUP_MAX_ENTRIES` at module scope so the test can assert against the real capacity rather than a hardcoded copy.

The two structures have to be mutated together or `seen` grows without bound, which is the one thing that could go wrong here — hence the comment on the struct and the eviction half of the test.

### Not done here

The plan also suggested keying on `EventId` bytes instead of hex strings. Left out: both call sites already need the hex string for their log lines, so the allocation does not actually disappear, and changing the signature would touch code beyond this fix. Worth revisiting when the logging around it changes.

## Test plan

- [x] New test asserts both halves: a repeated id is reported as duplicate, and an id is forgotten once `DEDUP_MAX_ENTRIES` newer ones have arrived. Confirmed it fails to build against the old code (no such constant) and passes after.
- [x] `cargo test` — 294 passed, 0 failed
- [x] `cargo clippy --all-targets` — no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon message deduplication to reliably detect repeated messages.
  * Ensured older deduplication entries are evicted when the tracking limit is reached.

* **Tests**
  * Added coverage for duplicate detection and removal of the oldest tracked entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->