### PR TITLE
perf(ui): look orders up by id instead of scanning the whole book

### DIFF
--- a/lib/features/chat/widgets/trade_state_header.dart
+++ b/lib/features/chat/widgets/trade_state_header.dart
@@ -31,8 +31,7 @@ final chatTradeOrderProvider =
   // Re-resolve when the polled status changes (e.g. active → fiatSent).
   ref.watch(tradeStatusProvider(orderId));
 
-  final book = ref.watch(orderBookProvider).valueOrNull;
-  final fromBook = book?.where((o) => o.id == orderId).firstOrNull;
+  final fromBook = ref.watch(orderByIdProvider(orderId));
   if (fromBook != null) return fromBook;
 
   try {

--- a/lib/features/home/providers/home_order_providers.dart
+++ b/lib/features/home/providers/home_order_providers.dart
@@ -108,6 +108,53 @@ class OrderItem {
     return v == v.truncateToDouble() ? v.toInt().toString() : v.toString();
   }
 
+  /// Value equality, so a screen watching one order can tell whether *its*
+  /// order actually moved. Every book emission rebuilds every [OrderItem],
+  /// so identity comparison always reports a change and
+  /// [orderByIdProvider]'s `select` would never filter anything out.
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is OrderItem &&
+          other.id == id &&
+          other.kind == kind &&
+          other.fiatAmount == fiatAmount &&
+          other.fiatAmountMin == fiatAmountMin &&
+          other.fiatAmountMax == fiatAmountMax &&
+          other.fiatCode == fiatCode &&
+          other.paymentMethod == paymentMethod &&
+          other.premium == premium &&
+          other.creatorPubkey == creatorPubkey &&
+          other.createdAt == createdAt &&
+          other.expiresAt == expiresAt &&
+          other.rating == rating &&
+          other.tradeCount == tradeCount &&
+          other.daysActive == daysActive &&
+          other.status == status &&
+          other.amountSats == amountSats &&
+          other.isMine == isMine;
+
+  @override
+  int get hashCode => Object.hashAll([
+        id,
+        kind,
+        fiatAmount,
+        fiatAmountMin,
+        fiatAmountMax,
+        fiatCode,
+        paymentMethod,
+        premium,
+        creatorPubkey,
+        createdAt,
+        expiresAt,
+        rating,
+        tradeCount,
+        daysActive,
+        status,
+        amountSats,
+        isMine,
+      ]);
+
   /// Map a Rust-bridge [OrderInfo] to an [OrderItem] for display.
   factory OrderItem.fromInfo(OrderInfo info) => OrderItem(
         id: info.id,
@@ -160,6 +207,25 @@ final orderBookProvider = StreamProvider.autoDispose<List<OrderItem>>((ref) asyn
     if (orders == null) break;
     yield orders.map(OrderItem.fromInfo).toList();
   }
+});
+
+/// The live book indexed by order id, rebuilt once per emission.
+///
+/// Screens that care about a single order used to scan the whole list for it,
+/// on every rebuild — an O(orders) walk per screen per relay event.
+final orderBookIndexProvider = Provider.autoDispose<Map<String, OrderItem>>((ref) {
+  final orders = ref.watch(orderBookProvider).valueOrNull ?? const <OrderItem>[];
+  return {for (final order in orders) order.id: order};
+});
+
+/// One order from the live book, or null when it is not in it.
+///
+/// The `select` is what makes this worth having: a screen watching one order
+/// rebuilds only when *that* order changes, not on every book emission. It
+/// relies on [OrderItem]'s value equality.
+final orderByIdProvider =
+    Provider.autoDispose.family<OrderItem?, String>((ref, orderId) {
+  return ref.watch(orderBookIndexProvider.select((index) => index[orderId]));
 });
 
 /// Filtered orders based on active tab and all filter providers.

