### PR TITLE
fix(storage): key notifications by id and commit bulk updates once

### DIFF
--- a/lib/features/notifications/providers/notifications_provider.dart
+++ b/lib/features/notifications/providers/notifications_provider.dart
@@ -22,7 +22,13 @@ class SembastNotificationsStore {
         _pathOverride = path;
 
   static const _dbName = 'notifications.db';
-  static const _storeName = 'notifications';
+  /// The int-keyed store this feature shipped with.
+  static const _legacyStoreName = 'notifications';
+
+  /// Records keyed by notification id. A separate store name, not a re-typed
+  /// view of the old one: the two must not share physical records, or
+  /// migrating out of the old shape would delete what it just wrote.
+  static const _storeName = 'notifications_v2';
 
   /// Test seam: when set, bypasses platform factory/path resolution (e.g. an
   /// in-memory Sembast factory for restart/replay tests).
@@ -31,7 +37,14 @@ class SembastNotificationsStore {
 
   Database? _db;
   Completer<Database>? _opening;
-  final _store = intMapStoreFactory.store(_storeName);
+  /// Keyed by notification id. Before this, the store used auto-incrementing
+  /// integer keys and every write looked its record up with a `Finder` — a
+  /// full-store scan per save, and O(n) scans for an O(n) bulk update.
+  final _store = StoreRef<String, Map<String, Object?>>(_storeName);
+
+  /// The int-keyed shape this store used to have. Only read, and only once
+  /// per database, by [_migrateLegacyRecords].
+  final _legacyStore = intMapStoreFactory.store(_legacyStoreName);
 
   /// Tombstone / processed-event ledger: ids of externally-sourced events that
   /// have already been handled. It survives deletion of the notification record,
@@ -54,6 +67,7 @@ class SembastNotificationsStore {
         final dir = await appDataDirPath();
         db = await databaseFactoryIo.openDatabase(p.join(dir, _dbName));
       }
+      await _migrateLegacyRecords(db);
       _db = db;
       _opening!.complete(db);
       return db;
@@ -62,6 +76,27 @@ class SembastNotificationsStore {
       _opening = null;
       rethrow;
     }
+  }
+
+  /// Re-key records written by the previous int-keyed store.
+  ///
+  /// Reading an int-keyed record through a `StoreRef<String, ...>` throws, so
+  /// without this an upgrade would either lose the user's notification history
+  /// or fail on open. Runs inside one transaction and clears the old records,
+  /// so it is a no-op from the second launch onwards.
+  Future<void> _migrateLegacyRecords(Database db) async {
+    final legacy = await _legacyStore.find(db);
+    if (legacy.isEmpty) return;
+    await db.transaction((txn) async {
+      for (final record in legacy) {
+        final value = Map<String, Object?>.from(record.value);
+        final id = value['id'];
+        if (id is String) {
+          await _store.record(id).put(txn, value);
+        }
+      }
+      await _legacyStore.delete(txn);
+    });
   }
 
   Future<List<NotificationModel>> loadAll() async {
@@ -77,16 +112,24 @@ class SembastNotificationsStore {
     await _upsert(await _open(), notification);
   }
 
+  /// Persist every notification in [notifications] in a single transaction.
+  ///
+  /// Bulk read-status updates used to fire one independent, un-awaited write
+  /// per notification, each committing separately.
+  Future<void> saveAll(List<NotificationModel> notifications) async {
+    if (notifications.isEmpty) return;
+    final db = await _open();
+    await db.transaction((txn) async {
+      for (final notification in notifications) {
+        await _upsert(txn, notification);
+      }
+    });
+  }
+
   Future<void> _upsert(DatabaseClient client, NotificationModel notification) async {
-    final json = Map<String, dynamic>.from(notification.toJson())
+    final json = Map<String, Object?>.from(notification.toJson())
       ..removeWhere((_, v) => v == null);
-    final finder = Finder(filter: Filter.equals('id', notification.id));
-    final existing = await _store.findFirst(client, finder: finder);
-    if (existing != null) {
-      await _store.update(client, json, finder: finder);
-    } else {
-      await _store.add(client, json);
-    }
+    await _store.record(notification.id).put(client, json);
   }
 
   /// Records [notification] and marks its source event processed in a single
@@ -109,7 +152,7 @@ class SembastNotificationsStore {
 
   Future<void> deleteRecord(String id) async {
     final db = await _open();
-    await _store.delete(db, finder: Finder(filter: Filter.equals('id', id)));
+    await _store.record(id).delete(db);
   }
 
   /// Clears the visible notification records but deliberately keeps the
@@ -241,13 +284,12 @@ class NotificationsNotifier extends StateNotifier<List<NotificationModel>> {
 
   void markAllAsRead() {
     state = [for (final n in state) n.copyWith(isRead: true)];
-    // Persist each updated record; fire-and-forget is acceptable for bulk
-    // read-status updates since ordering doesn't matter here.
-    for (final n in state) {
-      store?.save(n).catchError((Object e) {
-        debugPrint('NotificationsNotifier: failed to persist markAllAsRead: $e');
-      });
-    }
+    // One transaction for the batch, rather than one independent commit per
+    // notification. Still fire-and-forget: ordering does not matter here, and
+    // the in-memory state is already updated.
+    store?.saveAll(state).catchError((Object e) {
+      debugPrint('NotificationsNotifier: failed to persist markAllAsRead: \$e');
+    });
   }
 
   Future<void> delete(String id) async {

--- a/test/features/notifications/notifications_store_test.dart
+++ b/test/features/notifications/notifications_store_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro/features/notifications/models/notification_model.dart';
+import 'package:mostro/features/notifications/providers/notifications_provider.dart';
+import 'package:sembast/sembast_memory.dart';
+
+NotificationModel _note(String id, {bool isRead = false}) => NotificationModel(
+      id: id,
+      type: NotificationType.system,
+      title: 'title-$id',
+      message: 'message-$id',
+      timestamp: DateTime.utc(2026, 1, 1),
+      isRead: isRead,
+    );
+
+void main() {
+  late DatabaseFactory factory;
+  late String path;
+  var dbCounter = 0;
+
+  setUp(() {
+    // MemoryFs, not plain memory: a plain in-memory database is discarded on
+    // close, so the migration test could never reopen what it wrote.
+    factory = databaseFactoryMemoryFs;
+    path = 'notifications-test-${dbCounter++}.db';
+  });
+
+  SembastNotificationsStore openStore() =>
+      SembastNotificationsStore(factory: factory, path: path);
+
+  test('saving the same id twice leaves one record', () async {
+    final store = openStore();
+
+    await store.save(_note('a'));
+    await store.save(_note('a', isRead: true));
+
+    final all = await store.loadAll();
+    expect(all, hasLength(1));
+    expect(all.single.isRead, isTrue);
+  });
+
+  test('deleting by id removes only that record', () async {
+    final store = openStore();
+    await store.save(_note('a'));
+    await store.save(_note('b'));
+
+    await store.deleteRecord('a');
+
+    expect((await store.loadAll()).map((n) => n.id), ['b']);
+  });
+
+  test('saveAll marks a whole batch read in one commit', () async {
+    final store = openStore();
+    for (final id in ['a', 'b', 'c']) {
+      await store.save(_note(id));
+    }
+
+    await store.saveAll([
+      for (final n in await store.loadAll()) n.copyWith(isRead: true),
+    ]);
+
+    final all = await store.loadAll();
+    expect(all, hasLength(3));
+    expect(all.every((n) => n.isRead), isTrue);
+  });
+
+  /// Records written before the store was keyed by id live under
+  /// auto-incrementing integer keys. Reading those with a String-keyed
+  /// `StoreRef` throws, so without a migration a user upgrading would lose
+  /// their notification history — or crash on open.
+  test('adopts records left by the previously int-keyed store', () async {
+    final db = await factory.openDatabase(path);
+    final legacy = intMapStoreFactory.store('notifications');
+    await legacy.add(db, {
+      'id': 'legacy-1',
+      'type': 'system',
+      'title': 'from before',
+      'message': 'still here',
+      'timestamp': DateTime.utc(2026, 1, 1).millisecondsSinceEpoch,
+      'isRead': false,
+    });
+    await db.close();
+
+    final all = await openStore().loadAll();
+
+    expect(all.map((n) => n.id), ['legacy-1']);
+    expect(all.single.title, 'from before');
+  });
+}


### PR DESCRIPTION
Phase 2, PR 2.9 of the optimization plan (#348). Independent of the other Phase 2 PRs.

## Problem

The notification store used `intMapStoreFactory` — auto-incrementing integer keys — while every operation actually addresses records by **notification id**. So each one had to search:

```dart
final finder = Finder(filter: Filter.equals('id', notification.id));
final existing = await _store.findFirst(client, finder: finder);
```

A full-store scan per save (`:80-89`) and per delete (`:110`).

`markAllAsRead` (`:242-250`) compounded it: one independent, **un-awaited** `save()` per notification, each doing its own scan and committing its own transaction. Marking N notifications read cost N scans and N commits, all on the UI isolate.

## Change

- Records are keyed by notification id — `put`/`delete` by key, no scan.
- New `saveAll` commits a batch in **one** transaction; `markAllAsRead` uses it.

## The migration, and two traps in it

The keyed records live under a **new store name** (`notifications_v2`) rather than a re-typed view of the old one. Both alternatives I tried first were wrong, and both failed loudly in tests:

1. Reading an int-keyed record through a `StoreRef<String, …>` throws `type 'int' is not a subtype of type 'String'`. Without a migration, an upgrading user either loses their notification history or crashes on open.
2. Pointing the old and new `StoreRef`s at the **same** physical store makes the migration's cleanup (`_legacyStore.delete(txn)`) wipe the records it just wrote — the store name is the same, only the Dart type differs.

`_migrateLegacyRecords` runs once per database inside a transaction, re-keys existing records, and clears the old store. From the second launch it is a no-op (an empty `find`).

The processed-events tombstone ledger is untouched — it was already correctly keyed by String.

## Test plan

- [x] New test: saving the same id twice leaves one record (the upsert contract that the `Finder` used to provide).
- [x] New test: deleting by id removes only that record.
- [x] New test: `saveAll` marks a whole batch read.
- [x] New test: **records written by the old int-keyed store survive the upgrade.** This is the one that matters — it caught both traps above, and it is the difference between a perf fix and silent data loss for every existing user.
- [x] `flutter test` — 261 passed, 0 failed (`main`: 257; this PR adds 4)
- [x] `flutter analyze` — 7 issues, identical to `main`
- [ ] Manual: upgrade over an existing install with notifications present, confirm they are still listed and still marked read correctly