### PR TITLE
docs: note that generated code goes stale on pull, not just on edit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,15 @@ bridged by flutter_rust_bridge.
   a mismatched CLI yields bindings that fail to compile, with an error that never mentions
   versions (see issue #205). `--check` verifies without generating.
 - FRB scans only `crate::api` → changes in `nostr/`, `crypto/`, `mostro/`, etc. need no regen.
+- **Regenerate after pulling, too — not just after your own edits.** `lib/src/rust/` and
+  `lib/l10n/app_localizations*.dart` are gitignored, so a `git pull` that brings in someone
+  else's `rust/src/api/` field or `.arb` key leaves your copies stale. CI regenerates both
+  before it analyses (`ci.yml` → `frb-generate.sh`, `flutter gen-l10n`), so green CI proves
+  nothing about your checkout. The failure is loud but misdirected — the analyzer blames
+  whatever *uses* the missing field, so a stale `TradeInfo` reads as a broken test helper
+  rather than as out-of-date bindings. If `flutter analyze` reports a field or l10n getter
+  that plainly exists in `rust/src/api/types.rs` or `lib/l10n/*.arb`, regenerate before
+  believing it.
 
 ## Transport (protocol v2)
 - **Daemon messages** (new-order, take, release, cancel, dispute, rate, invoice, restore):


### PR DESCRIPTION
## Why

`CLAUDE.md` says to run `./scripts/frb-generate.sh` after changing `rust/src/api/`. It doesn't say the same applies after **pulling** somebody else's change to that surface — and since `lib/src/rust/` and `lib/l10n/app_localizations*.dart` are gitignored (`.gitignore:9,13`), that is just as capable of leaving a checkout stale.

This bit me for real while working on the Phase 1 optimization PRs (#348). A stale local `TradeInfo` was missing `peer_rating` / `peer_reviews` / `peer_days` (added in `rust/src/api/types.rs:271-275`, issue #305), which produced 27 analyzer errors and 10 test files that would not load.

What made it costly is that **the error points at the wrong file**. The analyzer blames whatever *uses* the missing field, so the top hit was `test/support/fake_trades.dart` passing named parameters "that aren't defined" — which reads exactly like a broken test helper, and nothing like out-of-date bindings. I reported it as pre-existing repo breakage before spotting the real cause; the repo was healthy the whole time (`main`: 257 tests passing, 0 analyzer errors, once regenerated).

CI can't catch this either, in either direction: it regenerates both artifacts before analysing (`ci.yml:109,116` → `:130,133`), so green CI proves nothing about anyone's working copy.

## Change

Four lines under **Generated code (don't corrupt it)**: regenerate after pulling as well as after editing, why CI's green tick doesn't cover you, and the recognition rule — if `flutter analyze` reports a field or l10n getter that plainly exists in `rust/src/api/types.rs` or `lib/l10n/*.arb`, regenerate before believing it.

## Test plan

- [x] Documentation only — no code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance to regenerate generated code after pulling changes.
  * Clarified that stale generated files can cause misleading analyzer errors, even when CI passes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->