### PR TITLE
perf(chat): O(1) dedupe, debounced mark-read, and no scroll hijack

### DIFF
--- a/lib/features/chat/screens/chat_room_screen.dart
+++ b/lib/features/chat/screens/chat_room_screen.dart
@@ -15,24 +15,15 @@ import 'package:mostro/shared/widgets/nym_avatar.dart';
 import 'package:mostro/src/rust/api/messages.dart' as messages_api;
 import 'package:mostro/src/rust/api/types.dart' as rust_types;
 
-/// Route: /chat_room/:orderId
-///
-/// Individual trade chat room screen with message history, info panels,
-/// and a composition bar.
-///
-/// The Rust bridge is fully wired:
-/// - [messages_api.getMessages] seeds message history on open.
-/// - [messages_api.sendMessage] encrypts and publishes outbound messages via
-///   NIP-59 gift wrap, directed to the ECDH shared-key pubkey per the Mostro
-///   P2P chat protocol.
-/// - [incomingMessageProvider] delivers real-time incoming messages from the
-///   Rust `subscribe_incoming_chat` background task.
-/// - [messages_api.markAsRead] resets unread count when the room is entered.
 /// How close to the end of the list still counts as "following along".
 ///
 /// Roughly one message bubble, so a reader who has scrolled up by even one
 /// message is left where they are.
 const double kFollowThresholdPixels = 80;
+
+/// How long a burst of incoming messages may stay quiet before the room is
+/// marked read once, instead of once per message.
+const Duration kMarkReadDebounce = Duration(milliseconds: 400);
 
 /// Whether an arriving message should scroll the list.
 ///
@@ -45,6 +36,20 @@ bool isPinnedToBottom({
 }) =>
     maxScrollExtent - offset <= kFollowThresholdPixels;
 