--- a/lib/features/order/screens/my_order_screen.dart
+++ b/lib/features/order/screens/my_order_screen.dart
@@ -95,8 +95,7 @@ class _MyOrderScreenState extends ConsumerState<MyOrderScreen> {
     final liveStatus =
         ref.watch(tradeStatusProvider(widget.orderId)).valueOrNull;
 
-    final orders = ref.watch(orderBookProvider).valueOrNull ?? [];
-    var order = orders.where((o) => o.id == widget.orderId).firstOrNull;
+    var order = ref.watch(orderByIdProvider(widget.orderId));
     // Fallback to the persisted trade DB when the order is no longer in the
     // in-memory order book (e.g. it was taken and moved out of pending).
     if (order == null) {

--- a/lib/features/order/screens/take_order_screen.dart
+++ b/lib/features/order/screens/take_order_screen.dart
@@ -207,8 +207,7 @@ class _TakeOrderScreenState extends ConsumerState<TakeOrderScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final orders = ref.watch(orderBookProvider).valueOrNull ?? [];
-    final order = orders.where((o) => o.id == widget.orderId).firstOrNull;
+    final order = ref.watch(orderByIdProvider(widget.orderId));
     final theme = Theme.of(context);
     final colors = theme.extension<AppColors>();
     final green = colors?.mostroGreen ?? const Color(0xFF8CC63F);

--- a/lib/features/trades/screens/trade_detail_screen.dart
+++ b/lib/features/trades/screens/trade_detail_screen.dart
@@ -539,8 +539,7 @@ class _TradeDetailScreenState extends ConsumerState<TradeDetailScreen> {
     }
 
     // Look up order details from the live order book.
-    final allOrders = ref.watch(orderBookProvider).valueOrNull ?? [];
-    final order = allOrders.where((o) => o.id == widget.orderId).firstOrNull;
+    final order = ref.watch(orderByIdProvider(widget.orderId));
 
     // Counterpart (taker) reputation snapshot persisted from the daemon's
     // follow-up Peer DM (#305). Read via tradeInfoProvider (not the polling

--- a/test/features/home/order_by_id_provider_test.dart
+++ b/test/features/home/order_by_id_provider_test.dart
@@ -1,0 +1,55 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro/features/home/providers/home_order_providers.dart';
+
+import '../../support/fake_orders.dart';
+import '../../support/provider_harness.dart';
+
+/// Let the stream event reach the provider and its dependents.
+Future<void> settle() =>
+    Future<void>.delayed(const Duration(milliseconds: 20));
+
+void main() {
+  group('orderByIdProvider', () {
+    test('resolves an order by id and null for an unknown one', () async {
+      final container = createContainer(overrides: [
+        orderBookProvider.overrideWith(
+          (ref) => Stream.value([fakeOrder(id: 'a'), fakeOrder(id: 'b')]),
+        ),
+      ]);
+      container.listen(orderBookProvider, (_, __) {});
+      await container.read(orderBookProvider.future);
+
+      expect(container.read(orderByIdProvider('a'))?.id, 'a');
+      expect(container.read(orderByIdProvider('missing')), isNull);
+    });
+
+    test('does not rebuild a screen whose order did not change', () async {
+      final book = StreamController<List<OrderItem>>();
+      addTearDown(book.close);
+
+      final container = createContainer(overrides: [
+        orderBookProvider.overrideWith((ref) => book.stream),
+      ]);
+
+      var rebuilds = 0;
+      container.listen(orderByIdProvider('a'), (_, __) => rebuilds++);
+
+      book.add([fakeOrder(id: 'a', premium: 1), fakeOrder(id: 'b', premium: 1)]);
+      await settle();
+      expect(rebuilds, 1, reason: 'the first value is a change');
+
+      // A different order moves. Watching one order must not repaint the
+      // screens watching the others — the whole point of the index.
+      book.add([fakeOrder(id: 'a', premium: 1), fakeOrder(id: 'b', premium: 9)]);
+      await settle();
+      expect(rebuilds, 1, reason: 'order a is untouched');
+
+      // Its own order moving must still come through.
+      book.add([fakeOrder(id: 'a', premium: 5), fakeOrder(id: 'b', premium: 9)]);
+      await settle();
+      expect(rebuilds, 2, reason: 'order a changed');
+    });
+  });
+}


### PR DESCRIPTION
Phase 2, PR 2.7 of the optimization plan (#348). Independent of the other Phase 2 PRs.

## Problem

Four screens need exactly one order, and each found it by watching the **entire** order book and walking it:

```dart
final orders = ref.watch(orderBookProvider).valueOrNull ?? [];
final order = orders.where((o) => o.id == widget.orderId).firstOrNull;
```

- `take_order_screen.dart:210`
- `my_order_screen.dart:98`
- `trade_detail_screen.dart:542`
- `trade_state_header.dart:34` (the chat header)

So each screen paid an O(orders) scan **and a full rebuild** on every relay event, regardless of what changed — while displaying a single order that had usually not moved at all. On a book of a few thousand orders, opening a chat means re-scanning it every time anything anywhere updates.

## Change

- `orderBookIndexProvider` — the book keyed by id, built once per emission.
- `orderByIdProvider` — a family that `select`s one entry out of that index.

Screens now watch only their own order.

### The part that makes it work

`select` compares the selected value to decide whether to notify. `OrderItem` had no `==`, so comparison fell back to identity — and since every book emission rebuilds every `OrderItem`, identity always reports a change and `select` would filter nothing.

So this PR adds value equality to `OrderItem`. I deliberately left that out of #357, where it would have been speculative; here it is load-bearing, and the test pins exactly what it buys.

## Test plan

- [x] New test: resolves an order by id, and returns null for an unknown one.
- [x] New test — the one that matters: a screen watching order `a` is **not** rebuilt when order `b` changes, and **is** rebuilt when `a` itself changes. Without value equality on `OrderItem` the first assertion fails, so this test also guards the equality implementation against someone trimming it later.
- [x] `flutter test` — 259 passed, 0 failed (`main`: 257; this PR adds 2)
- [x] `flutter analyze` — 7 issues, identical to `main` (pre-existing `info` deprecations)
- [ ] Manual: open a chat and a trade detail while the book is busy, confirm the values still track the order