### PR TITLE
chore: bump Android NDK to 28.2 and auto-regenerate bindings after pull

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -3,4 +3,8 @@
 # Args: <previous HEAD> <new HEAD> <1 if branch checkout, 0 if file checkout>
 # Install: git config core.hooksPath .githooks
 [[ "${3-0}" == "1" ]] || exit 0
+# Deliberately NOT skipped mid-rebase: a rebase that drops every local commit
+# (patches already upstream) fires this and no post-rewrite, and there the tree
+# checked out here IS the final one. A rebase that does replay commits pays for
+# one redundant run, and post-rewrite fixes up the result.
 exec "$(dirname "$0")/regen-if-needed.sh" "$1" "$2"

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Post-checkout hook: regenerate gitignored generated code after switching branches.
+# Args: <previous HEAD> <new HEAD> <1 if branch checkout, 0 if file checkout>
+# Install: git config core.hooksPath .githooks
+[[ "${3-0}" == "1" ]] || exit 0
+exec "$(dirname "$0")/regen-if-needed.sh" "$1" "$2"

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Post-merge hook: regenerate gitignored generated code after `git pull` / `git merge`.
+# Install: git config core.hooksPath .githooks
+exec "$(dirname "$0")/regen-if-needed.sh" ORIG_HEAD HEAD

--- a/.githooks/post-rewrite
+++ b/.githooks/post-rewrite
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Post-rewrite hook: regenerate gitignored generated code after a rebase.
+#
+# `git rebase` (so `git pull --rebase`) checks out the upstream tip FIRST and
+# only then replays the local commits. post-checkout therefore fires against a
+# tree that does not contain them yet — if one of those commits touches
+# rust/src/api/, the bindings it regenerates there are already stale by the time
+# the rebase finishes. This hook runs once at the end, on the final tree.
+#
+# Install: git config core.hooksPath .githooks
+[[ "${1-}" == "rebase" ]] || exit 0
+
+# stdin carries one "<old-sha> <new-sha>" line per rewritten commit, in replay
+# order. The first new commit's parent is where the replayed range starts.
+first=""
+while read -r _ new _; do
+  [[ -n "$first" ]] || first="$new"
+done
+[[ -n "$first" ]] || exit 0
+git rev-parse --verify --quiet "$first^" >/dev/null || exit 0
+
+exec "$(dirname "$0")/regen-if-needed.sh" "$first^" HEAD

--- a/.githooks/regen-if-needed.sh
+++ b/.githooks/regen-if-needed.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Shared body for the post-merge and post-checkout hooks.
+#
+# lib/src/rust/ and lib/l10n/app_localizations*.dart are gitignored, so a pull that
+# brings in someone else's rust/src/api/ field or .arb key leaves the local copies
+# stale. The failure is loud but misdirected: the analyzer blames whatever *uses* the
+# missing field. Regenerate here, right after the tree moved, and only when the
+# inputs actually changed so an ordinary pull stays fast.
+#
+# Usage: regen-if-needed.sh <old-head> <new-head>
+set -euo pipefail
+
+old="${1-}"
+new="${2-}"
+
+# Nothing to compare (fresh clone, orphan checkout) → nothing to do.
+if [[ -z "$old" || -z "$new" || "$old" == "$new" ]]; then
+  exit 0
+fi
+git rev-parse --verify --quiet "$old" >/dev/null || exit 0
+
+changed="$(git diff --name-only "$old" "$new" -- rust/src/api lib/l10n pubspec.yaml)"
+[[ -n "$changed" ]] || exit 0
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+if grep -qE '^(rust/src/api/|pubspec\.yaml$)' <<<"$changed"; then
+  echo "▶ rust/src/api changed — regenerating flutter_rust_bridge bindings..."
+  ./scripts/frb-generate.sh
+fi
+
+if grep -qE '^lib/l10n/.*\.arb$' <<<"$changed"; then
+  echo "▶ lib/l10n/*.arb changed — regenerating AppLocalizations..."
+  flutter gen-l10n
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,8 +104,9 @@ bridged by flutter_rust_bridge.
   rather than as out-of-date bindings. If `flutter analyze` reports a field or l10n getter
   that plainly exists in `rust/src/api/types.rs` or `lib/l10n/*.arb`, regenerate before
   believing it. **Automate it:** `git config core.hooksPath .githooks` installs