+/// Route: /chat_room/:orderId
+///
+/// Individual trade chat room screen with message history, info panels,
+/// and a composition bar.
+///
+/// The Rust bridge is fully wired:
+/// - [messages_api.getMessages] seeds message history on open.
+/// - [messages_api.sendMessage] encrypts and publishes outbound messages as
+///   a Mostro chat envelope (kind 14 signed with the shared key, NIP-44
+///   inner kind 1 signed by the trade key), directed to the ECDH shared-key
+///   pubkey per the Mostro P2P chat protocol.
+/// - [incomingMessageProvider] delivers real-time incoming messages from the
+///   Rust `subscribe_incoming_chat` background task.
+/// - [messages_api.markAsRead] resets unread count when the room is entered.
 class ChatRoomScreen extends ConsumerStatefulWidget {
   const ChatRoomScreen({
     super.key,
@@ -74,6 +79,15 @@ class _ChatRoomScreenState extends ConsumerState<ChatRoomScreen> {
   /// fire one bridge call per message.
   Timer? _markReadDebounce;
 
+  /// Rooms notifier captured while the widget is live, so a pending
+  /// mark-read can still be flushed from [dispose], where `ref` is unusable.
+  ChatRoomsNotifier? _roomsNotifier;
+
+  /// Follow animations still in flight (see [_scrollToBottom]). While one
+  /// runs the list lags behind the extent it is heading for, so the position
+  /// alone would misreport a reader who never left the bottom.
+  int _followAnimations = 0;
+
   bool _historyLoaded = false;
 
   final ScrollController _scrollController = ScrollController();
@@ -87,7 +101,7 @@ class _ChatRoomScreenState extends ConsumerState<ChatRoomScreen> {
 
   @override
   void dispose() {
-    _markReadDebounce?.cancel();
+    _flushMarkRead();
     _scrollController.dispose();
     super.dispose();
   }
@@ -124,10 +138,15 @@ class _ChatRoomScreenState extends ConsumerState<ChatRoomScreen> {
     }
   }
 
-  Future<void> _markRead() async {
+  Future<void> _markRead() =>
+      _markReadWith(ref.read(chatRoomsNotifierProvider.notifier));
+
+  /// [rooms] is passed in rather than read from `ref` so [_flushMarkRead]
+  /// can run it from [dispose].
+  Future<void> _markReadWith(ChatRoomsNotifier? rooms) async {
     try {
       await messages_api.markAsRead(tradeId: widget.orderId);
-      ref.read(chatRoomsNotifierProvider.notifier).markRead(widget.orderId);
+      if (rooms != null && rooms.mounted) rooms.markRead(widget.orderId);
     } catch (e) {
       debugPrint('[chat] markAsRead failed: $e');
     }
@@ -143,7 +162,12 @@ class _ChatRoomScreenState extends ConsumerState<ChatRoomScreen> {
         content: text.trim(),
       );
       if (!mounted) return;
-      setState(() => _messages.add(sent));
+      // Record the id here too: every path that appends to [_messages] must
+      // go through [_seenIds], or an echo of this send arriving on the
+      // stream would render it twice.
+      if (_seenIds.add(sent.id)) {
+        setState(() => _messages.add(sent));
+      }
       _scrollToBottom();
       ref.read(chatRoomsNotifierProvider.notifier).upsertRoom(
             _buildRoomPreview(
@@ -178,7 +202,9 @@ class _ChatRoomScreenState extends ConsumerState<ChatRoomScreen> {
     // _loadHistory).
     if (msg.messageType != rust_types.MessageType.peer) return;
     if (!_seenIds.add(msg.id)) return; // deduplicate
-    // Read the scroll position before the new message changes the extent.
+    // Decide from where the reader is *before* the message is added. The
+    // extent only grows at the next layout, so reading here keeps the
+    // decision about the list they were looking at, whenever that lands.
     final wasAtBottom = _isPinnedToBottom();
     setState(() => _messages.add(msg));
     // Only follow the conversation if the user was already at the bottom;
@@ -198,6 +224,9 @@ class _ChatRoomScreenState extends ConsumerState<ChatRoomScreen> {
 
   /// Whether the list is close enough to the end to keep following it.
   bool _isPinnedToBottom() {
+    // A follow animation still in flight means the reader was at the bottom
+    // and only the animation is behind; do not mistake that for scrolling up.
+    if (_followAnimations > 0) return true;
     if (!_scrollController.hasClients) return true;
     final position = _scrollController.position;
     return isPinnedToBottom(
@@ -208,21 +237,42 @@ class _ChatRoomScreenState extends ConsumerState<ChatRoomScreen> {
 
   /// Mark the room read once the burst settles, instead of once per message.
   void _scheduleMarkRead() {
+    _roomsNotifier = ref.read(chatRoomsNotifierProvider.notifier);
     _markReadDebounce?.cancel();
-    _markReadDebounce = Timer(const Duration(milliseconds: 400), () {
+    _markReadDebounce = Timer(kMarkReadDebounce, () {
       if (mounted) _markRead();
     });
   }
 
+  /// Runs a pending mark-read now instead of dropping it: the reader saw the
+  /// burst, and leaving within the debounce window must not leave the room
+  /// flagged unread until their next visit.
+  void _flushMarkRead() {
+    final pending = _markReadDebounce;
+    _markReadDebounce = null;
+    if (pending == null || !pending.isActive) return;
+    pending.cancel();
+    unawaited(_markReadWith(_roomsNotifier));
+  }
+
   void _scrollToBottom() {
+    // Counted from the request, not the frame, so a message arriving before
+    // the post-frame callback runs already sees a follow in progress.
+    _followAnimations++;
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (_scrollController.hasClients) {
-        _scrollController.animateTo(
-          _scrollController.position.maxScrollExtent,
-          duration: const Duration(milliseconds: 200),
-          curve: Curves.easeOut,
-        );
+      if (!mounted || !_scrollController.hasClients) {
+        _followAnimations--;
+        return;
       }
+      // Interrupting an earlier animation (a newer follow, or the reader
+      // dragging) completes its future, so the counter always drains.
+      _scrollController
+          .animateTo(
+            _scrollController.position.maxScrollExtent,
+            duration: const Duration(milliseconds: 200),
+            curve: Curves.easeOut,
+          )
+          .whenComplete(() => _followAnimations--);
     });
   }
 

--- a/lib/features/chat/screens/chat_room_screen.dart
+++ b/lib/features/chat/screens/chat_room_screen.dart
@@ -28,6 +28,23 @@ import 'package:mostro/src/rust/api/types.dart' as rust_types;
 /// - [incomingMessageProvider] delivers real-time incoming messages from the
 ///   Rust `subscribe_incoming_chat` background task.
 /// - [messages_api.markAsRead] resets unread count when the room is entered.
+/// How close to the end of the list still counts as "following along".
+///
+/// Roughly one message bubble, so a reader who has scrolled up by even one
+/// message is left where they are.
+const double kFollowThresholdPixels = 80;
+
+/// Whether an arriving message should scroll the list.
+///
+/// Pinning is the reason this is a decision at all: auto-scrolling
+/// unconditionally yanks a reader away from older messages every time the
+/// counterparty types, and a history burst starts one animation per message.
+bool isPinnedToBottom({
+  required double offset,
+  required double maxScrollExtent,
+}) =>
+    maxScrollExtent - offset <= kFollowThresholdPixels;
+
 class ChatRoomScreen extends ConsumerStatefulWidget {
   const ChatRoomScreen({
     super.key,
@@ -48,6 +65,15 @@ class _ChatRoomScreenState extends ConsumerState<ChatRoomScreen> {
 
   /// Message list seeded from bridge history, then appended via stream.
   final List<rust_types.ChatMessage> _messages = [];
+
+  /// Ids already in [_messages]. A replayed envelope is common, and scanning
+  /// the list for every incoming message made dedup O(history) per message.
+  final Set<String> _seenIds = {};
+
+  /// Coalesces mark-read across a burst. A history replay would otherwise
+  /// fire one bridge call per message.
+  Timer? _markReadDebounce;
+
   bool _historyLoaded = false;
 
   final ScrollController _scrollController = ScrollController();
@@ -61,6 +87,7 @@ class _ChatRoomScreenState extends ConsumerState<ChatRoomScreen> {
 
   @override
   void dispose() {
+    _markReadDebounce?.cancel();
     _scrollController.dispose();
     super.dispose();
   }
@@ -83,7 +110,7 @@ class _ChatRoomScreenState extends ConsumerState<ChatRoomScreen> {
           // must never surface here — replying would go to the counterparty,
           // not the solver (PR #254 review).
           if (msg.messageType != rust_types.MessageType.peer) continue;
-          if (!_messages.any((m) => m.id == msg.id)) {
+          if (_seenIds.add(msg.id)) {
             _messages.add(msg);
           }
         }
@@ -150,10 +177,15 @@ class _ChatRoomScreenState extends ConsumerState<ChatRoomScreen> {
     // Dispute-channel traffic never belongs in the peer room (see
     // _loadHistory).
     if (msg.messageType != rust_types.MessageType.peer) return;
-    if (_messages.any((m) => m.id == msg.id)) return; // deduplicate
+    if (!_seenIds.add(msg.id)) return; // deduplicate
+    // Read the scroll position before the new message changes the extent.
+    final wasAtBottom = _isPinnedToBottom();
     setState(() => _messages.add(msg));
-    _scrollToBottom();
-    _markRead();
+    // Only follow the conversation if the user was already at the bottom;
+    // otherwise an arriving message yanks them away from what they were
+    // reading, and a burst starts one animation per message.
+    if (wasAtBottom) _scrollToBottom();
+    _scheduleMarkRead();
     ref.read(chatRoomsNotifierProvider.notifier).upsertRoom(
           _buildRoomPreview(
             lastMsg: msg,
@@ -163,6 +195,24 @@ class _ChatRoomScreenState extends ConsumerState<ChatRoomScreen> {
   }
 
   // ── Helpers ───────────────────────────────────────────────────────────────
+
+  /// Whether the list is close enough to the end to keep following it.
+  bool _isPinnedToBottom() {
+    if (!_scrollController.hasClients) return true;
+    final position = _scrollController.position;
+    return isPinnedToBottom(
+      offset: position.pixels,
+      maxScrollExtent: position.maxScrollExtent,
+    );
+  }
+
+  /// Mark the room read once the burst settles, instead of once per message.
+  void _scheduleMarkRead() {
+    _markReadDebounce?.cancel();
+    _markReadDebounce = Timer(const Duration(milliseconds: 400), () {
+      if (mounted) _markRead();
+    });
+  }
 
   void _scrollToBottom() {
     WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/test/features/chat/chat_autoscroll_test.dart
+++ b/test/features/chat/chat_autoscroll_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro/features/chat/screens/chat_room_screen.dart';
+
+void main() {
+  group('isPinnedToBottom', () {
+    test('follows the conversation when already at the end', () {
+      expect(isPinnedToBottom(offset: 1000, maxScrollExtent: 1000), isTrue);
+    });
+
+    test('still follows within one bubble of the end', () {
+      expect(
+        isPinnedToBottom(
+          offset: 1000 - kFollowThresholdPixels,
+          maxScrollExtent: 1000,
+        ),
+        isTrue,
+      );
+    });
+
+    test('leaves a reader who has scrolled up where they are', () {
+      expect(
+        isPinnedToBottom(offset: 400, maxScrollExtent: 1000),
+        isFalse,
+        reason: 'an arriving message must not yank the reader to the bottom',
+      );
+    });
+
+    test('treats an unscrollable list as pinned', () {
+      expect(isPinnedToBottom(offset: 0, maxScrollExtent: 0), isTrue);
+    });
+  });
+}

--- a/test/features/chat/chat_room_screen_test.dart
+++ b/test/features/chat/chat_room_screen_test.dart
@@ -1,0 +1,245 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro/core/app_theme.dart';
+import 'package:mostro/features/chat/providers/chat_providers.dart';
+import 'package:mostro/features/chat/screens/chat_room_screen.dart';
+import 'package:mostro/features/chat/widgets/message_bubble.dart';
+import 'package:mostro/features/chat/widgets/trade_state_header.dart';
+import 'package:mostro/features/trades/providers/trades_providers.dart';
+import 'package:mostro/l10n/app_localizations.dart';
+import 'package:mostro/shared/utils/platform_int64.dart';
+import 'package:mostro/src/rust/api/types.dart' as rust_types;
+
+import '../../support/provider_harness.dart';
+
+const _orderId = 'order-chat';
+
+/// Tall enough that one bubble exceeds [kFollowThresholdPixels], so a list
+/// that has not finished animating to a new bubble reads as "not at the
+/// bottom" by position alone — the case a follow animation must not lose.
+const _tallContent = 'line one\nline two\nline three\nline four\nline five';
+
+rust_types.ChatMessage _peerMessage(int n, {String? id}) =>
+    rust_types.ChatMessage(
+      id: id ?? 'msg-$n',
+      tradeId: _orderId,
+      senderPubkey: 'peer',
+      content: '$_tallContent #$n',
+      messageType: rust_types.MessageType.peer,
+      isMine: false,
+      isRead: false,
+      hasAttachment: false,
+      createdAt: intToPlatformInt64(1000 + n),
+    );
+
+/// Pumps [ChatRoomScreen] without `RustLib.init()`, following the
+/// convention of `trade_detail_screen_test.dart`: the screen's own bridge
+/// calls (`getMessages`, `markAsRead`) fail inside their `try/catch`, and the
+/// incoming stream is driven from [incoming].
+///
+/// A phone-sized viewport keeps the list scrollable with a few dozen
+/// bubbles and hides the tablet side panel.
+Future<void> _pumpChatRoom(
+  WidgetTester tester,
+  StreamController<rust_types.ChatMessage> incoming,
+) async {
+  tester.view.physicalSize = const Size(400, 800);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  final container = createContainer(overrides: [
+    incomingMessageProvider(_orderId).overrideWith((ref) => incoming.stream),
+    // The sticky header and the nav badge would otherwise reach the bridge.
+    chatTradeOrderProvider(_orderId).overrideWith((ref) async => null),
+    orderBookNotificationCountProvider.overrideWith((ref) => 0),
+  ]);
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(
+        theme: buildDarkTheme(),
+        localizationsDelegates: const [
+          AppLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: const ChatRoomScreen(orderId: _orderId),
+      ),
+    ),
+  );
+  // Initial build, then a frame to flush the failed history load.
+  await tester.pump();
+  await tester.pump();
+}
+
+/// Delivers [messages] through the stream and lays them out.
+Future<void> _receive(
+  WidgetTester tester,
+  StreamController<rust_types.ChatMessage> incoming,
+  Iterable<rust_types.ChatMessage> messages,
+) async {
+  messages.forEach(incoming.add);
+  await tester.pump(); // stream delivery + setState
+  await tester.pump(); // layout + post-frame follow
+}
+
+/// Unmounts the screen and lets any flushed bridge call settle.
+Future<void> _leaveRoom(WidgetTester tester) async {
+  await tester.pumpWidget(const SizedBox.shrink());
+  await tester.pump();
+}
+
+ScrollController _listController(WidgetTester tester) =>
+    tester.widget<ListView>(find.byType(ListView)).controller!;
+
+/// Counts `markAsRead` bridge calls by their failure log line: without
+/// `RustLib.init()` every call fails, so the line count *is* the call count.
+///
+/// `debugPrint` is a foundation debug variable, and the test binding checks
+/// it is back to its original value before the test body returns, so
+/// [run] restores it itself rather than leaving that to a tear-down.
+class _MarkReadCounter {
+  _MarkReadCounter._();
+
+  int calls = 0;
+
+  static Future<void> run(
+    Future<void> Function(_MarkReadCounter counter) body,
+  ) async {
+    final counter = _MarkReadCounter._();
+    final previous = debugPrint;
+    debugPrint = (String? message, {int? wrapWidth}) {
+      if (message != null && message.contains('markAsRead failed')) {
+        counter.calls++;
+      }
+    };
+    try {
+      await body(counter);
+    } finally {
+      debugPrint = previous;
+    }
+  }
+}
+
+void main() {
+  late StreamController<rust_types.ChatMessage> incoming;
+
+  setUp(() => incoming = StreamController<rust_types.ChatMessage>());
+  tearDown(() => incoming.close());
+
+  group('ChatRoomScreen incoming messages', () {
+    testWidgets('renders a replayed id once', (tester) async {
+      await _pumpChatRoom(tester, incoming);
+
+      await _receive(tester, incoming, [
+        _peerMessage(1, id: 'same'),
+        _peerMessage(2, id: 'same'),
+      ]);
+
+      expect(find.byType(MessageBubble), findsOneWidget);
+      await _leaveRoom(tester);
+    });
+
+    testWidgets('leaves a reader who scrolled up where they were',
+        (tester) async {
+      await _pumpChatRoom(tester, incoming);
+      await _receive(
+          tester, incoming, List.generate(30, (i) => _peerMessage(i)));
+      await tester.pump(const Duration(milliseconds: 300));
+      final list = _listController(tester);
+      expect(list.position.maxScrollExtent, greaterThan(0),
+          reason: 'the list must be scrollable for the test to mean anything');
+      list.jumpTo(100);
+      await tester.pump();
+
+      await _receive(tester, incoming, [_peerMessage(99)]);
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(list.offset, 100,
+          reason: 'an arriving message must not yank the reader away');
+      await _leaveRoom(tester);
+    });
+
+    testWidgets('follows the conversation for a reader at the bottom',
+        (tester) async {
+      await _pumpChatRoom(tester, incoming);
+      await _receive(
+          tester, incoming, List.generate(30, (i) => _peerMessage(i)));
+      await tester.pump(const Duration(milliseconds: 300));
+      final list = _listController(tester);
+      list.jumpTo(list.position.maxScrollExtent);
+      await tester.pump();
+
+      await _receive(tester, incoming, [_peerMessage(99)]);
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(list.offset, list.position.maxScrollExtent);
+      await _leaveRoom(tester);
+    });
+
+    testWidgets('keeps following when a message lands mid-animation',
+        (tester) async {
+      await _pumpChatRoom(tester, incoming);
+      await _receive(
+          tester, incoming, List.generate(30, (i) => _peerMessage(i)));
+      await tester.pump(const Duration(milliseconds: 300));
+      final list = _listController(tester);
+      list.jumpTo(list.position.maxScrollExtent);
+      await tester.pump();
+
+      // First message starts a 200 ms follow animation; the second arrives
+      // while the list is still short of the end it is heading for.
+      await _receive(tester, incoming, [_peerMessage(98)]);
+      await tester.pump(const Duration(milliseconds: 40));
+      expect(list.offset, lessThan(list.position.maxScrollExtent),
+          reason: 'the follow animation must still be in flight');
+      await _receive(tester, incoming, [_peerMessage(99)]);
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(list.offset, list.position.maxScrollExtent,
+          reason: 'a reader who never scrolled up must not be left behind');
+      await _leaveRoom(tester);
+    });
+  });
+
+  group('ChatRoomScreen mark-read', () {
+    testWidgets('marks a burst read once, after it settles', (tester) async {
+      await _MarkReadCounter.run((counter) async {
+        await _pumpChatRoom(tester, incoming);
+        expect(counter.calls, 1, reason: 'entering the room marks it read');
+
+        await _receive(
+            tester, incoming, List.generate(40, (i) => _peerMessage(i)));
+        expect(counter.calls, 1, reason: 'nothing fires mid-burst');
+
+        await tester.pump(kMarkReadDebounce);
+        await tester.pump();
+        expect(counter.calls, 2, reason: 'one call for the whole burst');
+        await _leaveRoom(tester);
+      });
+    });
+
+    testWidgets('flushes a pending mark-read when leaving the room',
+        (tester) async {
+      await _MarkReadCounter.run((counter) async {
+        await _pumpChatRoom(tester, incoming);
+        await _receive(tester, incoming, [_peerMessage(1)]);
+        expect(counter.calls, 1);
+
+        await _leaveRoom(tester);
+
+        expect(counter.calls, 2,
+            reason: 'the reader saw the message; leaving early must not '
+                'leave the room flagged unread');
+      });
+    });
+  });
+}


### PR DESCRIPTION
Phase 2, PR 2.10 of the optimization plan (#348) — the last item in Phase 2. Independent of the other Phase 2 PRs.

## Problem

Three costs paid on **every** incoming message (`chat_room_screen.dart:150-165`):

1. **Dedup scanned the whole list** — `_messages.any((m) => m.id == msg.id)`, and the same pattern in `_loadHistory`. A replay of N messages is O(N²).
2. **`_markRead()` per message** — one bridge call each, so a burst issues a burst of them.
3. **Auto-scroll per message** — a 200 ms animation each. A burst starts a pile of competing animations, and a reader looking at older messages gets yanked to the bottom every time the counterparty types.

**Which of these matters.** Item 3 is the user-visible win: on `main` one arriving message drags a reader who is looking at older messages all the way to the end. Item 2 turns a burst into one bridge call. Item 1 is structurally right and scales, but at the size a trade's chat actually reaches (tens of messages) the `Set` saves nothing measurable — see the review's microbenchmark. It stays because it makes the dedup invariant a single `Set.add` on every append path, not for speed.

## Change

1. A `Set<String>` of seen ids. `_seenIds.add(...)` both tests and records in one step, so the dedup check and the insert cannot drift apart. All three append paths (`_loadHistory`, `_onIncomingMessage`, `_onSend`) go through it.
2. `_markRead` is debounced (`kMarkReadDebounce`, 400 ms): a burst costs one call instead of one per message. A pending call is **flushed** from `dispose`, not dropped, so leaving the room within the window does not leave it flagged unread.
3. Auto-scroll only when the reader was already at the bottom. A follow animation still in flight counts as "at the bottom": a message landing during the 200 ms animation for the previous one must not read the lagging position as "scrolled up" and stop following.

The pinned-to-bottom test reads the scroll position **before** `setState` adds the message. The extent only changes at the next layout, so reading before keeps the decision about the list the reader was actually looking at, whichever frame that layout lands on.

## Not included

The plan also suggested capping or paginating `_messages`. Left out deliberately: chat history is bounded by one trade's lifetime — tens of messages, not thousands — and silently dropping a counterparty's messages from a screen someone may need as a record of a trade is a worse failure than the memory it saves. Worth doing as a real pagination feature, not as a cap.

## Test plan

- [x] The follow decision is extracted as a pure `isPinnedToBottom` and tested at the boundary: at the end, within one bubble of the end, scrolled away, and the degenerate unscrollable list (`chat_autoscroll_test.dart`).
- [x] `ChatRoomScreen` harness (`chat_room_screen_test.dart`), in the `trade_detail_screen_test.dart` convention: pumped without `RustLib.init()` (the screen's bridge calls fail inside their own `try/catch`), `incomingMessageProvider` overridden with a `StreamController`, `markAsRead` calls counted through their failure log line. Covers: a replayed id renders once; a scrolled-up reader is not moved; a reader at the bottom follows; a message landing mid-animation still follows; a 40-message burst marks read once, after it settles; leaving the room mid-debounce flushes the mark-read. The last two behaviours and the mid-animation case fail on the first commit of this PR.
- [x] `flutter test` — 303 passed, 0 failed (`main`: 293; this PR adds 10)
- [x] `flutter analyze` — no issues in hand-written code (the 7 pre-existing infos are all in tests on `main`)
- [ ] Manual: open a chat with history, confirm it loads and scrolls to the bottom; scroll up and have the counterparty send a message (should not jump); confirm unread badges still clear

Not covered by test: the `_onSend` dedupe. `sendMessage` fails without `RustLib`, so the message is never added and the path cannot be driven from the harness. Per the review's Rust trace it is also unreachable today (the echo is dropped by `is_known` before `add_message` emits), so the line is belt-and-braces for the stated invariant.
