### PR TITLE
fix(ui): build each theme once and make push init idempotent

### DIFF
--- a/lib/core/app_theme.dart
+++ b/lib/core/app_theme.dart
@@ -402,13 +402,19 @@ const _light = AppColors(
 
 // ── ThemeData factories ────────────────────────────────────────────────────────
 
-ThemeData buildDarkTheme() => _buildTheme(
+// Built once and shared. ThemeData is immutable, and `MaterialApp.router` asks
+// for both themes on every rebuild — which includes every locale change,
+// theme-mode change and route change.
+ThemeData? _darkTheme;
+ThemeData? _lightTheme;
+
+ThemeData buildDarkTheme() => _darkTheme ??= _buildTheme(
   brightness: Brightness.dark,
   colors: _dark,
   scaffold: const Color(0xFF1B1E28),
 );
 
-ThemeData buildLightTheme() => _buildTheme(
+ThemeData buildLightTheme() => _lightTheme ??= _buildTheme(
   brightness: Brightness.light,
   colors: _light,
   scaffold: const Color(0xFFFFFFFF),

--- a/lib/features/notifications/services/push_notification_service.dart
+++ b/lib/features/notifications/services/push_notification_service.dart
@@ -28,6 +28,9 @@ class PushNotificationService {
   FirebaseMessaging get _fcm => _fcmInstance ??= FirebaseMessaging.instance;
   String? _token;
   bool _initialized = false;
+
+  /// Guards [initialize] against a second run attaching duplicate listeners.
+  bool _initStarted = false;
   SharedPreferences? _cachedPrefs;
   final Set<String> _registeredTradePubkeys = {};
 
@@ -36,6 +39,13 @@ class PushNotificationService {
 
   Future<void> initialize({ProviderContainer? container}) async {
     if (!_isSupported) return;
+    // Steps 4, 5 and 7 below attach stream listeners that are never
+    // cancelled, so a second run would double every foreground notification
+    // and every token re-registration. This is a separate flag from
+    // `_initialized`, which means "there is a token to delete" and must stay
+    // false on the paths that bail out below.
+    if (_initStarted) return;
+    _initStarted = true;
 
     // Bail out if Firebase hasn't been initialized (placeholder firebase_options).
     try {

--- a/test/core/app_theme_test.dart
+++ b/test/core/app_theme_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro/core/app_theme.dart';
+
+void main() {
+  group('theme construction', () {
+    // MaterialApp.router rebuilds on every locale, theme-mode and route
+    // change, and it asks for both themes each time. ThemeData is immutable,
+    // so there is nothing to gain from rebuilding it.
+    test('returns the same light theme instance every time', () {
+      expect(identical(buildLightTheme(), buildLightTheme()), isTrue);
+    });
+
+    test('returns the same dark theme instance every time', () {
+      expect(identical(buildDarkTheme(), buildDarkTheme()), isTrue);
+    });
+
+    test('keeps the two themes distinct', () {
+      expect(identical(buildLightTheme(), buildDarkTheme()), isFalse);
+      expect(buildLightTheme().brightness, isNot(buildDarkTheme().brightness));
+    });
+  });
+}


### PR DESCRIPTION
Phase 1, PR 1.11 of the optimization plan (#348). Two unrelated lifecycle papercuts.

## 1. Themes were rebuilt on every frame that rebuilt the app

`MostroApp.build` called `buildLightTheme()` and `buildDarkTheme()` inline (`app.dart:54-55`), and each call constructed a full `ThemeData` — colour scheme, text theme, every component theme. `MaterialApp.router` rebuilds on every locale change, theme-mode change and route change, and asks for **both** themes each time, including the one not currently in use.

`ThemeData` is immutable, so both are now built once and shared. The memoization lives in `app_theme.dart` rather than in the widget, so the ~15 widget tests and the golden harness that call these directly get the same benefit.

## 2. `PushNotificationService.initialize` could attach duplicate listeners

Steps 4, 5 and 7 attach `onMessage`, `onMessageOpenedApp` and `onTokenRefresh` listeners, and none of the subscriptions is stored or cancelled. Nothing guarded against a second run: `_initialized` was only *written* at the end and read somewhere else entirely. A second call would double every foreground notification and every token re-registration.

`initialize` now claims a guard flag before its first `await` — at the top, because the awaits in between are exactly where a concurrent second caller would slip through.

The guard is a **separate flag** from `_initialized`, which was tempting to reuse but wrong: `_initialized` gates `_fcm.deleteToken()` in `unregisterAllTokens`, so it has to stay false on the paths that bail out early (Firebase unavailable, permission denied). Setting it at the top would make `unregisterAllTokens` call `deleteToken` against a Firebase that was never available.

Today `initialize` is called once, from a post-frame callback in `app.dart:32`, so this is a latent bug rather than an active one — but the guard is one line and the failure mode is user-visible duplicate notifications.

## Dropped from this PR

The plan also listed `escrowModeProvider`'s `while (true) yield await stream.next();` as missing a null/close guard. It isn't: unlike the orders stream, `EscrowModeStream::next` returns `Result` and **bails** on a closed channel (`rust/src/api/escrow.rs:172-182`), so the Dart side sees a thrown error, the loop unwinds, and the provider enters its error state. There is no null to check and no hot loop. Its non-`autoDispose` lifetime is likewise deliberate — it is an app-wide capability gate fed by a rare wake-up event (node switch), not a per-screen subscription. No change made.

## Test plan

- [x] New tests: each builder returns the same instance across calls, and the two themes stay distinct (different `brightness`). Confirmed they fail against the old code.
- [x] `flutter test` — **260 passed, 0 failed** (`main`: 257 passed, 0 failed; this PR adds 3 tests)
- [x] `flutter analyze` — **7 issues, all `info`-level deprecation notices, 0 errors** — identical to `main`

Both figures are measured after running the two generation steps CI runs first (`./scripts/frb-generate.sh`, `flutter gen-l10n`), since `lib/src/rust/` and `lib/l10n/app_localizations*.dart` are gitignored. An earlier revision of this description reported pre-existing failures and a broken `test/support/fake_trades.dart`; that was stale generated code in my own checkout, not a repo problem. See the correction comment below.