-  `post-merge`/`post-checkout` hooks that regenerate both whenever the pull or branch
-  switch touched `rust/src/api/`, `pubspec.yaml`, or an `.arb` (no-op otherwise).
+  `post-merge`/`post-checkout`/`post-rewrite` hooks that regenerate both whenever the pull,
+  branch switch, or rebase touched `rust/src/api/`, `pubspec.yaml`, or an `.arb` (no-op
+  otherwise).
 
 ## Transport (protocol v2)
 - **Daemon messages** (new-order, take, release, cancel, dispute, rate, invoice, restore):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,9 @@ bridged by flutter_rust_bridge.
   whatever *uses* the missing field, so a stale `TradeInfo` reads as a broken test helper
   rather than as out-of-date bindings. If `flutter analyze` reports a field or l10n getter
   that plainly exists in `rust/src/api/types.rs` or `lib/l10n/*.arb`, regenerate before
-  believing it.
+  believing it. **Automate it:** `git config core.hooksPath .githooks` installs
+  `post-merge`/`post-checkout` hooks that regenerate both whenever the pull or branch
+  switch touched `rust/src/api/`, `pubspec.yaml`, or an `.arb` (no-op otherwise).
 
 ## Transport (protocol v2)
 - **Daemon messages** (new-order, take, release, cancel, dispute, rate, invoice, restore):

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -12,7 +12,7 @@ android {
     namespace = "foundation.mostro.app"
     compileSdk = flutter.compileSdkVersion
     // Pin NDK version for reproducible Rust cross-compilation builds
-    ndkVersion = "27.0.12077973"
+    ndkVersion = "28.2.13676358"
 
     compileOptions {
         isCoreLibraryDesugaringEnabled = true


### PR DESCRIPTION
## Summary
- **Android NDK 27 → 28.2.13676358** in `android/app/build.gradle.kts`: the transitive `jni` plugin now requires it and `assembleRelease` failed with *"jni requires Android NDK 28.2.13676358"*.
- **New `.githooks/post-merge` + `.githooks/post-checkout` + `.githooks/post-rewrite`** (sharing `regen-if-needed.sh`): after a pull or branch switch, if `rust/src/api/`, `pubspec.yaml` or any `lib/l10n/*.arb` changed between old and new HEAD, run `./scripts/frb-generate.sh` and/or `flutter gen-l10n`. No-op otherwise, so ordinary pulls stay fast. Installed by the same `git config core.hooksPath .githooks` the existing `pre-commit` already documents.
- `CLAUDE.md`: mention the hooks in the "regenerate after pulling" note.

## Why
`lib/src/rust/` and the generated l10n files are gitignored. Pulling #366/#368 brought `TradeInfo.peer_rating` and `fetch_exchange_rate` into `rust/src/api/` but not into local bindings, so the build failed with misleading `getter 'peerRating' isn't defined for 'TradeInfo'` errors. CI regenerates before analysing, so green CI never catches this on a developer checkout.

## Test plan
- [x] `.githooks/regen-if-needed.sh HEAD HEAD` → no-op
- [x] `post-checkout <old> HEAD 0` (file checkout) → skipped
- [x] `post-checkout 8dd5f5a HEAD 1` (range touching `rust/src/api/orders.rs`) → ran `frb-generate.sh`, bindings regenerated
- [x] `flutter analyze` clean after regen
- [x] `git pull --rebase` with a local commit touching `rust/src/api/` (git 2.43.0):
      `post-checkout` runs mid-rebase on the pre-replay tree, then `post-rewrite` runs
      again on the final tree — bindings match HEAD at the end (review r3919357657)
- [x] `git pull` (merge) / branch switch / rebase touching nothing generated / rebase
      that drops every local commit / `git commit --amend`: behaviour unchanged
- [ ] `flutter build apk --release` on a machine with NDK 28.2 installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7QQtaUvC1KPhmazAKCpH1
