### PR TITLE
fix(observability): log order-book stream lag

### DIFF
--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -175,6 +175,15 @@ pub struct OrderBook {
     tx: broadcast::Sender<Vec<OrderInfo>>,
 }
 
+/// Snapshots retained for a subscriber that has fallen behind.
+///
+/// A cold-start or refetch burst publishes far more updates than the UI reads
+/// in the same instant, so this is sized for that burst rather than for steady
+/// state. While each message is a full snapshot, overflowing is survivable —
+/// the newest snapshot supersedes the dropped ones. That stops being true if
+/// this channel ever carries deltas.
+const ORDER_STREAM_CAPACITY: usize = 64;
+
 impl Default for OrderBook {
     fn default() -> Self {
         Self::new()
@@ -183,7 +192,7 @@ impl Default for OrderBook {
 
 impl OrderBook {
     pub fn new() -> Self {
-        let (tx, _) = broadcast::channel(16);
+        let (tx, _) = broadcast::channel(ORDER_STREAM_CAPACITY);
         Self {
             orders: Arc::new(RwLock::new(Vec::new())),
             tx,
@@ -3638,7 +3647,15 @@ impl OrdersStream {
         loop {
             match self.rx.recv().await {
                 Ok(orders) => return Some(orders),
-                Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                // Each message is a full snapshot, so dropping some is
+                // survivable: the next one carries the whole book. Log it
+                // anyway — this is the only backpressure signal there is, and
+                // it stops being harmless the moment this channel carries
+                // deltas instead of snapshots.
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    log::warn!("[orders] order-book stream lagged, dropped {n} snapshots");
+                    continue;
+                }
                 Err(broadcast::error::RecvError::Closed) => return None,
             }
         }
@@ -3957,6 +3974,33 @@ mod tests {
             window.order.len() <= DEDUP_MAX_ENTRIES,
             "window grew past its bound: {}",
             window.order.len()
+        );
+    }
+
+    /// A subscriber that falls behind must resume from the retained window
+    /// rather than closing, and that window is `ORDER_STREAM_CAPACITY` deep.
+    #[tokio::test]
+    async fn a_lagged_orders_stream_resumes_from_the_retained_window() {
+        const SENT: usize = 100;
+        const _: () = assert!(SENT > ORDER_STREAM_CAPACITY, "the test must overflow the channel");
+
+        let book = OrderBook::new();
+        let mut stream = OrdersStream { rx: book.subscribe() };
+
+        // Publish without ever reading, so the receiver is forced to lag.
+        for n in 0..SENT {
+            book.set_orders(vec![dummy_order_info(&format!("order-{n}"))])
+                .await;
+        }
+
+        let recovered = stream
+            .next()
+            .await
+            .expect("a lagged stream must resume, not close");
+        assert_eq!(
+            recovered[0].id,
+            format!("order-{}", SENT - ORDER_STREAM_CAPACITY),
+            "should resume at the oldest snapshot still retained"
         );
     }
 


### PR DESCRIPTION
Phase 1, PR 1.7 of the optimization plan (#348). **Prerequisite for the Phase 3 delta work.**

## Problem

```rust
Err(broadcast::error::RecvError::Lagged(_)) => continue,
```

`OrdersStream::next` (`orders.rs:3506`) swallowed lag silently. The sibling `TradeUpdatesStream::next` logs the identical condition with a comment explaining why dropping is tolerable — the order-book stream just discarded it.

The channel held **16** snapshots (`orders.rs:186`). A cold start or a refetch publishes one snapshot per ingested event, far more than 16 before the UI reads any of them, so overflowing was the normal case rather than an exceptional one — and there was no way to see it happening.

## Change

- Lag is logged at warn, with the count.
- Capacity becomes a named `ORDER_STREAM_CAPACITY = 64`, sized for the burst rather than steady state.

Both the constant and the log record *why* dropping is currently survivable — every message is a full snapshot, so the newest supersedes anything lost — and that this stops being true the moment the channel carries deltas. That is the condition Phase 3 changes, which is why this PR comes first: the delta work needs lag to mean "resync", and it needs to be visible before it can mean anything.

Widening the window reduces how often lag happens; it does not fix the reason it happens, which is PR 2.1/2.2 (one broadcast per ingested event).

## Test plan

- [x] New test publishes 100 snapshots without reading, then asserts the subscriber resumes at the oldest **retained** snapshot rather than closing — which pins the retained-window depth behaviourally, not just the constant's value. Confirmed it fails to build against the old code.
- [x] `cargo test` — 294 passed, 0 failed
- [x] `cargo clippy --all-targets` — no new warnings

Note: the test covers the recovery contract and the window depth. The warn line itself is not asserted (no log capture in this suite) — it was verified by reading, and mirrors the already-reviewed trade-updates handler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved order-book stream recovery when a consumer falls behind, allowing updates to resume from the oldest retained snapshot.
  - Added warning information indicating how many snapshots were dropped during stream lag, improving visibility into missed updates.
  - Improved reliability when processing high-volume sequences of order-book snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->