### PR TITLE
fix(web): sanitize unparseable browser locale before engine bootstrap

### DIFF
--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -216,6 +216,41 @@ jobs:
           SMOKE_LOCALE: "C"
         run: BASE_PATH="/${GITHUB_REPOSITORY#*/}/" node smoke.mjs
 
+      # Negative control for the step above. On its own that step can go green
+      # for the wrong reason — if the engine stops crashing on an invalid
+      # locale, it passes whether or not the sanitizer is still there or even
+      # still works. So run the same bundle with the sanitizer stripped out and
+      # require it to FAIL. Together the two steps assert what actually
+      # matters: the bundle survives locale "C", and it survives it *because of
+      # this fix*.
+      - name: Control — the same bundle without the sanitizer must fail (#227)
+        working-directory: test/web/smoke
+        env:
+          SMOKE_LOCALE: "C"
+        run: |
+          set -euo pipefail
+          control_dir="${RUNNER_TEMP}/web-no-sanitizer"
+          rm -rf "$control_dir"
+          cp -r "${GITHUB_WORKSPACE}/build/web" "$control_dir"
+          # Delete the marker comment through the end of the inline script it
+          # introduces. The script contains no literal </script>, so the first
+          # one after the marker closes it.
+          sed -i '/<!-- locale-sanitizer/,/<\/script>/d' "$control_dir/index.html"
+          # Never let a silent no-op turn this control into a rubber stamp.
+          if grep -q 'locale-sanitizer' "$control_dir/index.html"; then
+            echo "::error::failed to strip the sanitizer — the control proves nothing"
+            exit 1
+          fi
+          if BUNDLE_DIR="$control_dir" BASE_PATH="/${GITHUB_REPOSITORY#*/}/" node smoke.mjs; then
+            echo "::error::the bundle passed under locale C without the sanitizer —"
+            echo "::error::the guard above is no longer testing this bug (see #227)"
+            exit 1
+          fi
+          # The failing control leaves a screenshot behind; drop it so a later
+          # failure does not upload this expected one as its evidence.
+          rm -f smoke-failure.png
+          echo "control failed as expected — the locale guard is load-bearing"
+
       - name: Upload smoke test failure screenshot
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -190,13 +190,25 @@ jobs:
           BUNDLE_DIR: ${{ github.workspace }}/build/web
         run: BASE_PATH="/${GITHUB_REPOSITORY#*/}/" node smoke.mjs
 
-      # Regression guard for issue #227: an unparseable browser locale (POSIX
-      # "C", underscored "en_US", empty) crashed the Flutter web engine's own
-      # bootstrap before runApp, with no error path — an unrecoverable blank
-      # page. Fixed by the locale sanitizer in web/index.html, which runs
-      # before flutter_bootstrap.js and normalizes navigator.language(s). This
-      # reruns the same smoke test forcing that invalid locale so the fix
-      # can't silently regress.
+      # Regression guard for issue #227: an unparseable browser locale (the
+      # POSIX "C" locale, an underscored "en_US", empty) crashed the Flutter
+      # web engine's own bootstrap before runApp, with no error path — an
+      # unrecoverable blank page. Fixed by the locale sanitizer in
+      # web/index.html, which runs before flutter_bootstrap.js and normalizes
+      # navigator.language(s). This reruns the same smoke test forcing an
+      # invalid locale so the fix can't silently regress.
+      #
+      # Only "C" is actually covered here: Playwright normalizes the locale it
+      # is given before the page sees it, so "en_US" reaches the browser as a
+      # valid "en-US" and "" falls back to the default. The sanitizer handles
+      # all three; CI can only exercise the first.
+      #
+      # The crash itself only exists on Flutter >= 3.38, where the engine's
+      # parseBrowserLanguages started building the locale through
+      # Intl.Locale (@JS binding) instead of a pure-Dart ui.Locale that
+      # validated nothing. If FLUTTER_VERSION ever moves back below that, or
+      # the engine stops using Intl, this step passes for the wrong reason —
+      # revalidate it against a build without the sanitizer before trusting it.
       - name: Smoke test the release bundle under an invalid locale (#227)
         working-directory: test/web/smoke
         env:

--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -190,6 +190,20 @@ jobs:
           BUNDLE_DIR: ${{ github.workspace }}/build/web
         run: BASE_PATH="/${GITHUB_REPOSITORY#*/}/" node smoke.mjs
 
+      # Regression guard for issue #227: an unparseable browser locale (POSIX
+      # "C", underscored "en_US", empty) crashed the Flutter web engine's own
+      # bootstrap before runApp, with no error path — an unrecoverable blank
+      # page. Fixed by the locale sanitizer in web/index.html, which runs
+      # before flutter_bootstrap.js and normalizes navigator.language(s). This
+      # reruns the same smoke test forcing that invalid locale so the fix
+      # can't silently regress.
+      - name: Smoke test the release bundle under an invalid locale (#227)
+        working-directory: test/web/smoke
+        env:
+          BUNDLE_DIR: ${{ github.workspace }}/build/web
+          SMOKE_LOCALE: "C"
+        run: BASE_PATH="/${GITHUB_REPOSITORY#*/}/" node smoke.mjs
+
       - name: Upload smoke test failure screenshot
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -220,13 +220,23 @@ jobs:
       # for the wrong reason — if the engine stops crashing on an invalid
       # locale, it passes whether or not the sanitizer is still there or even
       # still works. So run the same bundle with the sanitizer stripped out and
-      # require it to FAIL. Together the two steps assert what actually
-      # matters: the bundle survives locale "C", and it survives it *because of
-      # this fix*.
+      # require it to FAIL, and to fail with the RangeError this fix exists for
+      # — smoke.mjs exits non-zero for five unrelated reasons, plus the ones
+      # where Chromium never launches at all, so an exit code alone would let
+      # this control report success while proving nothing. Together the two
+      # steps assert what actually matters: the bundle survives locale "C", and
+      # it survives it *because of this fix*.
       - name: Control — the same bundle without the sanitizer must fail (#227)
         working-directory: test/web/smoke
         env:
           SMOKE_LOCALE: "C"
+          # This run is *expected* to die inside engine bootstrap, so the
+          # flutter-view selector it waits on will never appear and the wait
+          # always runs to the timeout. The crash is synchronous, so 20s is
+          # plenty; the default 120s here costs two idle minutes on every PR.
+          # Do not "unify" this with the positive steps, which need the
+          # generous default to instantiate the wasm core on a cold runner.
+          SMOKE_TIMEOUT_MS: "20000"
         run: |
           set -euo pipefail
           control_dir="${RUNNER_TEMP}/web-no-sanitizer"
@@ -241,11 +251,22 @@ jobs:
             echo "::error::failed to strip the sanitizer — the control proves nothing"
             exit 1
           fi
-          if BUNDLE_DIR="$control_dir" BASE_PATH="/${GITHUB_REPOSITORY#*/}/" node smoke.mjs; then
+          control_log="${RUNNER_TEMP}/control-smoke.log"
+          if BUNDLE_DIR="$control_dir" BASE_PATH="/${GITHUB_REPOSITORY#*/}/" node smoke.mjs >"$control_log" 2>&1; then
+            cat "$control_log"
             echo "::error::the bundle passed under locale C without the sanitizer —"
             echo "::error::the guard above is no longer testing this bug (see #227)"
             exit 1
           fi
+          # It failed — but smoke.mjs fails for five reasons that have nothing
+          # to do with this bug. Only the locale RangeError proves the control.
+          if ! grep -q 'Incorrect locale information provided' "$control_log"; then
+            cat "$control_log"
+            echo "::error::the control failed, but not with the locale RangeError —"
+            echo "::error::it proves nothing about this fix (see #227)"
+            exit 1
+          fi
+          cat "$control_log"
           # The failing control leaves a screenshot behind; drop it so a later
           # failure does not upload this expected one as its evidence.
           rm -f smoke-failure.png

--- a/test/web/pages_bundle_test.dart
+++ b/test/web/pages_bundle_test.dart
@@ -47,6 +47,25 @@ void main() {
       expect(bootstrapAt, greaterThanOrEqualTo(0));
       expect(shimAt, lessThan(bootstrapAt));
     });
+
+    test('loads the locale sanitizer between the shim and flutter_bootstrap.js',
+        () {
+      // Arrange
+      final html = indexHtml.readAsStringSync();
+
+      // Act
+      final shimAt = html.indexOf('<script src="coi-serviceworker.min.js">');
+      final sanitizerAt = html.indexOf('<!-- locale-sanitizer');
+      final bootstrapAt = html.indexOf('flutter_bootstrap.js');
+
+      // Assert — the sanitizer must rewrite navigator.language(s) before the
+      // engine reads them during CanvasKit bootstrap, or an unparseable
+      // browser locale throws out of it and the page stays blank (#227). It
+      // still comes after the shim, which reloads the page to gain isolation.
+      expect(sanitizerAt, greaterThanOrEqualTo(0));
+      expect(shimAt, lessThan(sanitizerAt));
+      expect(sanitizerAt, lessThan(bootstrapAt));
+    });
   });
 
   group('vendored coi-serviceworker', () {

--- a/test/web/smoke/smoke.mjs
+++ b/test/web/smoke/smoke.mjs
@@ -156,13 +156,17 @@ async function main() {
   let browser;
   try {
     browser = await chromium.launch();
-    // Pin the locale. A CI container usually has none configured, so Chromium
-    // reports something Dart's intl rejects outright — `RangeError: Incorrect
-    // locale information provided` thrown from main(), before runApp, leaving
-    // the engine bootstrapped but no view mounted. Real browsers always report
-    // a locale, so leaving it unset tests a situation no user is ever in while
-    // hiding every failure that comes after it.
-    const page = await browser.newPage({ locale: 'en-US' });
+    // Pin the locale, overridable via SMOKE_LOCALE. A CI container usually has
+    // none configured, so Chromium reports something Dart's intl rejects
+    // outright — `RangeError: Incorrect locale information provided` thrown
+    // before runApp, leaving the engine bootstrapped but no view mounted. Real
+    // browsers always report a valid locale, so leaving it unset tests a
+    // situation no user is ever in while hiding every failure that comes
+    // after it — hence the 'en-US' default. web-build.yml also runs this
+    // script once with SMOKE_LOCALE=C: a regression guard for issue #227,
+    // fixed by the locale sanitizer in web/index.html. The pin stays for
+    // determinism; it is no longer load-bearing for that bug.
+    const page = await browser.newPage({ locale: process.env.SMOKE_LOCALE || 'en-US' });
 
     const record = (origin, text) => {
       (isIgnorable(text) ? ignored : errors).push(`[${origin}] ${text}`);

--- a/test/web/smoke/smoke.mjs
+++ b/test/web/smoke/smoke.mjs
@@ -166,7 +166,11 @@ async function main() {
     // script once with SMOKE_LOCALE=C: a regression guard for issue #227,
     // fixed by the locale sanitizer in web/index.html. The pin stays for
     // determinism; it is no longer load-bearing for that bug.
-    const page = await browser.newPage({ locale: process.env.SMOKE_LOCALE || 'en-US' });
+    //
+    // `??`, not `||`: the empty string is one of the broken tags this guards
+    // against, and `||` would silently turn SMOKE_LOCALE='' into 'en-US' —
+    // the one case the knob exists for, passing green without testing it.
+    const page = await browser.newPage({ locale: process.env.SMOKE_LOCALE ?? 'en-US' });
 
     const record = (origin, text) => {
       (isIgnorable(text) ? ignored : errors).push(`[${origin}] ${text}`);

--- a/web/index.html
+++ b/web/index.html
@@ -57,12 +57,17 @@
     //
     // The Flutter web engine builds a Locale from navigator.language(s) while
     // CanvasKit is initializing, using JS's own Intl constructors. A tag that
-    // isn't valid BCP 47 (POSIX-style "C"/"POSIX", underscored "en_US", or an
+    // isn't valid BCP 47 (the POSIX "C" locale, an underscored "en_US", or an
     // empty string — all things a container/CI/kiosk browser with no locale
     // configured can report) throws an uncaught RangeError there, before
     // runApp — an unrecoverable blank page with nothing logged. No mainstream
     // browser reports a tag like this, so real users never hit it; CI and
     // headless/embedded environments do. See issue #227.
+    //
+    // Note "POSIX", the other name of that same Unix locale, is NOT one of
+    // them: unlike "C" it is a structurally valid five-letter language subtag,
+    // so Intl accepts it and it passes through untouched — correctly, since it
+    // never crashed anything.
     (function () {
       function isValidBcp47(tag) {
         try { new Intl.DateTimeFormat(tag); return true; }
@@ -79,9 +84,18 @@
         : [navigator.language];
       var sanitized = raw.map(sanitize).filter(Boolean);
       if (sanitized.length === 0) sanitized = [fallback];
-      if (sanitized.join(',') !== raw.join(',')) {
+      if (sanitized.join(',') === raw.join(',')) return;
+      // Shadowing these is not guaranteed: a browser may expose them as
+      // non-configurable. Never let that throw — this script runs before the
+      // engine, in exactly the locked-down environments it exists to rescue,
+      // and an uncaught error here would be the blank page it is preventing.
+      // Both writes go together so a partial shadow can't leave language and
+      // languages disagreeing.
+      try {
         Object.defineProperty(navigator, 'language', { get: function () { return sanitized[0]; }, configurable: true });
         Object.defineProperty(navigator, 'languages', { get: function () { return sanitized; }, configurable: true });
+      } catch (e) {
+        console.warn('locale sanitizer: could not override navigator.language(s)', e);
       }
     })();
   </script>

--- a/web/index.html
+++ b/web/index.html
@@ -52,6 +52,10 @@
   <link rel="manifest" href="manifest.json">
 </head>
 <body>
+  <!-- locale-sanitizer: must stay between the isolation shim and
+       flutter_bootstrap.js. test/web/pages_bundle_test.dart anchors on this
+       marker to assert that ordering statically — do not remove or rename it
+       without updating that test. -->
   <script>
     // Sanitize navigator.language(s) before Flutter's engine bootstrap reads it.
     //
@@ -89,8 +93,23 @@
       // non-configurable. Never let that throw — this script runs before the
       // engine, in exactly the locked-down environments it exists to rescue,
       // and an uncaught error here would be the blank page it is preventing.
-      // Both writes go together so a partial shadow can't leave language and
-      // languages disagreeing.
+      //
+      // A try/catch is not a transaction: if the first defineProperty applies
+      // and the second throws, the first cannot be undone, and the engine
+      // reads navigator.languages only — so a partial shadow can both leave
+      // the two properties disagreeing and fail to fix the crash. Check that
+      // both are writable before touching either, and do nothing at all if
+      // one is locked. Normally neither is an own property (both live on
+      // Navigator.prototype), and defining an own accessor shadows them; an
+      // absent descriptor is therefore the writable case.
+      function isLockedDown(name) {
+        var d = Object.getOwnPropertyDescriptor(navigator, name);
+        return !!d && !d.configurable;
+      }
+      if (isLockedDown('language') || isLockedDown('languages')) {
+        console.warn('locale sanitizer: navigator.language(s) is not configurable, leaving it alone');
+        return;
+      }
       try {
         Object.defineProperty(navigator, 'language', { get: function () { return sanitized[0]; }, configurable: true });
         Object.defineProperty(navigator, 'languages', { get: function () { return sanitized; }, configurable: true });

--- a/web/index.html
+++ b/web/index.html
@@ -52,6 +52,39 @@
   <link rel="manifest" href="manifest.json">
 </head>
 <body>
+  <script>
+    // Sanitize navigator.language(s) before Flutter's engine bootstrap reads it.
+    //
+    // The Flutter web engine builds a Locale from navigator.language(s) while
+    // CanvasKit is initializing, using JS's own Intl constructors. A tag that
+    // isn't valid BCP 47 (POSIX-style "C"/"POSIX", underscored "en_US", or an
+    // empty string — all things a container/CI/kiosk browser with no locale
+    // configured can report) throws an uncaught RangeError there, before
+    // runApp — an unrecoverable blank page with nothing logged. No mainstream
+    // browser reports a tag like this, so real users never hit it; CI and
+    // headless/embedded environments do. See issue #227.
+    (function () {
+      function isValidBcp47(tag) {
+        try { new Intl.DateTimeFormat(tag); return true; }
+        catch (e) { return false; }
+      }
+      function sanitize(tag) {
+        if (typeof tag !== 'string' || !tag) return null;
+        var hyphenated = tag.replace(/_/g, '-');
+        return isValidBcp47(hyphenated) ? hyphenated : null;
+      }
+      var fallback = 'en-US';
+      var raw = (navigator.languages && navigator.languages.length)
+        ? navigator.languages
+        : [navigator.language];
+      var sanitized = raw.map(sanitize).filter(Boolean);
+      if (sanitized.length === 0) sanitized = [fallback];
+      if (sanitized.join(',') !== raw.join(',')) {
+        Object.defineProperty(navigator, 'language', { get: function () { return sanitized[0]; }, configurable: true });
+        Object.defineProperty(navigator, 'languages', { get: function () { return sanitized; }, configurable: true });
+      }
+    })();
+  </script>
   <script src="flutter_bootstrap.js" async></script>
 </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -86,8 +86,12 @@
       var raw = (navigator.languages && navigator.languages.length)
         ? navigator.languages
         : [navigator.language];
-      var sanitized = raw.map(sanitize).filter(Boolean);
-      if (sanitized.length === 0) sanitized = [fallback];
+      // Frozen to match the real thing: per the HTML spec navigator.languages
+      // returns a frozen array, so an unfrozen shadow would quietly accept a
+      // push() the genuine property rejects. Both assignments need it — the
+      // second is the one the "C" case actually ends up using.
+      var sanitized = Object.freeze(raw.map(sanitize).filter(Boolean));
+      if (sanitized.length === 0) sanitized = Object.freeze([fallback]);
       if (sanitized.join(',') === raw.join(',')) return;
       // Shadowing these is not guaranteed: a browser may expose them as
       // non-configurable. Never let that throw — this script runs before the


### PR DESCRIPTION
 # Summary

  Part of #227: on web, an unparseable browser locale (the POSIX `C` locale, an underscored `en_US`, or empty) crashed the app before `runApp` with a blank page and nothing logged.

  **Root cause, pinned down with a full stack trace** (the original issue narrowed it to "somewhere in early `main()`" but not further):

  RangeError: Incorrect locale information provided
      at new Locale (<anonymous>)
      at Object.EnginePlatformDispatcher_parseBrowserLanguages (main.dart.js:2494:21)
      at Object.EnginePlatformDispatcher$ (main.dart.js:2471:14)
      at CanvasKitRenderer.initialize$0 (main.dart.js:73965:16)

  This is inside the **Flutter web engine's own bootstrap** (`CanvasKitRenderer.initialize`), not in this app's code — it fires before `Firebase.initializeApp` or `RustLib.init()` ever run. That rules out both of the issue's other suspects and means no app-level `try/catch` around `main()` can guard it; the fix has to happen before the engine reads the locale at all.

  # Fix

  Added a small inline script to `web/index.html`, before `flutter_bootstrap.js` loads (same pattern already used there for `coi-serviceworker.min.js`): it validates `navigator.language`/`navigator.languages` with `Intl.DateTimeFormat` (the same check that throws inside the engine), normalizes underscored tags (`en_US` → `en-US`), and falls back to `en-US` for anything still invalid (`C`, empty). Note `POSIX` is *not* one of those: unlike the single-letter `C`, it is a structurally valid five-letter language subtag, so `Intl` accepts it and it passes through untouched — correctly, since it never crashed anything. If the shadowing itself is refused by the browser, the script warns and leaves the locale alone rather than throwing. By the time the engine reads it, the browser only ever reports a valid tag.

  # Testing

  **Manual, against a real release bundle**, both directions — with `navigator.language(s)` shadowed to `C` before the sanitizer runs, since Chrome's DevTools rejects `C` in its locale override field ("Locale must contain alphabetic characters"):

  - Without the fix → blank page, `RangeError: Incorrect locale information provided` in the console, `flutter-view` never created.
  - With the fix → `navigator.languages` reports `["en-US"]` and the app renders.
  - Same result for `""` (empty locale).
  - Note: real browsers never report a broken tag like `C` themselves (they self-sanitize), which is why this only shows up in CI/headless/embedded environments — matches the "low severity" framing in the issue.

  **Automated regression guard**: `smoke.mjs` now reads the locale from `SMOKE_LOCALE` (defaults to `en-US`, unchanged). `web-build.yml` reruns the release-bundle smoke test with `SMOKE_LOCALE=C` right after the existing one. Verified locally against a real bundle (`build-web.sh --release` + `flutter build web --release`, Flutter 3.38.2), stripping only the sanitizer `<script>` from the built `index.html` between runs so both sides come from the same build:

  |                    | `en-US`      | `C`                          |
  | ------------------ | ------------ | ---------------------------- |
  | with sanitizer     | passes fully | passes fully                 |
| without sanitizer  | passes fully | **Flutter view never mounted** |

"Passes fully" means all four smoke assertions, Rust bridge call included.

# Acceptance criteria (from #227)

- [x] Exact call site identified and recorded (commented on the issue with the full stack trace)
- [x] App starts and renders with locale forced to `C`, `en_US`†, and `""` — verified against a real release bundle; the CI step only exercises `C`, since Playwright normalizes the other two before the page sees them
- [x] No unhandled exception escapes `main()` for a bad locale — it's normalized before the engine ever sees it
- [x] `Firebase.initializeApp` was already unaffected — the crash happens earlier, before that line runs
- [x] CI case loads the release bundle under an invalid locale and asserts the view mounts
- [x] `locale: 'en-US'` pin in `smoke.mjs` kept for determinism, documented as no longer load-bearing for this bug

† `en_US` gets normalized to `en-US` by the sanitizer like any other case; a separate `Accept-Language: en_US` fetch failure I hit while testing that one specific tag turned out to be a pre-existing Playwright/Chromium quirk unrelated to this fix (reproduces identically with the sanitizer removed) — not covered by this PR.