### PR TITLE
fix(nostr): cap what a relay may replay for the order book

### DIFF
--- a/rust/src/nostr/order_events.rs
+++ b/rust/src/nostr/order_events.rs
@@ -207,6 +207,17 @@ fn parse_range(min: &str, max: &str) -> (Option<f64>, Option<f64>, Option<f64>) 
     }
 }
 
+/// Ceiling on the stored events a relay may replay for the order book, both on
+/// the live subscription and on the one-shot refetch.
+///
+/// Kind 38383 is addressable, so a well-behaved relay already returns only the
+/// latest event per order — this is a bound on what a misbehaving or hostile
+/// one can push at us, not on the book itself. Set well above any realistic
+/// active book: if a node ever legitimately approaches it, the answer is
+/// pagination, not a larger number, because the cost of the replay is paid on
+/// the ingest path.
+pub const ORDER_BOOK_FETCH_LIMIT: usize = 5_000;
+
 /// Build a Nostr filter for **all** Kind 38383 orders from a specific Mostro node,
 /// regardless of status.
 ///
@@ -218,6 +229,7 @@ pub fn all_orders_filter(mostro_pubkey: &PublicKey) -> Filter {
     Filter::new()
         .kind(Kind::from(KIND_ORDER))
         .author(*mostro_pubkey)
+        .limit(ORDER_BOOK_FETCH_LIMIT)
 }
 
 /// Build a Nostr filter for a **single** Kind 38383 order by `d`-tag (order ID).
@@ -236,6 +248,21 @@ pub fn trade_order_filter(mostro_pubkey: &PublicKey, order_id: &str) -> Filter {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// An unbounded filter lets a relay replay its entire history of the
+    /// node's orders, and every replayed event is paid for on the ingest path.
+    #[test]
+    fn the_order_book_filter_caps_what_a_relay_may_replay() {
+        let mostro = Keys::generate().public_key();
+
+        let filter = all_orders_filter(&mostro);
+
+        assert_eq!(
+            filter.limit,
+            Some(ORDER_BOOK_FETCH_LIMIT),
+            "the order-book filter must carry a replay ceiling"
+        );
+    }
 
     /// Build a signed Kind 38383 event with the standard order tags and the
     /// given `fa` tag values.


### PR DESCRIPTION
Phase 1, PR 1.6 of the optimization plan (#348).

## Problem

`all_orders_filter` (`order_events.rs:217`) pinned only kind and author:

```rust
Filter::new().kind(Kind::from(KIND_ORDER)).author(*mostro_pubkey)
```

No `limit`. Both users of it — the live order-book subscription (`orders.rs:2785`) and the node-switch / pull-to-refresh refetch (`orders.rs:2744`) — therefore ask every connected relay for its **entire** history of that node's orders.

Kind 38383 is addressable, so in practice a well-behaved relay returns only the latest event per order id and this stays bounded. But nothing in the request says so: what actually arrives is the relay's choice, it grows with node age, and every replayed event is paid for on the ingest path (parse → fingerprint check → book upsert → bridge emission).

## Change

Adds `ORDER_BOOK_FETCH_LIMIT` (5 000) and applies it to the filter.

The number is deliberately far above any realistic active book — this is a ceiling on what a misbehaving or hostile relay can push at us, **not** a page size. The doc comment says so explicitly, because the natural reading of a `limit` constant is "how many orders we show", and if a node ever legitimately approaches it the answer is pagination, not a bigger constant.

On a subscription, `limit` applies to the stored-event replay before EOSE; live events after it are unaffected, so real-time status transitions still arrive as before.

## Deliberately not included

The plan also suggested `.since(now - retention_window)` on the refetch path. Left out: order lifetime is set by the daemon's `expiration` tag (`order_events.rs:80`) and there is no client-side retention policy to derive a safe cutoff from. Any window picked here would risk silently hiding live orders — a correctness bug traded for a marginal saving. Worth revisiting only alongside a stated daemon retention guarantee.

## Test plan

- [x] New test asserts the filter carries the replay ceiling. Confirmed it fails against the old code (`limit` is `None`).
- [x] `cargo test` — 294 passed, 0 failed
- [x] `cargo clippy --all-targets` — no new warnings
- [ ] Manual: against a live node, confirm the book still populates fully and status transitions still arrive