### PR TITLE
fix(#335): replace-not-discard the session on a confirmed retake

### DIFF
--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -6792,6 +6792,66 @@ mod tests {
         );
     }
 
+    /// The mirror case, and the one #345/#347 made reachable: the session
+    /// `take_order` finds already belongs to *this* take, because
+    /// `apply_peer_reveal` created it when the daemon's first reply carried
+    /// both trade pubkeys. Same `trade_key_index`, but with peer material the
+    /// call site cannot rebuild — replacing it would silently drop the chat
+    /// keys the peer-reveal path exists to establish (#334).
+    ///
+    /// The index is what tells the two cases apart: a stale session from a
+    /// failed attempt always carries an older index, because every take
+    /// derives a fresh trade key.
+    #[tokio::test]
+    async fn install_session_keeps_this_takes_own_session_with_peer_material() {
+        let order_id = uuid::Uuid::new_v4().to_string();
+        let order = dummy_order_info(&order_id);
+        let mgr = session_manager();
+
+        // The peer reveal got there first, with the shared key already derived.
+        mgr.install_session(order_id.clone(), TradeRole::Buyer, 4, order.clone())
+            .await
+            .expect("peer-reveal install must succeed");
+        let mut revealed = mgr
+            .get_session(&order_id)
+            .await
+            .expect("session must exist");
+        revealed.peer_pubkey = Some("aabbccdd".to_string());
+        revealed.shared_key = Some([7u8; 32]);
+        mgr.update_session(&order_id, revealed)
+            .await
+            .expect("planting peer material must succeed");
+
+        // `take_order` now runs for the same take: same trade_key_index.
+        let returned = mgr
+            .install_session(order_id.clone(), TradeRole::Buyer, 4, order)
+            .await
+            .expect("install for the same index must succeed");
+
+        let session = mgr
+            .get_session(&order_id)
+            .await
+            .expect("session must exist");
+        assert_eq!(
+            session.trade_key_index, 4,
+            "the index must be unchanged — same take"
+        );
+        assert_eq!(
+            session.peer_pubkey.as_deref(),
+            Some("aabbccdd"),
+            "peer_pubkey established by the reveal must survive take_order"
+        );
+        assert_eq!(
+            session.shared_key,
+            Some([7u8; 32]),
+            "shared_key established by the reveal must survive take_order"
+        );
+        assert_eq!(
+            returned.peer_pubkey, session.peer_pubkey,
+            "the returned session must be the kept one, not a fresh empty one"
+        );
+    }
+
     /// After create_session the session has no peer pubkey or shared key yet.
     #[tokio::test]
     async fn new_session_has_no_peer_keys() {

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -1103,16 +1103,22 @@ pub async fn take_order(
     // trade_key_index — replace it), or `maybe_capture_peer_reveal` created
     // this take's own session with peer + shared key already set (same index —
     // keep it, #334/#345). `install_session` distinguishes them by index.
-    let _ = crate::mostro::session::session_manager()
+    //
+    // The only error it can return is the `order_id != order.id` mismatch,
+    // i.e. a programming error here — log it rather than swallow it.
+    if let Err(e) = crate::mostro::session::session_manager()
         .install_session(
             order_id.clone(),
             trade.role.clone(),
             trade_index,
             trade.order.clone(),
         )
-        .await;
-    // In that same case the reveal ran before the trade row existed, so its
-    // durable write was a no-op — replay it from the session now that the
+        .await
+    {
+        log::warn!("[orders] take_order: install_session failed: {e}");
+    }
+    // In the peer-reveal case the reveal ran before the trade row existed, so
+    // its durable write was a no-op — replay it from the session now that the
     // row is persisted (#334). Mirror it on the returned struct too:
     // `TradeInfo.counterparty_pubkey` is what `tradeInfoToChatRoom` gates
     // the chat room on, so the value handed across the bridge must agree
@@ -6694,13 +6700,15 @@ mod tests {
             .contains("SessionAlreadyExists"));
     }
 
-    /// Reproduces #335 part 1: `take_order` calls `create_session` and
-    /// discards the error with `let _ = ...` (orders.rs, current production
-    /// code). A retake over an order that already has a session (first take
-    /// timed out or was rejected, second take succeeded with a fresh trade
-    /// key) silently keeps the OLD session — chat key lookups then use the
-    /// wrong `trade_key_index`. This test fails today; it should pass once
-    /// the retake path replaces the stale session instead of discarding it.
+    /// #335 part 1, the replacement semantics `take_order` depends on: a
+    /// second `install_session` for an order that already has one wins,
+    /// carrying the retake's fresh `trade_key_index`. A retake derives a new
+    /// trade key, so keeping the earlier session would leave chat key lookups
+    /// reading a superseded index.
+    ///
+    /// Scope: this pins `install_session` itself, not the `take_order` call
+    /// site — reaching that needs a daemon. The seam is covered by the manual
+    /// regtest run recorded in the PR description.
     #[tokio::test]
     async fn retake_replaces_stale_session_trade_key_index() {
         let order_id = uuid::Uuid::new_v4().to_string();
@@ -6708,16 +6716,16 @@ mod tests {
         let mgr = session_manager();
 
         // First take: derives trade key index 0, session gets created.
-        let _ = mgr
-            .install_session(order_id.clone(), TradeRole::Buyer, 0, order.clone())
-            .await;
+        mgr.install_session(order_id.clone(), TradeRole::Buyer, 0, order.clone())
+            .await
+            .expect("first install must succeed");
 
         // Retake (first attempt timed out / was rejected by the daemon):
         // derives a fresh trade key index 1. `take_order` calls
         // `install_session` the same way.
-        let _ = mgr
-            .install_session(order_id.clone(), TradeRole::Buyer, 1, order)
-            .await;
+        mgr.install_session(order_id.clone(), TradeRole::Buyer, 1, order)
+            .await
+            .expect("retake install must succeed");
 
         let session = mgr
             .get_session(&order_id)
@@ -6726,6 +6734,61 @@ mod tests {
         assert_eq!(
             session.trade_key_index, 1,
             "the confirmed retake's trade_key_index must win, not the stale one"
+        );
+    }
+
+    /// The replacement is total: a retake also clears the peer material the
+    /// previous attempt accumulated. That is what makes it correct rather than
+    /// merely last-write-wins — the old `shared_key` was derived from the old
+    /// trade key, so carrying it forward would leave chat keys that no longer
+    /// decrypt anything. It is also the reason `install_session` is documented
+    /// as only for a confirmed take.
+    #[tokio::test]
+    async fn install_session_discards_previous_peer_material() {
+        let order_id = uuid::Uuid::new_v4().to_string();
+        let order = dummy_order_info(&order_id);
+        let mgr = session_manager();
+
+        mgr.install_session(order_id.clone(), TradeRole::Buyer, 0, order.clone())
+            .await
+            .expect("first install must succeed");
+
+        // Give the first attempt's session peer material, as a reveal would.
+        let mut with_peer = mgr
+            .get_session(&order_id)
+            .await
+            .expect("session must exist");
+        with_peer.peer_pubkey = Some("aabbccdd".to_string());
+        with_peer.shared_key = Some([7u8; 32]);
+        with_peer.admin_shared_key = Some([9u8; 32]);
+        mgr.update_session(&order_id, with_peer)
+            .await
+            .expect("planting peer material must succeed");
+
+        // The retake must still win, and must not inherit that material.
+        mgr.install_session(order_id.clone(), TradeRole::Buyer, 1, order)
+            .await
+            .expect("retake install must succeed");
+
+        let session = mgr
+            .get_session(&order_id)
+            .await
+            .expect("session must exist");
+        assert_eq!(
+            session.trade_key_index, 1,
+            "the retake must win even over a session holding peer material"
+        );
+        assert!(
+            session.peer_pubkey.is_none(),
+            "peer_pubkey from the superseded take must not survive"
+        );
+        assert!(
+            session.shared_key.is_none(),
+            "shared_key derived from the old trade key must not survive"
+        );
+        assert!(
+            session.admin_shared_key.is_none(),
+            "admin_shared_key from the superseded take must not survive"
         );
     }
 

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -1094,12 +1094,17 @@ pub async fn take_order(
     // success / canceled at the end); the fine-grained states only ever arrive
     // as daemon messages.
     subscribe_single_order(&order_id).await;
-    // Create a session so the chat API can look up keys immediately. May
-    // already exist: when the take's first reply carried both trade pubkeys,
-    // `maybe_capture_peer_reveal` created it (with peer + shared key set)
-    // before this task was woken — the duplicate-create error is expected.
+    // Create (or replace, on a retake) the session so the chat API can look
+    // up keys immediately. A confirmed take always wins over whatever a prior
+    // failed/timed-out attempt left behind (#335).
+    //
+    // A session may already exist for two different reasons, and they must not
+    // be treated alike: a prior failed take left a *stale* one (different
+    // trade_key_index — replace it), or `maybe_capture_peer_reveal` created
+    // this take's own session with peer + shared key already set (same index —
+    // keep it, #334/#345). `install_session` distinguishes them by index.
     let _ = crate::mostro::session::session_manager()
-        .create_session(
+        .install_session(
             order_id.clone(),
             trade.role.clone(),
             trade_index,
@@ -6687,6 +6692,41 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("SessionAlreadyExists"));
+    }
+
+    /// Reproduces #335 part 1: `take_order` calls `create_session` and
+    /// discards the error with `let _ = ...` (orders.rs, current production
+    /// code). A retake over an order that already has a session (first take
+    /// timed out or was rejected, second take succeeded with a fresh trade
+    /// key) silently keeps the OLD session — chat key lookups then use the
+    /// wrong `trade_key_index`. This test fails today; it should pass once
+    /// the retake path replaces the stale session instead of discarding it.
+    #[tokio::test]
+    async fn retake_replaces_stale_session_trade_key_index() {
+        let order_id = uuid::Uuid::new_v4().to_string();
+        let order = dummy_order_info(&order_id);
+        let mgr = session_manager();
+
+        // First take: derives trade key index 0, session gets created.
+        let _ = mgr
+            .install_session(order_id.clone(), TradeRole::Buyer, 0, order.clone())
+            .await;
+
+        // Retake (first attempt timed out / was rejected by the daemon):
+        // derives a fresh trade key index 1. `take_order` calls
+        // `install_session` the same way.
+        let _ = mgr
+            .install_session(order_id.clone(), TradeRole::Buyer, 1, order)
+            .await;
+
+        let session = mgr
+            .get_session(&order_id)
+            .await
+            .expect("session must exist");
+        assert_eq!(
+            session.trade_key_index, 1,
+            "the confirmed retake's trade_key_index must win, not the stale one"
+        );
     }
 
     /// After create_session the session has no peer pubkey or shared key yet.

--- a/rust/src/mostro/session.rs
+++ b/rust/src/mostro/session.rs
@@ -158,6 +158,57 @@ impl SessionManager {
         Ok(session)
     }
 
+    /// Create or replace the session for a trade. Unlike [`create_session`],
+    /// an existing session for `order_id` is overwritten rather than
+    /// rejected — a confirmed retake (fresh `trade_key_index`) must always
+    /// win over whatever a prior failed/timed-out take left behind (#335).
+    ///
+    /// Replaces the whole session, so it **discards peer material**:
+    /// `peer_pubkey`, `shared_key` and `admin_shared_key` all reset to `None`.
+    /// That is correct for the case this exists for — a retake derives a fresh
+    /// trade key, which invalidates any shared key derived from the old one —
+    /// but it means this is **only for a confirmed take**. Calling it once peer
+    /// material is present would drop the chat keys silently.
+    pub async fn install_session(
+        &self,
+        order_id: String,
+        role: TradeRole,
+        trade_key_index: u32,
+        order: OrderInfo,
+    ) -> Result<Session> {
+        if order_id != order.id {
+            return Err(anyhow!(
+                "order_id mismatch: param='{}' vs order.id='{}'",
+                order_id,
+                order.id
+            ));
+        }
+
+        let session = Session {
+            order_id: order_id.clone(),
+            role,
+            trade_key_index,
+            shared_key: None,
+            admin_shared_key: None,
+            peer_pubkey: None,
+            order,
+            created_at: crate::rt::unix_now(),
+        };
+
+        let mut sessions = self.sessions.write().await;
+        crate::api::logging::blog_info(
+            "session",
+            format!(
+                "installed order={} idx={} role={:?}",
+                crate::api::logging::short_id(&order_id),
+                session.trade_key_index,
+                session.role,
+            ),
+        );
+        sessions.insert(order_id, session.clone());
+        Ok(session)
+    }
+
     /// Update an existing session.
     pub async fn update_session(&self, order_id: &str, session: Session) -> Result<()> {
         if session.order_id != order_id {

--- a/rust/src/mostro/session.rs
+++ b/rust/src/mostro/session.rs
@@ -158,17 +158,25 @@ impl SessionManager {
         Ok(session)
     }
 
-    /// Create or replace the session for a trade. Unlike [`create_session`],
-    /// an existing session for `order_id` is overwritten rather than
-    /// rejected — a confirmed retake (fresh `trade_key_index`) must always
-    /// win over whatever a prior failed/timed-out take left behind (#335).
+    /// Create or replace the session for a trade.
     ///
-    /// Replaces the whole session, so it **discards peer material**:
-    /// `peer_pubkey`, `shared_key` and `admin_shared_key` all reset to `None`.
-    /// That is correct for the case this exists for — a retake derives a fresh
-    /// trade key, which invalidates any shared key derived from the old one —
-    /// but it means this is **only for a confirmed take**. Calling it once peer
-    /// material is present would drop the chat keys silently.
+    /// Unlike [`create_session`], an existing session is not a hard error —
+    /// but it is not blindly overwritten either. At a confirmed take a session
+    /// can already exist for two unrelated reasons, told apart by its index:
+    ///
+    /// * **different `trade_key_index`** — a prior failed or timed-out take
+    ///   left it behind. It is stale and must lose: each attempt derives a
+    ///   fresh trade key, so keeping it would leave chat key lookups reading
+    ///   a superseded index (#335). Replaced.
+    /// * **same `trade_key_index`** — this take's own session, created by
+    ///   `apply_peer_reveal` when the first reply already carried both trade
+    ///   pubkeys, with `peer_pubkey` and `shared_key` set (#334/#345). It is
+    ///   strictly richer than what this call would build. Left untouched.
+    ///
+    /// The replacement path resets `peer_pubkey`, `shared_key` and
+    /// `admin_shared_key` to `None`, which is correct rather than lossy: a
+    /// shared key derived from the superseded trade key is invalid, and
+    /// carrying it over would fail the chat silently instead of rebuilding it.
     pub async fn install_session(
         &self,
         order_id: String,
@@ -184,6 +192,26 @@ impl SessionManager {
             ));
         }
 
+        let mut sessions = self.sessions.write().await;
+
+        // Both the read and the write happen under this one lock: deciding
+        // outside it would let a peer reveal land in between and be discarded
+        // by a replacement that was decided when it did not yet exist.
+        if let Some(existing) = sessions.get(&order_id) {
+            if existing.trade_key_index == trade_key_index {
+                crate::api::logging::blog_info(
+                    "session",
+                    format!(
+                        "install kept existing order={} idx={} peer={}",
+                        crate::api::logging::short_id(&order_id),
+                        trade_key_index,
+                        existing.peer_pubkey.is_some(),
+                    ),
+                );
+                return Ok(existing.clone());
+            }
+        }
+
         let session = Session {
             order_id: order_id.clone(),
             role,
@@ -195,7 +223,6 @@ impl SessionManager {
             created_at: crate::rt::unix_now(),
         };
 
-        let mut sessions = self.sessions.write().await;
         crate::api::logging::blog_info(
             "session",
             format!(

--- a/specs/004-mostro-p2p-client/contracts/orders.md
+++ b/specs/004-mostro-p2p-client/contracts/orders.md
@@ -120,6 +120,10 @@ or a direct progression message. Only on a correlated reply is the trade
 created: the TradeInfo is built from the reply's real data (status,
 calculated `amount_sats`, `hold_invoice`), persisted to My Trades, the
 order book entry is synced, and the trade session/subscriptions start.
+A confirmed take **installs** that session, replacing whatever a prior
+failed or timed-out attempt left behind: each attempt derives a fresh trade
+key, so keeping the earlier session would leave chat key lookups reading a
+superseded `trade_key_index` (#335).
 That persistence half runs under the per-order lock (see *Per-order
 serialization*), acquired after the reply and never around the wait for it.
 On rejection or timeout **nothing is persisted** — no phantom trade.
@@ -482,7 +486,12 @@ Invariants:
   the binding still holds the old index (`take_order` rebinds only after
   that reply resolves its waiter), and the identity counter only grows, so
   newer-than-bound is always legitimate. No binding fails open (a create's
-  confirmation precedes any binding for the daemon id). `BondSlashed` is
+  confirmation precedes any binding for the daemon id). The gate compares
+  against the persisted `trade_keys` binding — written by `take_order` on
+  every attempt (`store_trade_key_index`) — not against
+  `Session.trade_key_index`, which a retake could leave stale until #335.
+  That is why a superseded reply was already dropped even while the session
+  held the previous take's index. `BondSlashed` is
   exempt: it never writes order state, and a trailing slash notice
   addressed to the slashed (superseded) generation is by-design delivery
   (#197).

--- a/specs/004-mostro-p2p-client/contracts/orders.md
+++ b/specs/004-mostro-p2p-client/contracts/orders.md
@@ -120,10 +120,14 @@ or a direct progression message. Only on a correlated reply is the trade
 created: the TradeInfo is built from the reply's real data (status,
 calculated `amount_sats`, `hold_invoice`), persisted to My Trades, the
 order book entry is synced, and the trade session/subscriptions start.
-A confirmed take **installs** that session, replacing whatever a prior
-failed or timed-out attempt left behind: each attempt derives a fresh trade
-key, so keeping the earlier session would leave chat key lookups reading a
-superseded `trade_key_index` (#335).
+A confirmed take **installs** that session. A session may already exist for
+two unrelated reasons, told apart by its `trade_key_index`: a prior failed or
+timed-out attempt left a stale one (different index — replaced, since each
+attempt derives a fresh trade key and keeping the earlier session would leave
+chat key lookups reading a superseded index, #335), or the peer reveal already
+created this take's own session with `peer_pubkey` and `shared_key` set (same
+index — kept, since replacing it would drop the chat keys that path exists to
+establish, #334).
 That persistence half runs under the per-order lock (see *Per-order
 serialization*), acquired after the reply and never around the wait for it.
 On rejection or timeout **nothing is persisted** — no phantom trade.


### PR DESCRIPTION
# Summary

Part 1 of #335.

`take_order` created the session with `create_session` and discarded the `Err("SessionAlreadyExists")` with `let _ = ...`.

A retake of an order that already had a session — the first take timed out or was rejected, and the retake succeeded with a fresh trade key — silently kept the stale session and its old `trade_key_index`, which chat key lookups then read.

## Why a plain replacement is not enough

Since #345 and #347 merged, a session can already exist at that call site for **two unrelated reasons**, and they must not be treated alike:

| | how it got there | what it holds | what must happen |
|---|---|---|---|
| stale | a prior failed or timed-out take | an **older** `trade_key_index`, no peer material | replaced (#335) |
| current | `apply_peer_reveal`, when the daemon's first reply carried both trade pubkeys | the **same** index, plus `peer_pubkey` and `shared_key` | left untouched (#334/#345) |

An unconditional replacement would wipe exactly the chat keys the peer-reveal path exists to establish. `main`'s own comment above the call site says the duplicate-create error there is now *expected* for that reason.

The `trade_key_index` separates the two exactly: every take derives a fresh trade key, so a stale session always carries an older index and a peer-reveal session always carries the current one.

## Changes

* Added `SessionManager::install_session` in `rust/src/mostro/session.rs`.
  * Replaces the session when the existing one carries a **different** `trade_key_index`; returns the existing one untouched when the index **matches**.
  * The replacement path resets `peer_pubkey`, `shared_key` and `admin_shared_key`. That is correct rather than lossy: a shared key derived from the superseded trade key is invalid, so carrying it over would fail the chat silently instead of rebuilding it.
  * The read and the write happen under one write lock, so a peer reveal cannot land between the decision and the write.
* `take_order` calls `install_session` and logs the error instead of discarding it. The only error it can return is an order-ID mismatch, i.e. a programming error.
* Updated `contracts/orders.md`: both branches of the install, and the fact that the generation gate reads the persisted `trade_keys` binding rather than `Session.trade_key_index` — which is why a superseded reply was already dropped even while the session held the previous take's index.

## `create_session`

Kept, with its reject-on-duplicate behaviour and its tests. It has a production caller again: #345/#347 added one at the peer-reveal path. The earlier concern that this PR would leave it callerless no longer applies.

## Test coverage and its limit

* `retake_replaces_stale_session_trade_key_index` — the retake wins, carrying its fresh index.
* `install_session_discards_previous_peer_material` — the retake wins even over a session holding peer material, and inherits none of it.
* `install_session_keeps_this_takes_own_session_with_peer_material` — the same-index case: the peer reveal's session survives `take_order`, with `peer_pubkey` and `shared_key` intact.

The third is mutation-checked: removing the index gate fails it with `left: None, right: Some("aabbccdd")`.

These pin `install_session` itself. Reaching it through `take_order` needs a running daemon, so that seam is covered only by the manual run below — the test docstrings say so rather than implying coverage that does not exist.

## Test plan

* [x] `cargo test --locked` — 414 passed
* [x] `cargo clippy --locked -- -D warnings` — clean
* [x] `cargo check --locked` and `--target wasm32-unknown-unknown` — clean
* [x] Manual regtest runs on the rebased branch (Polar + local relay + `mostrod`, `mostro-cli` as maker, app as taker in Chrome). The run in the original PR predated the rebase onto `main` and no longer covered this code, so it was redone — in two passes, because the first got the chat step wrong.

  1. **Full happy path**: order created, taken from the browser, buyer invoice, hold paid from an LND node other than the node's own (`IN_FLIGHT`, not settled), fiat-sent, release, counterparty rated from the app. Settles in LND.
  2. **Chat with the trade active**, which is what exercises this round. Verified against the relay rather than the UI: subscribing to kind 14 on the local relay, sending the message publishes a peer-to-peer event — neither author nor `p` tag is the node.

  Had `install_session` replaced the peer reveal's session, there would be no shared key, `send_message` would fall back to storing local-only, and nothing would reach the relay — silently, since all four of its fallback paths only `log::warn!` and the UI renders the message as sent either way. That is why this was checked on the wire and not in the app.

  Worth recording: the chat only works once the trade is **active**. Before the hold is paid the node has not revealed the counterparty pubkeys (`payload=Order(..., buyer_pk=-, seller_pk=-)` in the app log), so there is no peer material and a message sent then is correctly local-only. That was the mistake in the first pass.

All of the above on the toolchain CI pins (1.97.0).

## Part 2 of #335

No code here. The generation gate already exists (`rust/src/api/orders.rs:1710`) and reads the persisted `trade_keys` binding rather than `Session.trade_key_index`, so part 1's bug never reached it. `contracts/orders.md` now records that. Whether this ticks part 2's box is a maintainer call — left unticked, raised in the review thread.
