### PR TITLE
feat(nostr): discover relays from the Mostro node's kind 10002 list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,10 +159,12 @@ bridged by flutter_rust_bridge.
 - **Reputation/ratings come from Kind 38383 event tags, not a DB.** In-memory
   `RATING_STORE`/`DISPUTE_STORE` are correct by design — don't invent "persist to DB" tasks.
   Chat history persists to the `messages` table since #246 (web still memory-only, #233).
-- **Relays persist in the `relays` table and grow from the node's kind 10002 list.** `initialize(None)`
-  restores the persisted set (or seeds the defaults on a fresh install); the active node's NIP-65
-  list is subscribed live and applied **additively** (never disconnects). Removing a
-  `MostroDiscovered` relay blacklists it (persisted), re-adding it lifts the blacklist.
+- **On native, relays persist in the `relays` table and grow from the node's kind 10002 list.**
+  `initialize(None)` restores the persisted set (or seeds the defaults on a fresh install); the
+  active node's NIP-65 list is subscribed live and applied **additively** (never disconnects).
+  Removing a `MostroDiscovered` relay blacklists it, re-adding it lifts the blacklist. On **web**
+  the IndexedDB relay store is still a stub (#233), so none of that survives a reload: discovery
+  works in-session only and every persistence failure is logged and ignored.
 - **Order book is sourced only from daemon Kind 38383 events.** `create_order` waits for daemon
   confirmation; on timeout it returns an error and **persists nothing** (no phantom order).
 - **The Kind 38383 `s` tag is never a trade's status.** It is NIP-69's four-bucket public view

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,10 @@ bridged by flutter_rust_bridge.
 - **Reputation/ratings come from Kind 38383 event tags, not a DB.** In-memory
   `RATING_STORE`/`DISPUTE_STORE` are correct by design — don't invent "persist to DB" tasks.
   Chat history persists to the `messages` table since #246 (web still memory-only, #233).
+- **Relays persist in the `relays` table and grow from the node's kind 10002 list.** `initialize(None)`
+  restores the persisted set (or seeds the defaults on a fresh install); the active node's NIP-65
+  list is subscribed live and applied **additively** (never disconnects). Removing a
+  `MostroDiscovered` relay blacklists it (persisted), re-adding it lifts the blacklist.
 - **Order book is sourced only from daemon Kind 38383 events.** `create_order` waits for daemon
   confirmation; on timeout it returns an error and **persists nothing** (no phantom order).
 - **The Kind 38383 `s` tag is never a trade's status.** It is NIP-69's four-bucket public view

--- a/lib/core/services/coalescing_loader.dart
+++ b/lib/core/services/coalescing_loader.dart
@@ -1,0 +1,39 @@
+import 'dart:async';
+
+/// Runs an async load at most once at a time, and remembers that one more was
+/// asked for while it was running.
+///
+/// The naive `if (_loading) return;` guard silently drops that request — and a
+/// dropped request is not a no-op when the running load has already read its
+/// data: it ends up showing a snapshot taken before whatever triggered the
+/// second request. One extra pass afterwards is enough to settle, however many
+/// requests arrived while the first was in flight.
+class CoalescingLoader {
+  CoalescingLoader(this._load);
+
+  final Future<void> Function() _load;
+
+  bool _running = false;
+  bool _pending = false;
+
+  /// Whether a load is in flight.
+  bool get isRunning => _running;
+
+  /// Run the load, or mark one as owed if it is already running.
+  Future<void> run() async {
+    if (_running) {
+      _pending = true;
+      return;
+    }
+    _running = true;
+    try {
+      await _load();
+    } finally {
+      _running = false;
+    }
+    if (_pending) {
+      _pending = false;
+      await run();
+    }
+  }
+}

--- a/lib/features/settings/providers/relay_auto_sync_provider.dart
+++ b/lib/features/settings/providers/relay_auto_sync_provider.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:mostro/src/rust/api/nostr.dart' as nostr_api;
+
+/// Relay URLs the Rust core auto-added from the active Mostro node's kind
+/// 10002 list, one emission per applied event.
+///
+/// **One subscription for the whole process, deliberately.** The Rust
+/// broadcast sender is process-global and never closes, so a pending
+/// `stream.next()` cannot be cancelled from Dart: a per-widget subscription
+/// would strand one blocked bridge task and one receiver on every visit to
+/// Settings. Keeping this provider alive means exactly one of each, ever.
+///
+/// The first emission is an **empty list**, sent as soon as the receiver
+/// exists rather than when a relay is discovered. That is what lets a
+/// listener take its relay snapshot with the receiver already installed, so
+/// a list applied in between arrives as an emission instead of being lost.
+final relayAutoSyncProvider = StreamProvider<List<String>>((ref) async* {
+  final stream = await nostr_api.onRelayAutoSynced();
+  yield const <String>[];
+  while (true) {
+    final added = await stream.next();
+    if (added == null) break;
+    yield added;
+  }
+});

--- a/lib/features/settings/widgets/relay_management_card.dart
+++ b/lib/features/settings/widgets/relay_management_card.dart
@@ -8,6 +8,7 @@ import 'package:mostro/core/mostro_defaults.dart';
 import 'package:mostro/core/test_environment.dart';
 import 'package:mostro/l10n/app_localizations.dart';
 import 'package:mostro/src/rust/api/nostr.dart' as nostr_api;
+import 'package:mostro/src/rust/api/types.dart' show RelaySource;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -25,11 +26,15 @@ class _RelayEntry {
     required this.url,
     required this.isActive,
     required this.isDefault,
+    this.source = RelaySource.default_,
   });
 
   final String url;
   bool isActive;
   final bool isDefault;
+  final RelaySource source;
+
+  bool get isFromMostro => source == RelaySource.mostroDiscovered;
 }
 
 // ── Widget ────────────────────────────────────────────────────────────────────
@@ -37,7 +42,10 @@ class _RelayEntry {
 /// Inline relay management card shown within the Settings screen.
 ///
 /// Default relays (from config.rs) are pre-populated and cannot be removed.
-/// Users may add additional relays with a `wss://` prefix.
+/// Users may add additional relays with a `wss://` prefix. Relays the active
+/// Mostro node announces in its kind 10002 list are auto-added by the Rust
+/// core and labelled as such; removing one blacklists it so the node's list
+/// does not bring it back.
 class RelayManagementCard extends ConsumerStatefulWidget {
   const RelayManagementCard({super.key});
 
@@ -52,6 +60,7 @@ class _RelayManagementCardState extends ConsumerState<RelayManagementCard> {
 
   late List<_RelayEntry> _relays;
   bool _loading = false;
+  bool _disposed = false;
 
   @override
   void initState() {
@@ -60,6 +69,30 @@ class _RelayManagementCardState extends ConsumerState<RelayManagementCard> {
         .map((url) => _RelayEntry(url: url, isActive: true, isDefault: true))
         .toList();
     _loadRelays();
+    _watchAutoSync();
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    super.dispose();
+  }
+
+  /// Reload the list whenever the Rust core auto-adds relays from the
+  /// active node's kind 10002 relay list, so they appear without a
+  /// screen re-entry.
+  Future<void> _watchAutoSync() async {
+    try {
+      final stream = await nostr_api.onRelayAutoSynced();
+      while (!_disposed) {
+        final added = await stream.next();
+        if (added == null || _disposed) break;
+        debugPrint('[RelayManagement] auto-synced relays: $added');
+        await _loadRelays();
+      }
+    } catch (e) {
+      debugPrint('[RelayManagement] auto-sync watch failed: $e');
+    }
   }
 
   Future<void> _loadRelays() async {
@@ -73,6 +106,7 @@ class _RelayManagementCardState extends ConsumerState<RelayManagementCard> {
           url: r.url,
           isActive: r.isActive,
           isDefault: r.isDefault,
+          source: r.source,
         )).toList();
       });
     } catch (e) {
@@ -247,14 +281,26 @@ class _RelayManagementCardState extends ConsumerState<RelayManagementCard> {
                   ),
                 ),
                 const SizedBox(width: AppSpacing.sm),
-                // Relay URL
+                // Relay URL, plus where it came from when a node added it
                 Expanded(
-                  child: Text(
-                    relay.url,
-                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          fontFamily: 'monospace',
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        relay.url,
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                              fontFamily: 'monospace',
+                            ),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      if (relay.isFromMostro)
+                        Text(
+                          l10n.relayFromMostroLabel,
+                          style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                                color: colors.textDisabled,
+                              ),
                         ),
-                    overflow: TextOverflow.ellipsis,
+                    ],
                   ),
                 ),
                 // Active toggle
@@ -268,7 +314,7 @@ class _RelayManagementCardState extends ConsumerState<RelayManagementCard> {
                     activeThumbColor: colors.mostroGreen,
                   ),
                 ),
-                // Remove button (user-added relays only)
+                // Remove button (user-added and node-announced relays)
                 if (!relay.isDefault)
                   IconButton(
                     icon: Icon(Icons.delete_outline, color: colors.destructiveRed),

--- a/lib/features/settings/widgets/relay_management_card.dart
+++ b/lib/features/settings/widgets/relay_management_card.dart
@@ -5,7 +5,9 @@ import 'package:mostro/core/app_theme.dart';
 import 'package:mostro/core/automation/automation_id.dart';
 import 'package:mostro/core/automation/automation_ids.dart';
 import 'package:mostro/core/mostro_defaults.dart';
+import 'package:mostro/core/services/coalescing_loader.dart';
 import 'package:mostro/core/test_environment.dart';
+import 'package:mostro/features/settings/providers/relay_auto_sync_provider.dart';
 import 'package:mostro/l10n/app_localizations.dart';
 import 'package:mostro/src/rust/api/nostr.dart' as nostr_api;
 import 'package:mostro/src/rust/api/types.dart' show RelaySource;
@@ -59,8 +61,11 @@ class _RelayManagementCardState extends ConsumerState<RelayManagementCard> {
   static const _defaultRelays = defaultMostroRelays;
 
   late List<_RelayEntry> _relays;
-  bool _loading = false;
-  bool _disposed = false;
+  /// Serialises reloads and keeps the one an auto-sync asks for while another
+  /// is in flight — that load may have read its snapshot before the new relay
+  /// existed, so dropping the request would hide it until a screen re-entry.
+  late final CoalescingLoader _loader = CoalescingLoader(_readRelays);
+  ProviderSubscription<AsyncValue<List<String>>>? _autoSyncSub;
 
   @override
   void initState() {
@@ -68,36 +73,33 @@ class _RelayManagementCardState extends ConsumerState<RelayManagementCard> {
     _relays = _defaultRelays
         .map((url) => _RelayEntry(url: url, isActive: true, isDefault: true))
         .toList();
-    _loadRelays();
-    _watchAutoSync();
+    // The initial load is driven by this subscription, not started here:
+    // `relayAutoSyncProvider` emits once the Rust-side receiver exists, so
+    // the first snapshot is taken with nothing able to slip past it. Every
+    // later emission is a node-announced relay to fold into the list.
+    _autoSyncSub = ref.listenManual<AsyncValue<List<String>>>(
+      relayAutoSyncProvider,
+      (_, next) => next.whenData((added) {
+        if (added.isNotEmpty) {
+          debugPrint('[RelayManagement] auto-synced relays: $added');
+        }
+        _loadRelays();
+      }),
+      onError: (e, _) =>
+          debugPrint('[RelayManagement] auto-sync watch failed: $e'),
+      fireImmediately: true,
+    );
   }
 
   @override
   void dispose() {
-    _disposed = true;
+    _autoSyncSub?.close();
     super.dispose();
   }
 
-  /// Reload the list whenever the Rust core auto-adds relays from the
-  /// active node's kind 10002 relay list, so they appear without a
-  /// screen re-entry.
-  Future<void> _watchAutoSync() async {
-    try {
-      final stream = await nostr_api.onRelayAutoSynced();
-      while (!_disposed) {
-        final added = await stream.next();
-        if (added == null || _disposed) break;
-        debugPrint('[RelayManagement] auto-synced relays: $added');
-        await _loadRelays();
-      }
-    } catch (e) {
-      debugPrint('[RelayManagement] auto-sync watch failed: $e');
-    }
-  }
+  Future<void> _loadRelays() => _loader.run();
 
-  Future<void> _loadRelays() async {
-    if (_loading) return;
-    _loading = true;
+  Future<void> _readRelays() async {
     try {
       final relays = await nostr_api.getRelays();
       if (!mounted) return;
@@ -111,8 +113,6 @@ class _RelayManagementCardState extends ConsumerState<RelayManagementCard> {
       });
     } catch (e) {
       debugPrint('[RelayManagement] failed to load relays: $e');
-    } finally {
-      _loading = false;
     }
   }
 

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -202,6 +202,7 @@
   "disableRelayLabel": "Relay {url} deaktivieren",
   "enableRelayLabel": "Relay {url} aktivieren",
   "removeRelayTooltip": "Relay entfernen",
+  "relayFromMostroLabel": "Vom Mostro-Knoten hinzugefügt",
   "relayAddFailed": "Relay konnte nicht hinzugefügt werden",
   "relayRemoveFailed": "Relay konnte nicht entfernt werden",
   "backupConfirmCheckbox": "Ich habe meine Wörter aufgeschrieben und sicher gespeichert",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -428,6 +428,8 @@
   },
   "removeRelayTooltip": "Remove relay",
   "@removeRelayTooltip": {"description": "Tooltip for the remove-relay icon button"},
+  "relayFromMostroLabel": "Added from the Mostro node",
+  "@relayFromMostroLabel": {"description": "Label under a relay URL that the active Mostro node announced in its kind 10002 relay list"},
   "relayAddFailed": "Failed to add relay",
   "@relayAddFailed": {"description": "SnackBar message shown when adding a relay fails"},
   "relayRemoveFailed": "Failed to remove relay",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -202,6 +202,7 @@
   "disableRelayLabel": "Desactivar relay {url}",
   "enableRelayLabel": "Activar relay {url}",
   "removeRelayTooltip": "Eliminar relay",
+  "relayFromMostroLabel": "Añadido desde el nodo Mostro",
   "relayAddFailed": "Error al añadir el relay",
   "relayRemoveFailed": "Error al eliminar el relay",
   "backupConfirmCheckbox": "He anotado mis palabras y las he guardado de forma segura",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -202,6 +202,7 @@
   "disableRelayLabel": "Désactiver le relais {url}",
   "enableRelayLabel": "Activer le relais {url}",
   "removeRelayTooltip": "Supprimer le relais",
+  "relayFromMostroLabel": "Ajouté depuis le nœud Mostro",
   "relayAddFailed": "Échec de l'ajout du relais",
   "relayRemoveFailed": "Échec de la suppression du relais",
   "backupConfirmCheckbox": "J'ai noté mes mots et les ai sauvegardés en lieu sûr",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -202,6 +202,7 @@
   "disableRelayLabel": "Disabilita relay {url}",
   "enableRelayLabel": "Abilita relay {url}",
   "removeRelayTooltip": "Rimuovi relay",
+  "relayFromMostroLabel": "Aggiunto dal nodo Mostro",
   "relayAddFailed": "Impossibile aggiungere il relay",
   "relayRemoveFailed": "Impossibile rimuovere il relay",
   "backupConfirmCheckbox": "Ho annotato le mie parole e le ho salvate in modo sicuro",

--- a/rust/src/api/nostr.rs
+++ b/rust/src/api/nostr.rs
@@ -8,11 +8,31 @@ use std::sync::Arc;
 use tokio::sync::OnceCell;
 
 use crate::api::types::{ConnectionState, RelayInfo};
+use crate::db::Storage;
 use crate::nostr::relay_pool::RelayPool;
 use crate::queue::outbox;
 
 /// Global relay pool singleton, initialised once by `initialize()`.
 static POOL: OnceCell<Arc<RelayPool>> = OnceCell::const_new();
+
+/// Newly auto-added relay URLs, one message per applied kind 10002 event.
+static RELAY_SYNC_TX: std::sync::OnceLock<tokio::sync::broadcast::Sender<Vec<String>>> =
+    std::sync::OnceLock::new();
+
+fn relay_sync_tx() -> &'static tokio::sync::broadcast::Sender<Vec<String>> {
+    RELAY_SYNC_TX.get_or_init(|| tokio::sync::broadcast::channel(16).0)
+}
+
+/// `created_at` of the newest kind 10002 applied, per node pubkey. Relays
+/// hold different generations of a replaceable event, so the live
+/// subscription can deliver an older list after a newer one; only the newest
+/// is ever applied.
+static RELAY_LIST_SEEN: std::sync::OnceLock<tokio::sync::Mutex<std::collections::HashMap<String, u64>>> =
+    std::sync::OnceLock::new();
+
+fn relay_list_seen() -> &'static tokio::sync::Mutex<std::collections::HashMap<String, u64>> {
+    RELAY_LIST_SEEN.get_or_init(|| tokio::sync::Mutex::new(std::collections::HashMap::new()))
+}
 
 fn pool() -> Result<&'static Arc<RelayPool>> {
     POOL.get().ok_or_else(|| anyhow::anyhow!("NotInitialized"))
@@ -20,7 +40,11 @@ fn pool() -> Result<&'static Arc<RelayPool>> {
 
 /// Initialize the Nostr client with a relay list.
 ///
-/// If `relays` is empty or `None`, uses preconfigured defaults.
+/// If `relays` is empty or `None`, uses the persisted relay set — every
+/// active relay the user or a Mostro node's kind 10002 list added, with the
+/// user's removals of announced relays restored as the blacklist — and,
+/// when nothing is persisted yet, the compiled-in defaults (which are then
+/// seeded so later runs read them back).
 pub async fn initialize(relays: Option<Vec<String>>) -> Result<()> {
     if POOL.get().is_some() {
         return Err(anyhow::anyhow!("AlreadyInitialized"));
@@ -33,12 +57,34 @@ pub async fn initialize(relays: Option<Vec<String>>) -> Result<()> {
         .filter(|s| !s.is_empty())
         .collect();
 
-    let urls = if urls.is_empty() { default_relays() } else { urls };
+    let (urls, persisted) = if urls.is_empty() {
+        let persisted = load_persisted_relays().await;
+        let active: Vec<String> = persisted
+            .iter()
+            .filter(|r| r.is_active && !r.is_blacklisted)
+            .map(|r| r.url.clone())
+            .collect();
+        if active.is_empty() {
+            (default_relays(), persisted)
+        } else {
+            (active, persisted)
+        }
+    } else {
+        (urls, Vec::new())
+    };
 
     // get_or_try_init is atomic — only one caller creates the pool even if
     // two race past the is_some() guard above.
-    POOL.get_or_try_init(|| async { RelayPool::new(urls).await })
+    let pool_ref = POOL
+        .get_or_try_init(|| async { RelayPool::new(urls).await })
         .await?;
+
+    // Restore what a previous session learned: sources of the persisted
+    // rows and the blacklist that keeps removed announced relays out.
+    pool_ref.restore_persisted(&persisted).await;
+    if persisted.is_empty() {
+        seed_default_relays().await;
+    }
 
     // Spawn a background task that flushes the outbox whenever the relay pool
     // transitions to Online.  The task exits when the broadcast channel closes.
@@ -83,12 +129,159 @@ pub async fn initialize(relays: Option<Vec<String>>) -> Result<()> {
 
 /// Add a new relay and connect to it.
 pub async fn add_relay(url: String) -> Result<RelayInfo> {
-    pool()?.add_relay(&url).await
+    let info = pool()?.add_relay(&url).await?;
+    persist_relay(&info).await;
+    Ok(info)
 }
 
 /// Remove a relay and disconnect.
+///
+/// A relay a Mostro node announced stays persisted as blacklisted, so the
+/// node's list cannot bring it back on the next start either.
 pub async fn remove_relay(url: String) -> Result<()> {
-    pool()?.remove_relay(&url).await
+    let pool = pool()?;
+    let removed = pool.get_relays().await.into_iter().find(|r| r.url == url);
+    pool.remove_relay(&url).await?;
+    match removed {
+        Some(mut info) if matches!(info.source, crate::api::types::RelaySource::MostroDiscovered) => {
+            info.is_active = false;
+            info.is_blacklisted = true;
+            info.status = crate::api::types::RelayStatus::Disconnected;
+            persist_relay(&info).await;
+        }
+        _ => unpersist_relay(&url).await,
+    }
+    Ok(())
+}
+
+/// Stream of relay URLs auto-added from the active node's kind 10002 relay
+/// list, one emission per applied event (only when something was added).
+pub async fn on_relay_auto_synced() -> Result<RelayAutoSyncStream> {
+    Ok(RelayAutoSyncStream {
+        rx: relay_sync_tx().subscribe(),
+    })
+}
+
+/// Wrapper so flutter_rust_bridge can generate a Dart Stream.
+pub struct RelayAutoSyncStream {
+    rx: tokio::sync::broadcast::Receiver<Vec<String>>,
+}
+
+impl RelayAutoSyncStream {
+    pub async fn next(&mut self) -> Option<Vec<String>> {
+        loop {
+            match self.rx.recv().await {
+                Ok(urls) => return Some(urls),
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => return None,
+            }
+        }
+    }
+}
+
+/// Apply a kind 10002 relay list published by the active node (the caller
+/// checks the author): parse it, add every announced relay we do not have
+/// and have not blacklisted, persist the additions, and tell the UI. Older
+/// generations than one already applied for this node are ignored.
+pub(crate) async fn apply_relay_list_event(event: &Event) {
+    let node = event.pubkey.to_hex();
+    let created_at = event.created_at.as_secs();
+    if !note_relay_list_generation(&mut *relay_list_seen().lock().await, &node, created_at) {
+        return;
+    }
+
+    let announced = crate::nostr::relay_list::parse_relay_list(event);
+    crate::api::logging::blog_info(
+        "relay",
+        format!(
+            "kind 10002 from node={}: {} relay(s) announced",
+            crate::api::logging::short_id(&node),
+            announced.len()
+        ),
+    );
+    let Ok(pool) = pool() else {
+        return;
+    };
+    let added = pool.sync_discovered(&announced).await;
+    if added.is_empty() {
+        return;
+    }
+    for info in pool.get_relays().await.iter().filter(|r| added.contains(&r.url)) {
+        persist_relay(info).await;
+    }
+    crate::api::logging::blog_info(
+        "relay",
+        format!(
+            "auto-added {} relay(s) from node list: {}",
+            added.len(),
+            added
+                .iter()
+                .map(|u| crate::api::logging::display_relay(u))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+    );
+    let _ = relay_sync_tx().send(added);
+}
+
+/// Record `created_at` as the newest relay list seen for `node` and say
+/// whether it is newer than every one applied before (strictly: a replay of
+/// the same generation from another relay is not applied twice).
+fn note_relay_list_generation(
+    seen: &mut std::collections::HashMap<String, u64>,
+    node: &str,
+    created_at: u64,
+) -> bool {
+    if seen.get(node).is_some_and(|&newest| created_at <= newest) {
+        return false;
+    }
+    seen.insert(node.to_string(), created_at);
+    true
+}
+
+// ── Relay persistence (best effort: web has no relay store yet, #233) ───────
+
+async fn load_persisted_relays() -> Vec<RelayInfo> {
+    let Some(db) = crate::db::app_db::db() else {
+        return Vec::new();
+    };
+    match db.list_relays().await {
+        Ok(rows) => rows,
+        Err(e) => {
+            log::warn!("[nostr] relay list not loaded from storage: {e}");
+            Vec::new()
+        }
+    }
+}
+
+async fn seed_default_relays() {
+    if let Some(db) = crate::db::app_db::db() {
+        if let Err(e) = crate::db::seeds::seed_defaults(db).await {
+            log::warn!("[nostr] default relays not seeded: {e}");
+        }
+    }
+}
+
+async fn persist_relay(info: &RelayInfo) {
+    if let Some(db) = crate::db::app_db::db() {
+        if let Err(e) = db.save_relay(info).await {
+            log::warn!(
+                "[nostr] relay {} not persisted: {e}",
+                crate::api::logging::display_relay(&info.url)
+            );
+        }
+    }
+}
+
+async fn unpersist_relay(url: &str) {
+    if let Some(db) = crate::db::app_db::db() {
+        if let Err(e) = db.delete_relay(url).await {
+            log::warn!(
+                "[nostr] relay {} not removed from storage: {e}",
+                crate::api::logging::display_relay(url)
+            );
+        }
+    }
 }
 
 /// Get all configured relays with current status.
@@ -506,5 +699,33 @@ mod tests {
             .sign_with_keys(&node)
             .unwrap();
         assert!(select_rates_event([wrong_d_tag], &node.public_key()).is_none());
+    }
+}
+
+#[cfg(test)]
+mod relay_list_generation_tests {
+    use super::note_relay_list_generation;
+    use std::collections::HashMap;
+
+    #[test]
+    fn first_list_for_a_node_is_applied() {
+        let mut seen = HashMap::new();
+        assert!(note_relay_list_generation(&mut seen, "node-a", 100));
+    }
+
+    #[test]
+    fn older_or_replayed_generations_are_ignored() {
+        let mut seen = HashMap::new();
+        assert!(note_relay_list_generation(&mut seen, "node-a", 100));
+        assert!(!note_relay_list_generation(&mut seen, "node-a", 100));
+        assert!(!note_relay_list_generation(&mut seen, "node-a", 99));
+        assert!(note_relay_list_generation(&mut seen, "node-a", 101));
+    }
+
+    #[test]
+    fn generations_are_tracked_per_node() {
+        let mut seen = HashMap::new();
+        assert!(note_relay_list_generation(&mut seen, "node-a", 100));
+        assert!(note_relay_list_generation(&mut seen, "node-b", 50));
     }
 }

--- a/rust/src/api/nostr.rs
+++ b/rust/src/api/nostr.rs
@@ -23,15 +23,37 @@ fn relay_sync_tx() -> &'static tokio::sync::broadcast::Sender<Vec<String>> {
     RELAY_SYNC_TX.get_or_init(|| tokio::sync::broadcast::channel(16).0)
 }
 
-/// `created_at` of the newest kind 10002 applied, per node pubkey. Relays
-/// hold different generations of a replaceable event, so the live
-/// subscription can deliver an older list after a newer one; only the newest
-/// is ever applied.
-static RELAY_LIST_SEEN: std::sync::OnceLock<tokio::sync::Mutex<std::collections::HashMap<String, u64>>> =
-    std::sync::OnceLock::new();
+/// The newest kind 10002 generation applied, per node pubkey. Relays hold
+/// different generations of a replaceable event, so the live subscription can
+/// deliver an older list after a newer one; only the newest is ever applied.
+///
+/// A generation is `(created_at, event id)`, not just `created_at`: NIP-01
+/// breaks a timestamp tie between two revisions of a replaceable event by
+/// keeping the **lowest** event id, so two lists published within the same
+/// second must be ordered by id and not both rejected.
+type RelayListGeneration = (u64, nostr_sdk::prelude::EventId);
 
-fn relay_list_seen() -> &'static tokio::sync::Mutex<std::collections::HashMap<String, u64>> {
+static RELAY_LIST_SEEN: std::sync::OnceLock<
+    tokio::sync::Mutex<std::collections::HashMap<String, RelayListGeneration>>,
+> = std::sync::OnceLock::new();
+
+fn relay_list_seen(
+) -> &'static tokio::sync::Mutex<std::collections::HashMap<String, RelayListGeneration>> {
     RELAY_LIST_SEEN.get_or_init(|| tokio::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+/// Order two generations of the same node's relay list the way NIP-01 orders
+/// revisions of a replaceable event: newer `created_at` wins, and on a tie the
+/// lower event id wins.
+fn generation_is_newer(candidate: RelayListGeneration, applied: RelayListGeneration) -> bool {
+    let (cand_at, cand_id) = candidate;
+    let (seen_at, seen_id) = applied;
+    match cand_at.cmp(&seen_at) {
+        std::cmp::Ordering::Greater => true,
+        std::cmp::Ordering::Less => false,
+        // Same second: NIP-01 retains the lexically lowest id.
+        std::cmp::Ordering::Equal => cand_id.as_bytes() < seen_id.as_bytes(),
+    }
 }
 
 fn pool() -> Result<&'static Arc<RelayPool>> {
@@ -142,16 +164,28 @@ pub async fn remove_relay(url: String) -> Result<()> {
     let pool = pool()?;
     let removed = pool.get_relays().await.into_iter().find(|r| r.url == url);
     pool.remove_relay(&url).await?;
-    match removed {
-        Some(mut info) if matches!(info.source, crate::api::types::RelaySource::MostroDiscovered) => {
-            info.is_active = false;
-            info.is_blacklisted = true;
-            info.status = crate::api::types::RelayStatus::Disconnected;
-            persist_relay(&info).await;
-        }
-        _ => unpersist_relay(&url).await,
+    match removal_effect(removed) {
+        Some(row) => persist_relay(&row).await,
+        None => unpersist_relay(&url).await,
     }
     Ok(())
+}
+
+/// What removing a relay leaves in storage: `Some(row)` to persist, `None` to
+/// delete the row outright.
+///
+/// A relay a Mostro node announced is kept as a blacklisted row instead of
+/// being deleted — the node re-announces its list on every reconnect, so
+/// forgetting the removal would bring the relay straight back.
+fn removal_effect(removed: Option<RelayInfo>) -> Option<RelayInfo> {
+    let mut info = removed?;
+    if !matches!(info.source, crate::api::types::RelaySource::MostroDiscovered) {
+        return None;
+    }
+    info.is_active = false;
+    info.is_blacklisted = true;
+    info.status = crate::api::types::RelayStatus::Disconnected;
+    Some(info)
 }
 
 /// Stream of relay URLs auto-added from the active node's kind 10002 relay
@@ -185,8 +219,8 @@ impl RelayAutoSyncStream {
 /// generations than one already applied for this node are ignored.
 pub(crate) async fn apply_relay_list_event(event: &Event) {
     let node = event.pubkey.to_hex();
-    let created_at = event.created_at.as_secs();
-    if !note_relay_list_generation(&mut *relay_list_seen().lock().await, &node, created_at) {
+    let generation = (event.created_at.as_secs(), event.id);
+    if !note_relay_list_generation(&mut *relay_list_seen().lock().await, &node, generation) {
         return;
     }
 
@@ -224,18 +258,21 @@ pub(crate) async fn apply_relay_list_event(event: &Event) {
     let _ = relay_sync_tx().send(added);
 }
 
-/// Record `created_at` as the newest relay list seen for `node` and say
+/// Record `generation` as the newest relay list seen for `node` and say
 /// whether it is newer than every one applied before (strictly: a replay of
 /// the same generation from another relay is not applied twice).
 fn note_relay_list_generation(
-    seen: &mut std::collections::HashMap<String, u64>,
+    seen: &mut std::collections::HashMap<String, RelayListGeneration>,
     node: &str,
-    created_at: u64,
+    generation: RelayListGeneration,
 ) -> bool {
-    if seen.get(node).is_some_and(|&newest| created_at <= newest) {
+    if seen
+        .get(node)
+        .is_some_and(|&applied| !generation_is_newer(generation, applied))
+    {
         return false;
     }
-    seen.insert(node.to_string(), created_at);
+    seen.insert(node.to_string(), generation);
     true
 }
 
@@ -704,30 +741,159 @@ mod tests {
     }
 }
 
+/// The remove → restart → restore → re-add lifecycle, against a real SQLite
+/// file rather than an in-memory fixture: a relay the node announced and the
+/// user removed must stay out across a restart, and adding it back by hand
+/// must lift the blacklist for good.
+///
+/// Native only: the IndexedDB backend does not persist relays yet (#233).
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod relay_blacklist_restart_tests {
+    use super::{removal_effect, RelayInfo};
+    use crate::db::sqlite::SqliteStorage;
+    use crate::db::Storage;
+    use crate::nostr::relay_pool::RelayPool;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    const DEFAULT: &str = "wss://default.example";
+    const ANNOUNCED: &str = "wss://announced.example";
+
+    fn temp_db_path() -> std::path::PathBuf {
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!("mostro_relay_bl_{}_{n}.db", std::process::id()))
+    }
+
+    /// A fresh pool restored from `storage`, the way `initialize(None)` builds
+    /// one at startup.
+    async fn boot(storage: &SqliteStorage) -> (std::sync::Arc<RelayPool>, Vec<RelayInfo>) {
+        let persisted = storage.list_relays().await.unwrap();
+        let urls: Vec<String> = if persisted.is_empty() {
+            vec![DEFAULT.to_string()]
+        } else {
+            persisted
+                .iter()
+                .filter(|r| !r.is_blacklisted)
+                .map(|r| r.url.clone())
+                .collect()
+        };
+        let pool = RelayPool::new(urls).await.unwrap();
+        pool.restore_persisted(&persisted).await;
+        (pool, persisted)
+    }
+
+    #[tokio::test]
+    async fn a_removed_announced_relay_stays_out_across_a_restart_until_re_added() {
+        let path = temp_db_path();
+        let db = path.to_str().unwrap().to_string();
+
+        // ── Session 1: the node announces a relay, the user removes it ──
+        {
+            let storage = SqliteStorage::open(&db).await.unwrap();
+            let (pool, _) = boot(&storage).await;
+            let added = pool.sync_discovered(&[ANNOUNCED.to_string()]).await;
+            assert_eq!(added, vec![ANNOUNCED.to_string()], "relay not auto-added");
+            for info in pool.get_relays().await {
+                storage.save_relay(&info).await.unwrap();
+            }
+
+            let removed = pool.get_relays().await.into_iter().find(|r| r.url == ANNOUNCED);
+            pool.remove_relay(ANNOUNCED).await.unwrap();
+            let row = removal_effect(removed).expect("an announced relay is kept, not deleted");
+            assert!(row.is_blacklisted);
+            storage.save_relay(&row).await.unwrap();
+        }
+
+        // ── Session 2: restart — the blacklist comes back from storage ──
+        {
+            let storage = SqliteStorage::open(&db).await.unwrap();
+            let (pool, persisted) = boot(&storage).await;
+            assert!(
+                persisted.iter().any(|r| r.url == ANNOUNCED && r.is_blacklisted),
+                "blacklisted row did not survive the restart"
+            );
+            assert_eq!(pool.blacklist().await, vec![ANNOUNCED.to_string()]);
+
+            // The node re-announces it on reconnect: it must not come back.
+            let added = pool.sync_discovered(&[ANNOUNCED.to_string()]).await;
+            assert!(added.is_empty(), "a blacklisted relay was re-added: {added:?}");
+
+            // Adding it by hand lifts the blacklist and persists it as active.
+            let info = pool.add_relay(ANNOUNCED).await.unwrap();
+            assert!(!info.is_blacklisted);
+            assert!(pool.blacklist().await.is_empty());
+            storage.save_relay(&info).await.unwrap();
+        }
+
+        // ── Session 3: restart again — it is a normal relay now ──
+        {
+            let storage = SqliteStorage::open(&db).await.unwrap();
+            let (pool, _) = boot(&storage).await;
+            assert!(pool.blacklist().await.is_empty(), "blacklist not cleared");
+            assert!(
+                pool.get_relays().await.iter().any(|r| r.url == ANNOUNCED),
+                "re-added relay missing after restart"
+            );
+        }
+
+        let _ = std::fs::remove_file(&path);
+    }
+}
+
 #[cfg(test)]
 mod relay_list_generation_tests {
-    use super::note_relay_list_generation;
+    use super::{note_relay_list_generation, RelayListGeneration};
+    use nostr_sdk::prelude::EventId;
     use std::collections::HashMap;
+
+    /// An event id whose first byte is `lead`; the rest is zero, so ids
+    /// compare in the order their `lead` bytes do.
+    fn id(lead: u8) -> EventId {
+        let mut bytes = [0u8; 32];
+        bytes[0] = lead;
+        EventId::from_byte_array(bytes)
+    }
+
+    fn gen(created_at: u64, lead: u8) -> RelayListGeneration {
+        (created_at, id(lead))
+    }
 
     #[test]
     fn first_list_for_a_node_is_applied() {
         let mut seen = HashMap::new();
-        assert!(note_relay_list_generation(&mut seen, "node-a", 100));
+        assert!(note_relay_list_generation(&mut seen, "node-a", gen(100, 1)));
     }
 
     #[test]
     fn older_or_replayed_generations_are_ignored() {
         let mut seen = HashMap::new();
-        assert!(note_relay_list_generation(&mut seen, "node-a", 100));
-        assert!(!note_relay_list_generation(&mut seen, "node-a", 100));
-        assert!(!note_relay_list_generation(&mut seen, "node-a", 99));
-        assert!(note_relay_list_generation(&mut seen, "node-a", 101));
+        assert!(note_relay_list_generation(&mut seen, "node-a", gen(100, 1)));
+        assert!(!note_relay_list_generation(&mut seen, "node-a", gen(100, 1)));
+        assert!(!note_relay_list_generation(&mut seen, "node-a", gen(99, 1)));
+        assert!(note_relay_list_generation(&mut seen, "node-a", gen(101, 1)));
     }
 
     #[test]
     fn generations_are_tracked_per_node() {
         let mut seen = HashMap::new();
-        assert!(note_relay_list_generation(&mut seen, "node-a", 100));
-        assert!(note_relay_list_generation(&mut seen, "node-b", 50));
+        assert!(note_relay_list_generation(&mut seen, "node-a", gen(100, 1)));
+        assert!(note_relay_list_generation(&mut seen, "node-b", gen(50, 1)));
+    }
+
+    /// NIP-01 breaks a `created_at` tie between two revisions of a
+    /// replaceable event by keeping the lowest event id — so the winner must
+    /// be applied whichever order the two arrive in.
+    #[test]
+    fn an_equal_timestamp_list_with_a_lower_id_wins() {
+        let mut seen = HashMap::new();
+        assert!(note_relay_list_generation(&mut seen, "node-a", gen(100, 9)));
+        assert!(note_relay_list_generation(&mut seen, "node-a", gen(100, 2)));
+    }
+
+    #[test]
+    fn an_equal_timestamp_list_with_a_higher_id_loses() {
+        let mut seen = HashMap::new();
+        assert!(note_relay_list_generation(&mut seen, "node-a", gen(100, 2)));
+        assert!(!note_relay_list_generation(&mut seen, "node-a", gen(100, 9)));
     }
 }

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -2976,6 +2976,11 @@ fn mostro_dm_subscription_id() -> nostr_sdk::SubscriptionId {
     nostr_sdk::SubscriptionId::new("mostro-dm")
 }
 
+/// Stable subscription ID for the node's kind 10002 relay list.
+fn relay_list_subscription_id() -> nostr_sdk::SubscriptionId {
+    nostr_sdk::SubscriptionId::new("mostro-relay-list")
+}
+
 /// (Re)subscribe the order-book (Kind 38383) and Mostro-reply (Kind 14)
 /// filters, author-pinned to `mostro_pubkey`.
 ///
@@ -3000,6 +3005,21 @@ async fn subscribe_node_filters(
             orders_subscription_id(),
             crate::api::logging::short_id(&mostro_pubkey.to_hex()),
         ),
+    );
+
+    // The node's NIP-65 relay list, kept live so an operator adding a relay
+    // reaches running clients; applied additively by apply_relay_list_event.
+    client
+        .subscribe_with_id(
+            relay_list_subscription_id(),
+            crate::nostr::relay_list::relay_list_filter(&mostro_pubkey),
+            None,
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("relay-list subscribe failed: {e}"))?;
+    crate::api::logging::blog_info(
+        "relay",
+        format!("sub created id={} kinds=[10002]", relay_list_subscription_id()),
     );
 
     // Kind-14 NIP-44 replies authored by Mostro for all known trade pubkeys.
@@ -3539,13 +3559,21 @@ async fn _run_order_subscription() {
                     continue;
                 }
 
-                // ── Kind 38383 order book event ──
-                // Ignore stale orders from a previously-active node (e.g. events
-                // buffered across a node switch); the book only ever holds the
-                // active node's orders.
+                // Everything below is authored by the active node only.
+                // Ignore stale events from a previously-active node (e.g.
+                // buffered across a node switch): the book only ever holds
+                // the active node's orders, and only its relay list is applied.
                 if event.pubkey != active_mostro {
                     continue;
                 }
+
+                // ── Kind 10002 relay list: auto-add announced relays ──
+                if event.kind.as_u16() == crate::nostr::relay_list::KIND_RELAY_LIST {
+                    crate::api::nostr::apply_relay_list_event(&event).await;
+                    continue;
+                }
+
+                // ── Kind 38383 order book event ──
                 ingest_order_event(&event).await;
             }
             // Raw relay control messages. Observation only — every arm just

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -48,7 +48,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1401466058;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1607104262;
 
 // Section: executor
 
@@ -1056,6 +1056,64 @@ fn wire__crate__api__reputation__RatingStream_next_impl(
                         let output_ok =
                             crate::api::reputation::RatingStream::next(&mut *api_that_guard)
                                 .await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__nostr__RelayAutoSyncStream_next_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "RelayAutoSyncStream_next",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<RelayAutoSyncStream>,
+            >>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, ()>(
+                    (move || async move {
+                        let mut api_that_guard = None;
+                        let decode_indices_ =
+                            flutter_rust_bridge::for_generated::lockable_compute_decode_order(
+                                vec![flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                    &api_that, 0, true,
+                                )],
+                            );
+                        for i in decode_indices_ {
+                            match i {
+                                0 => {
+                                    api_that_guard =
+                                        Some(api_that.lockable_decode_async_ref_mut().await)
+                                }
+                                _ => unreachable!(),
+                            }
+                        }
+                        let mut api_that_guard = api_that_guard.unwrap();
+                        let output_ok = Result::<_, ()>::Ok(
+                            crate::api::nostr::RelayAutoSyncStream::next(&mut *api_that_guard)
+                                .await,
+                        )?;
                         Ok(output_ok)
                     })()
                     .await,
@@ -3416,6 +3474,41 @@ fn wire__crate__api__reputation__on_rating_received_impl(
         },
     )
 }
+fn wire__crate__api__nostr__on_relay_auto_synced_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "on_relay_auto_synced",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || async move {
+                        let output_ok = crate::api::nostr::on_relay_auto_synced().await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
 fn wire__crate__api__nostr__on_relay_status_changed_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -4616,6 +4709,9 @@ flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
     flutter_rust_bridge::for_generated::RustAutoOpaqueInner<RatingStream>
 );
 flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
+    flutter_rust_bridge::for_generated::RustAutoOpaqueInner<RelayAutoSyncStream>
+);
+flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
     flutter_rust_bridge::for_generated::RustAutoOpaqueInner<RelayStatusStream>
 );
 flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
@@ -4739,6 +4835,16 @@ impl SseDecode for RatingStream {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut inner = <RustOpaqueMoi<
             flutter_rust_bridge::for_generated::RustAutoOpaqueInner<RatingStream>,
+        >>::sse_decode(deserializer);
+        return flutter_rust_bridge::for_generated::rust_auto_opaque_decode_owned(inner);
+    }
+}
+
+impl SseDecode for RelayAutoSyncStream {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <RustOpaqueMoi<
+            flutter_rust_bridge::for_generated::RustAutoOpaqueInner<RelayAutoSyncStream>,
         >>::sse_decode(deserializer);
         return flutter_rust_bridge::for_generated::rust_auto_opaque_decode_owned(inner);
     }
@@ -4900,6 +5006,16 @@ impl SseDecode
 
 impl SseDecode
     for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<RatingStream>>
+{
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <usize>::sse_decode(deserializer);
+        return decode_rust_opaque_moi(inner);
+    }
+}
+
+impl SseDecode
+    for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<RelayAutoSyncStream>>
 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -6240,247 +6356,254 @@ fn pde_ffi_dispatcher_primary_impl(
         18 => {
             wire__crate__api__reputation__RatingStream_next_impl(port, ptr, rust_vec_len, data_len)
         }
-        19 => {
+        19 => wire__crate__api__nostr__RelayAutoSyncStream_next_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        20 => {
             wire__crate__api__nostr__RelayStatusStream_next_impl(port, ptr, rust_vec_len, data_len)
         }
-        20 => {
+        21 => {
             wire__crate__api__settings__SettingsStream_next_impl(port, ptr, rust_vec_len, data_len)
         }
-        21 => wire__crate__api__identity__TradeKeyIndexStream_next_impl(
+        22 => wire__crate__api__identity__TradeKeyIndexStream_next_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        22 => wire__crate__api__orders__TradeUpdatesStream_next_impl(
+        23 => wire__crate__api__orders__TradeUpdatesStream_next_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        23 => wire__crate__api__messages__UnreadCountStream_next_impl(
+        24 => wire__crate__api__messages__UnreadCountStream_next_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        24 => {
+        25 => {
             wire__crate__api__nwc__WalletStatusStream_next_impl(port, ptr, rust_vec_len, data_len)
         }
-        25 => wire__crate__api__nostr__add_relay_impl(port, ptr, rust_vec_len, data_len),
-        26 => wire__crate__api__orders__cancel_order_impl(port, ptr, rust_vec_len, data_len),
-        27 => wire__crate__api__logging__clear_logs_impl(port, ptr, rust_vec_len, data_len),
-        28 => wire__crate__api__nwc__connect_wallet_impl(port, ptr, rust_vec_len, data_len),
-        29 => wire__crate__api__identity__create_identity_impl(port, ptr, rust_vec_len, data_len),
-        30 => wire__crate__api__orders__create_order_impl(port, ptr, rust_vec_len, data_len),
-        31 => wire__crate__api__identity__delete_identity_impl(port, ptr, rust_vec_len, data_len),
-        32 => wire__crate__api__identity__derive_trade_key_impl(port, ptr, rust_vec_len, data_len),
-        33 => wire__crate__api__nwc__disconnect_wallet_impl(port, ptr, rust_vec_len, data_len),
-        34 => {
+        26 => wire__crate__api__nostr__add_relay_impl(port, ptr, rust_vec_len, data_len),
+        27 => wire__crate__api__orders__cancel_order_impl(port, ptr, rust_vec_len, data_len),
+        28 => wire__crate__api__logging__clear_logs_impl(port, ptr, rust_vec_len, data_len),
+        29 => wire__crate__api__nwc__connect_wallet_impl(port, ptr, rust_vec_len, data_len),
+        30 => wire__crate__api__identity__create_identity_impl(port, ptr, rust_vec_len, data_len),
+        31 => wire__crate__api__orders__create_order_impl(port, ptr, rust_vec_len, data_len),
+        32 => wire__crate__api__identity__delete_identity_impl(port, ptr, rust_vec_len, data_len),
+        33 => wire__crate__api__identity__derive_trade_key_impl(port, ptr, rust_vec_len, data_len),
+        34 => wire__crate__api__nwc__disconnect_wallet_impl(port, ptr, rust_vec_len, data_len),
+        35 => {
             wire__crate__api__messages__download_attachment_impl(port, ptr, rust_vec_len, data_len)
         }
-        35 => wire__crate__api__identity__export_encrypted_backup_impl(
+        36 => wire__crate__api__identity__export_encrypted_backup_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        36 => wire__crate__api__nostr__fetch_exchange_rate_impl(port, ptr, rust_vec_len, data_len),
-        37 => wire__crate__api__nostr__fetch_mostro_instance_tags_impl(
+        37 => wire__crate__api__nostr__fetch_exchange_rate_impl(port, ptr, rust_vec_len, data_len),
+        38 => wire__crate__api__nostr__fetch_mostro_instance_tags_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        38 => wire__crate__api__nostr__flush_message_queue_impl(port, ptr, rust_vec_len, data_len),
-        39 => wire__crate__api__get_app_version_impl(port, ptr, rust_vec_len, data_len),
-        40 => wire__crate__api__messages__get_attachment_status_impl(
+        39 => wire__crate__api__nostr__flush_message_queue_impl(port, ptr, rust_vec_len, data_len),
+        40 => wire__crate__api__get_app_version_impl(port, ptr, rust_vec_len, data_len),
+        41 => wire__crate__api__messages__get_attachment_status_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        41 => wire__crate__api__nwc__get_balance_impl(port, ptr, rust_vec_len, data_len),
-        42 => wire__crate__api__nostr__get_connection_state_impl(port, ptr, rust_vec_len, data_len),
-        43 => wire__crate__api__disputes__get_dispute_impl(port, ptr, rust_vec_len, data_len),
-        44 => wire__crate__api__escrow__get_escrow_mode_impl(port, ptr, rust_vec_len, data_len),
-        45 => wire__crate__api__identity__get_identity_impl(port, ptr, rust_vec_len, data_len),
-        46 => wire__crate__api__messages__get_messages_impl(port, ptr, rust_vec_len, data_len),
-        47 => wire__crate__api__settings__get_mostro_pubkey_impl(port, ptr, rust_vec_len, data_len),
-        48 => wire__crate__api__identity__get_nym_identity_impl(port, ptr, rust_vec_len, data_len),
-        49 => wire__crate__api__orders__get_order_impl(port, ptr, rust_vec_len, data_len),
-        50 => wire__crate__api__orders__get_orders_impl(port, ptr, rust_vec_len, data_len),
-        51 => {
+        42 => wire__crate__api__nwc__get_balance_impl(port, ptr, rust_vec_len, data_len),
+        43 => wire__crate__api__nostr__get_connection_state_impl(port, ptr, rust_vec_len, data_len),
+        44 => wire__crate__api__disputes__get_dispute_impl(port, ptr, rust_vec_len, data_len),
+        45 => wire__crate__api__escrow__get_escrow_mode_impl(port, ptr, rust_vec_len, data_len),
+        46 => wire__crate__api__identity__get_identity_impl(port, ptr, rust_vec_len, data_len),
+        47 => wire__crate__api__messages__get_messages_impl(port, ptr, rust_vec_len, data_len),
+        48 => wire__crate__api__settings__get_mostro_pubkey_impl(port, ptr, rust_vec_len, data_len),
+        49 => wire__crate__api__identity__get_nym_identity_impl(port, ptr, rust_vec_len, data_len),
+        50 => wire__crate__api__orders__get_order_impl(port, ptr, rust_vec_len, data_len),
+        51 => wire__crate__api__orders__get_orders_impl(port, ptr, rust_vec_len, data_len),
+        52 => {
             wire__crate__api__reputation__get_privacy_mode_impl(port, ptr, rust_vec_len, data_len)
         }
-        52 => wire__crate__api__reputation__get_rating_for_trade_impl(
+        53 => wire__crate__api__reputation__get_rating_for_trade_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        53 => wire__crate__api__nostr__get_relays_impl(port, ptr, rust_vec_len, data_len),
-        54 => wire__crate__api__settings__get_settings_impl(port, ptr, rust_vec_len, data_len),
-        55 => wire__crate__api__identity__get_trade_key_impl(port, ptr, rust_vec_len, data_len),
-        56 => wire__crate__api__orders__get_trade_role_impl(port, ptr, rust_vec_len, data_len),
-        57 => wire__crate__api__messages__get_unread_count_impl(port, ptr, rust_vec_len, data_len),
-        58 => wire__crate__api__nwc__get_wallet_impl(port, ptr, rust_vec_len, data_len),
-        59 => wire__crate__api__disputes__handle_admin_canceled_impl(
+        54 => wire__crate__api__nostr__get_relays_impl(port, ptr, rust_vec_len, data_len),
+        55 => wire__crate__api__settings__get_settings_impl(port, ptr, rust_vec_len, data_len),
+        56 => wire__crate__api__identity__get_trade_key_impl(port, ptr, rust_vec_len, data_len),
+        57 => wire__crate__api__orders__get_trade_role_impl(port, ptr, rust_vec_len, data_len),
+        58 => wire__crate__api__messages__get_unread_count_impl(port, ptr, rust_vec_len, data_len),
+        59 => wire__crate__api__nwc__get_wallet_impl(port, ptr, rust_vec_len, data_len),
+        60 => wire__crate__api__disputes__handle_admin_canceled_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        60 => {
+        61 => {
             wire__crate__api__disputes__handle_admin_settled_impl(port, ptr, rust_vec_len, data_len)
         }
-        61 => wire__crate__api__disputes__handle_admin_took_dispute_impl(
+        62 => wire__crate__api__disputes__handle_admin_took_dispute_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        62 => wire__crate__api__reputation__handle_rating_received_impl(
+        63 => wire__crate__api__reputation__handle_rating_received_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        63 => {
+        64 => {
             wire__crate__api__identity__import_from_mnemonic_impl(port, ptr, rust_vec_len, data_len)
         }
-        64 => wire__crate__api__identity__import_from_nsec_impl(port, ptr, rust_vec_len, data_len),
-        65 => wire__crate__api__init_db_impl(port, ptr, rust_vec_len, data_len),
-        66 => wire__crate__api__nostr__initialize_impl(port, ptr, rust_vec_len, data_len),
-        67 => wire__crate__api__logging__install_log_bridge_impl(port, ptr, rust_vec_len, data_len),
-        68 => wire__crate__api__orders__list_trades_impl(port, ptr, rust_vec_len, data_len),
-        69 => wire__crate__api__identity__load_identity_from_mnemonic_impl(
+        65 => wire__crate__api__identity__import_from_nsec_impl(port, ptr, rust_vec_len, data_len),
+        66 => wire__crate__api__init_db_impl(port, ptr, rust_vec_len, data_len),
+        67 => wire__crate__api__nostr__initialize_impl(port, ptr, rust_vec_len, data_len),
+        68 => wire__crate__api__logging__install_log_bridge_impl(port, ptr, rust_vec_len, data_len),
+        69 => wire__crate__api__orders__list_trades_impl(port, ptr, rust_vec_len, data_len),
+        70 => wire__crate__api__identity__load_identity_from_mnemonic_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        70 => wire__crate__api__nwc__make_invoice_impl(port, ptr, rust_vec_len, data_len),
-        71 => wire__crate__api__messages__mark_as_read_impl(port, ptr, rust_vec_len, data_len),
-        72 => wire__crate__api__messages__on_attachment_progress_impl(
+        71 => wire__crate__api__nwc__make_invoice_impl(port, ptr, rust_vec_len, data_len),
+        72 => wire__crate__api__messages__mark_as_read_impl(port, ptr, rust_vec_len, data_len),
+        73 => wire__crate__api__messages__on_attachment_progress_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        73 => wire__crate__api__bond__on_bond_slashed_impl(port, ptr, rust_vec_len, data_len),
-        74 => wire__crate__api__nostr__on_connection_state_changed_impl(
+        74 => wire__crate__api__bond__on_bond_slashed_impl(port, ptr, rust_vec_len, data_len),
+        75 => wire__crate__api__nostr__on_connection_state_changed_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        75 => {
+        76 => {
             wire__crate__api__disputes__on_dispute_updated_impl(port, ptr, rust_vec_len, data_len)
         }
-        76 => {
+        77 => {
             wire__crate__api__escrow__on_escrow_mode_changed_impl(port, ptr, rust_vec_len, data_len)
         }
-        77 => wire__crate__api__logging__on_log_entry_impl(port, ptr, rust_vec_len, data_len),
-        78 => wire__crate__api__messages__on_new_message_impl(port, ptr, rust_vec_len, data_len),
-        79 => wire__crate__api__orders__on_orders_updated_impl(port, ptr, rust_vec_len, data_len),
-        80 => {
+        78 => wire__crate__api__logging__on_log_entry_impl(port, ptr, rust_vec_len, data_len),
+        79 => wire__crate__api__messages__on_new_message_impl(port, ptr, rust_vec_len, data_len),
+        80 => wire__crate__api__orders__on_orders_updated_impl(port, ptr, rust_vec_len, data_len),
+        81 => {
             wire__crate__api__reputation__on_rating_received_impl(port, ptr, rust_vec_len, data_len)
         }
-        81 => {
+        82 => wire__crate__api__nostr__on_relay_auto_synced_impl(port, ptr, rust_vec_len, data_len),
+        83 => {
             wire__crate__api__nostr__on_relay_status_changed_impl(port, ptr, rust_vec_len, data_len)
         }
-        82 => {
+        84 => {
             wire__crate__api__settings__on_settings_changed_impl(port, ptr, rust_vec_len, data_len)
         }
-        83 => wire__crate__api__identity__on_trade_key_index_changed_impl(
+        85 => wire__crate__api__identity__on_trade_key_index_changed_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        84 => wire__crate__api__orders__on_trade_updated_impl(port, ptr, rust_vec_len, data_len),
-        85 => wire__crate__api__messages__on_unread_count_changed_impl(
+        86 => wire__crate__api__orders__on_trade_updated_impl(port, ptr, rust_vec_len, data_len),
+        87 => wire__crate__api__messages__on_unread_count_changed_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        86 => {
+        88 => {
             wire__crate__api__nwc__on_wallet_status_changed_impl(port, ptr, rust_vec_len, data_len)
         }
-        87 => wire__crate__api__disputes__open_dispute_impl(port, ptr, rust_vec_len, data_len),
-        88 => {
+        89 => wire__crate__api__disputes__open_dispute_impl(port, ptr, rust_vec_len, data_len),
+        90 => {
             wire__crate__api__orders__order_filters_default_impl(port, ptr, rust_vec_len, data_len)
         }
-        89 => wire__crate__api__nwc__pay_invoice_impl(port, ptr, rust_vec_len, data_len),
-        90 => wire__crate__api__logging__recent_logs_impl(port, ptr, rust_vec_len, data_len),
-        91 => wire__crate__api__settings__rehydrate_active_mostro_node_impl(
+        91 => wire__crate__api__nwc__pay_invoice_impl(port, ptr, rust_vec_len, data_len),
+        92 => wire__crate__api__logging__recent_logs_impl(port, ptr, rust_vec_len, data_len),
+        93 => wire__crate__api__settings__rehydrate_active_mostro_node_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        92 => wire__crate__api__escrow__rehydrate_escrow_overrides_impl(
+        94 => wire__crate__api__escrow__rehydrate_escrow_overrides_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        93 => wire__crate__api__orders__release_order_impl(port, ptr, rust_vec_len, data_len),
-        94 => wire__crate__api__nostr__remove_relay_impl(port, ptr, rust_vec_len, data_len),
-        95 => wire__crate__api__orders__restart_orders_subscription_impl(
+        95 => wire__crate__api__orders__release_order_impl(port, ptr, rust_vec_len, data_len),
+        96 => wire__crate__api__nostr__remove_relay_impl(port, ptr, rust_vec_len, data_len),
+        97 => wire__crate__api__orders__restart_orders_subscription_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        96 => wire__crate__api__orders__send_fiat_sent_impl(port, ptr, rust_vec_len, data_len),
-        97 => wire__crate__api__messages__send_file_impl(port, ptr, rust_vec_len, data_len),
-        98 => wire__crate__api__orders__send_invoice_impl(port, ptr, rust_vec_len, data_len),
-        99 => wire__crate__api__messages__send_message_impl(port, ptr, rust_vec_len, data_len),
-        100 => wire__crate__api__settings__set_active_mostro_node_impl(
+        98 => wire__crate__api__orders__send_fiat_sent_impl(port, ptr, rust_vec_len, data_len),
+        99 => wire__crate__api__messages__send_file_impl(port, ptr, rust_vec_len, data_len),
+        100 => wire__crate__api__orders__send_invoice_impl(port, ptr, rust_vec_len, data_len),
+        101 => wire__crate__api__messages__send_message_impl(port, ptr, rust_vec_len, data_len),
+        102 => wire__crate__api__settings__set_active_mostro_node_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        101 => wire__crate__api__escrow__set_cashu_mint_url_override_impl(
+        103 => wire__crate__api__escrow__set_cashu_mint_url_override_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        102 => wire__crate__api__settings__set_default_fiat_code_impl(
+        104 => wire__crate__api__settings__set_default_fiat_code_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        103 => wire__crate__api__settings__set_default_lightning_address_impl(
+        105 => wire__crate__api__settings__set_default_lightning_address_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        104 => wire__crate__api__escrow__set_escrow_mode_override_impl(
+        106 => wire__crate__api__escrow__set_escrow_mode_override_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        105 => wire__crate__api__settings__set_language_impl(port, ptr, rust_vec_len, data_len),
-        106 => {
+        107 => wire__crate__api__settings__set_language_impl(port, ptr, rust_vec_len, data_len),
+        108 => {
             wire__crate__api__settings__set_logging_enabled_impl(port, ptr, rust_vec_len, data_len)
         }
-        107 => {
+        109 => {
             wire__crate__api__reputation__set_privacy_mode_impl(port, ptr, rust_vec_len, data_len)
         }
-        108 => wire__crate__api__settings__set_theme_impl(port, ptr, rust_vec_len, data_len),
-        109 => wire__crate__api__disputes__submit_evidence_impl(port, ptr, rust_vec_len, data_len),
-        110 => wire__crate__api__reputation__submit_rating_impl(port, ptr, rust_vec_len, data_len),
-        111 => wire__crate__api__orders__subscribe_orders_impl(port, ptr, rust_vec_len, data_len),
-        112 => wire__crate__api__orders__take_order_impl(port, ptr, rust_vec_len, data_len),
+        110 => wire__crate__api__settings__set_theme_impl(port, ptr, rust_vec_len, data_len),
+        111 => wire__crate__api__disputes__submit_evidence_impl(port, ptr, rust_vec_len, data_len),
+        112 => wire__crate__api__reputation__submit_rating_impl(port, ptr, rust_vec_len, data_len),
+        113 => wire__crate__api__orders__subscribe_orders_impl(port, ptr, rust_vec_len, data_len),
+        114 => wire__crate__api__orders__take_order_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -6655,6 +6778,24 @@ impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for FrbWrapper<
 
 impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<RatingStream>> for RatingStream {
     fn into_into_dart(self) -> FrbWrapper<RatingStream> {
+        self.into()
+    }
+}
+
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<RelayAutoSyncStream> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        flutter_rust_bridge::for_generated::rust_auto_opaque_encode::<_, MoiArc<_>>(self.0)
+            .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<RelayAutoSyncStream>
+{
+}
+
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<RelayAutoSyncStream>> for RelayAutoSyncStream {
+    fn into_into_dart(self) -> FrbWrapper<RelayAutoSyncStream> {
         self.into()
     }
 }
@@ -7823,6 +7964,13 @@ impl SseEncode for RatingStream {
     }
 }
 
+impl SseEncode for RelayAutoSyncStream {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<RelayAutoSyncStream>>>::sse_encode(flutter_rust_bridge::for_generated::rust_auto_opaque_encode::<_, MoiArc<_>>(self), serializer);
+    }
+}
+
 impl SseEncode for RelayStatusStream {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -7970,6 +8118,17 @@ impl SseEncode
 
 impl SseEncode
     for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<RatingStream>>
+{
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        let (ptr, size) = self.sse_encode_raw();
+        <usize>::sse_encode(ptr, serializer);
+        <i32>::sse_encode(size, serializer);
+    }
+}
+
+impl SseEncode
+    for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<RelayAutoSyncStream>>
 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -9273,6 +9432,20 @@ mod io {
     }
 
     #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_mostro_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRelayAutoSyncStream(
+        ptr: *const std::ffi::c_void,
+    ) {
+        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<RelayAutoSyncStream>>::increment_strong_count(ptr as _);
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_mostro_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRelayAutoSyncStream(
+        ptr: *const std::ffi::c_void,
+    ) {
+        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<RelayAutoSyncStream>>::decrement_strong_count(ptr as _);
+    }
+
+    #[unsafe(no_mangle)]
     pub extern "C" fn frbgen_mostro_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRelayStatusStream(
         ptr: *const std::ffi::c_void,
     ) {
@@ -9529,6 +9702,20 @@ mod web {
         ptr: *const std::ffi::c_void,
     ) {
         MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<RatingStream>>::decrement_strong_count(ptr as _);
+    }
+
+    #[wasm_bindgen]
+    pub fn rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRelayAutoSyncStream(
+        ptr: *const std::ffi::c_void,
+    ) {
+        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<RelayAutoSyncStream>>::increment_strong_count(ptr as _);
+    }
+
+    #[wasm_bindgen]
+    pub fn rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRelayAutoSyncStream(
+        ptr: *const std::ffi::c_void,
+    ) {
+        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<RelayAutoSyncStream>>::decrement_strong_count(ptr as _);
     }
 
     #[wasm_bindgen]

--- a/rust/src/nostr/mod.rs
+++ b/rust/src/nostr/mod.rs
@@ -1,4 +1,5 @@
 pub mod blossom;
 pub mod transport;
 pub mod order_events;
+pub mod relay_list;
 pub mod relay_pool;

--- a/rust/src/nostr/relay_list.rs
+++ b/rust/src/nostr/relay_list.rs
@@ -1,0 +1,141 @@
+//! Kind 10002 (NIP-65) relay list published by a Mostro node.
+//!
+//! The daemon announces the relays it reads from and writes to as `r` tags.
+//! Both directions matter to a client — we read its Kind 38383 / Kind 14
+//! events where it writes, and it reads our Kind 14 messages where it reads
+//! — so every `r` tag is taken regardless of its read/write marker.
+//!
+//! Reference: <https://github.com/nostr-protocol/nips/blob/master/65.md>
+use nostr_sdk::prelude::*;
+
+/// Kind 10002 — NIP-65 relay list metadata.
+pub const KIND_RELAY_LIST: u16 = 10002;
+
+/// Filter for the newest relay list of a node. Kind 10002 is replaceable,
+/// so a relay holds at most one per author; `limit(1)` only trims the
+/// duplicates a multi-relay fetch returns.
+pub fn relay_list_filter(mostro_pubkey: &PublicKey) -> Filter {
+    Filter::new()
+        .kind(Kind::from(KIND_RELAY_LIST))
+        .author(*mostro_pubkey)
+        .limit(1)
+}
+
+/// The relay URLs announced by a Kind 10002 event, normalised and
+/// de-duplicated in tag order. Tags that are not `r`, that carry no URL, or
+/// whose URL is not a WebSocket URL are skipped.
+pub fn parse_relay_list(event: &Event) -> Vec<String> {
+    let mut urls: Vec<String> = Vec::new();
+    for tag in event.tags.iter() {
+        let parts = tag.as_slice();
+        if parts.first().map(String::as_str) != Some("r") {
+            continue;
+        }
+        let Some(url) = parts.get(1).and_then(|raw| normalize_relay_url(raw)) else {
+            continue;
+        };
+        if !urls.contains(&url) {
+            urls.push(url);
+        }
+    }
+    urls
+}
+
+/// Canonical form of a relay URL for equality checks: trimmed, scheme and
+/// host lower-cased, no trailing slash. Returns `None` unless the scheme is
+/// `ws` or `wss` and a host is present.
+pub fn normalize_relay_url(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    let (scheme, rest) = trimmed.split_once("://")?;
+    let scheme = scheme.to_ascii_lowercase();
+    if scheme != "ws" && scheme != "wss" {
+        return None;
+    }
+    let rest = rest.trim_end_matches('/');
+    let (host, path) = match rest.find('/') {
+        Some(i) => (&rest[..i], &rest[i..]),
+        None => (rest, ""),
+    };
+    if host.is_empty() {
+        return None;
+    }
+    Some(format!("{scheme}://{}{path}", host.to_ascii_lowercase()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn relay_list_event(tags: &[&[&str]]) -> Event {
+        EventBuilder::new(Kind::from(KIND_RELAY_LIST), "")
+            .tags(tags.iter().map(|t| Tag::parse(t.iter().copied()).unwrap()))
+            .sign_with_keys(&Keys::generate())
+            .unwrap()
+    }
+
+    #[test]
+    fn takes_every_r_tag_regardless_of_marker() {
+        let event = relay_list_event(&[
+            &["r", "wss://relay.mostro.network"],
+            &["r", "wss://nos.lol", "read"],
+            &["r", "wss://mostro-p2p.tech", "write"],
+        ]);
+
+        let urls = parse_relay_list(&event);
+
+        assert_eq!(
+            urls,
+            vec!["wss://relay.mostro.network", "wss://nos.lol", "wss://mostro-p2p.tech"]
+        );
+    }
+
+    #[test]
+    fn normalises_and_dedupes_urls_in_tag_order() {
+        let event = relay_list_event(&[
+            &["r", "WSS://Relay.Mostro.Network/"],
+            &["r", "wss://relay.mostro.network"],
+            &["r", " wss://nos.lol "],
+        ]);
+
+        let urls = parse_relay_list(&event);
+
+        assert_eq!(urls, vec!["wss://relay.mostro.network", "wss://nos.lol"]);
+    }
+
+    #[test]
+    fn skips_non_r_tags_and_non_websocket_urls() {
+        let event = relay_list_event(&[
+            &["r", "https://relay.mostro.network"],
+            &["r", "relay.mostro.network"],
+            &["r", ""],
+            &["r"],
+            &["p", "wss://not-a-relay-tag.example"],
+            &["r", "ws://localhost:7777"],
+        ]);
+
+        let urls = parse_relay_list(&event);
+
+        assert_eq!(urls, vec!["ws://localhost:7777"]);
+    }
+
+    #[test]
+    fn relay_list_filter_is_author_pinned_to_kind_10002() {
+        let mostro = Keys::generate().public_key();
+
+        let filter = relay_list_filter(&mostro);
+
+        assert_eq!(filter.kinds, Some([Kind::from(10002)].into_iter().collect()));
+        assert_eq!(filter.authors, Some([mostro].into_iter().collect()));
+        assert_eq!(filter.limit, Some(1));
+    }
+
+    #[test]
+    fn normalize_keeps_path_case_and_strips_trailing_slash() {
+        assert_eq!(
+            normalize_relay_url("wss://Example.com/Path/"),
+            Some("wss://example.com/Path".to_string())
+        );
+        assert_eq!(normalize_relay_url("wss:///"), None);
+        assert_eq!(normalize_relay_url("http://example.com"), None);
+    }
+}

--- a/rust/src/nostr/relay_pool.rs
+++ b/rust/src/nostr/relay_pool.rs
@@ -12,6 +12,7 @@ use nostr_sdk::prelude::*;
 // The SDK re-exports its own `RelayStatus` via the prelude. Alias it to avoid
 // conflicting with our internal `RelayStatus` from `crate::api::types`.
 use nostr_sdk::RelayStatus as SdkRelayStatus;
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{broadcast, RwLock};
@@ -25,6 +26,10 @@ const STATUS_POLL_INTERVAL_SECS: u64 = 2;
 pub struct RelayPool {
     client: Arc<Client>,
     relays: Arc<RwLock<Vec<RelayInfo>>>,
+    /// Relays the user removed after a Mostro node announced them. A node's
+    /// kind 10002 list is re-applied on every reconnect and node switch, so
+    /// without this the removed relay would come straight back.
+    blacklist: RwLock<HashSet<String>>,
     conn_tx: broadcast::Sender<ConnectionState>,
     relay_tx: broadcast::Sender<RelayInfo>,
 }
@@ -41,6 +46,7 @@ impl RelayPool {
         let pool = Arc::new(Self {
             client: client.clone(),
             relays: Arc::new(RwLock::new(Vec::new())),
+            blacklist: RwLock::new(HashSet::new()),
             conn_tx,
             relay_tx,
         });
@@ -68,6 +74,17 @@ impl RelayPool {
             .add_relay(url)
             .await
             .map_err(|e| anyhow!("add relay failed: {e}"))?;
+        // `add_relay` only registers the relay; the SDK connects nothing on
+        // its own. During construction `new()` calls `connect()` for the
+        // whole set afterwards, but a relay added to a running pool — by the
+        // user or from a node's relay list — would otherwise sit in
+        // `Initialized` forever. `connect_relay` is non-blocking.
+        if let Err(e) = self.client.connect_relay(url).await {
+            log::warn!(
+                "[relay] connect {} not started: {e}",
+                crate::api::logging::display_relay(url)
+            );
+        }
 
         let info = RelayInfo {
             url: url.to_string(),
@@ -87,16 +104,24 @@ impl RelayPool {
     }
 
     /// Add a relay and connect to it.
+    ///
+    /// An explicit add lifts the relay off the blacklist: the user asking
+    /// for it back overrides their earlier removal.
     pub async fn add_relay(&self, url: &str) -> Result<RelayInfo> {
         let relays = self.relays.read().await;
         if relays.iter().any(|r| r.url == url) {
             return Err(anyhow!("RelayAlreadyExists"));
         }
         drop(relays);
+        self.blacklist.write().await.remove(url);
         self.add_relay_internal(url, RelaySource::UserAdded).await
     }
 
     /// Remove a relay and disconnect.
+    ///
+    /// Removing a node-announced relay blacklists it (see `blacklist`), so
+    /// the next relay-list sync leaves it out. Defaults and user-added relays
+    /// are not blacklisted: they only come back if the user re-adds them.
     pub async fn remove_relay(&self, url: &str) -> Result<()> {
         let mut relays = self.relays.write().await;
         let active_count = relays.iter().filter(|r| r.is_active).count();
@@ -111,6 +136,10 @@ impl RelayPool {
         removed.status = RelayStatus::Disconnected;
         drop(relays);
 
+        if matches!(removed.source, RelaySource::MostroDiscovered) {
+            self.blacklist.write().await.insert(url.to_string());
+        }
+
         self.client
             .remove_relay(url)
             .await
@@ -119,6 +148,65 @@ impl RelayPool {
         let _ = self.relay_tx.send(removed);
         self.broadcast_connection_state().await;
         Ok(())
+    }
+
+    /// Seed the blacklist (e.g. from persisted state) before the first sync.
+    pub async fn set_blacklist(&self, urls: impl IntoIterator<Item = String>) {
+        *self.blacklist.write().await = urls.into_iter().collect();
+    }
+
+    /// Re-apply what a previous session persisted: the source/default flags
+    /// of relays this pool was constructed with (construction marks them all
+    /// `Default`), and the blacklist. Rows for relays not in the pool are
+    /// only consulted for the blacklist.
+    pub async fn restore_persisted(&self, persisted: &[RelayInfo]) {
+        {
+            let mut relays = self.relays.write().await;
+            for row in persisted.iter().filter(|r| !r.is_blacklisted) {
+                if let Some(info) = relays.iter_mut().find(|r| r.url == row.url) {
+                    info.source = row.source.clone();
+                    info.is_default = row.is_default;
+                }
+            }
+        }
+        self.set_blacklist(
+            persisted
+                .iter()
+                .filter(|r| r.is_blacklisted)
+                .map(|r| r.url.clone()),
+        )
+        .await;
+    }
+
+    /// Relays the user removed after a node announced them.
+    pub async fn blacklist(&self) -> Vec<String> {
+        let mut urls: Vec<String> = self.blacklist.read().await.iter().cloned().collect();
+        urls.sort();
+        urls
+    }
+
+    /// Apply a Mostro node's announced relay list. **Additive only**: relays
+    /// already configured are left alone (whatever their source), blacklisted
+    /// ones are skipped, and nothing is ever disconnected — a node that
+    /// drops a relay from its list does not take it away from the user.
+    /// Returns the URLs that were newly added, in announcement order.
+    pub async fn sync_discovered(&self, announced: &[String]) -> Vec<String> {
+        let to_add = {
+            let relays = self.relays.read().await;
+            let blacklist = self.blacklist.read().await;
+            plan_relay_sync(&relays, announced, &blacklist)
+        };
+        let mut added = Vec::with_capacity(to_add.len());
+        for url in to_add {
+            match self.add_relay_internal(&url, RelaySource::MostroDiscovered).await {
+                Ok(_) => added.push(url),
+                Err(e) => log::warn!(
+                    "[relay] discovered relay {} not added: {e}",
+                    crate::api::logging::display_relay(&url)
+                ),
+            }
+        }
+        added
     }
 
     pub async fn get_relays(&self) -> Vec<RelayInfo> {
@@ -219,6 +307,25 @@ impl RelayPool {
 
 // ── Pure helpers ──────────────────────────────────────────────────────────────
 
+/// Which of `announced` should be added: not configured yet, not
+/// blacklisted, first occurrence only. Order is preserved so the user sees
+/// them in the order the node listed them.
+fn plan_relay_sync(
+    current: &[RelayInfo],
+    announced: &[String],
+    blacklist: &HashSet<String>,
+) -> Vec<String> {
+    let mut planned: Vec<String> = Vec::new();
+    for url in announced {
+        let known = current.iter().any(|r| &r.url == url);
+        if known || blacklist.contains(url) || planned.contains(url) {
+            continue;
+        }
+        planned.push(url.clone());
+    }
+    planned
+}
+
 fn derive_connection_state(relays: &[RelayInfo]) -> ConnectionState {
     let any_connected = relays
         .iter()
@@ -250,3 +357,99 @@ fn map_sdk_status(s: SdkRelayStatus) -> RelayStatus {
 }
 
 use crate::rt::unix_now;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn relay(url: &str, source: RelaySource) -> RelayInfo {
+        RelayInfo {
+            url: url.to_string(),
+            is_active: true,
+            is_default: matches!(source, RelaySource::Default),
+            source,
+            is_blacklisted: false,
+            status: RelayStatus::Connected,
+            last_connected_at: None,
+            last_error: None,
+        }
+    }
+
+    fn urls(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn sync_plan_adds_only_unknown_relays_in_announcement_order() {
+        let current = vec![relay("wss://relay.mostro.network", RelaySource::Default)];
+        let announced = urls(&["wss://mostro-p2p.tech", "wss://relay.mostro.network", "wss://nos.lol"]);
+
+        let planned = plan_relay_sync(&current, &announced, &HashSet::new());
+
+        assert_eq!(planned, urls(&["wss://mostro-p2p.tech", "wss://nos.lol"]));
+    }
+
+    #[test]
+    fn sync_plan_skips_blacklisted_relays() {
+        let current = vec![relay("wss://relay.mostro.network", RelaySource::Default)];
+        let announced = urls(&["wss://mostro-p2p.tech", "wss://nos.lol"]);
+        let blacklist: HashSet<String> = ["wss://nos.lol".to_string()].into_iter().collect();
+
+        let planned = plan_relay_sync(&current, &announced, &blacklist);
+
+        assert_eq!(planned, urls(&["wss://mostro-p2p.tech"]));
+    }
+
+    #[test]
+    fn sync_plan_never_removes_relays_the_node_stopped_announcing() {
+        let current = vec![
+            relay("wss://relay.mostro.network", RelaySource::Default),
+            relay("wss://old.example", RelaySource::MostroDiscovered),
+            relay("wss://mine.example", RelaySource::UserAdded),
+        ];
+        let announced = urls(&["wss://relay.mostro.network"]);
+
+        let planned = plan_relay_sync(&current, &announced, &HashSet::new());
+
+        assert!(planned.is_empty());
+    }
+
+    #[test]
+    fn sync_plan_dedupes_repeated_announcements() {
+        let announced = urls(&["wss://a.example", "wss://a.example"]);
+
+        let planned = plan_relay_sync(&[], &announced, &HashSet::new());
+
+        assert_eq!(planned, urls(&["wss://a.example"]));
+    }
+
+    #[tokio::test]
+    async fn removing_a_discovered_relay_blacklists_it_and_re_adding_clears_it() {
+        let pool = RelayPool::new(vec!["ws://127.0.0.1:1".to_string()]).await.unwrap();
+        let added = pool.sync_discovered(&urls(&["ws://127.0.0.1:2"])).await;
+        assert_eq!(added, urls(&["ws://127.0.0.1:2"]));
+
+        pool.remove_relay("ws://127.0.0.1:2").await.unwrap();
+        assert_eq!(pool.blacklist().await, urls(&["ws://127.0.0.1:2"]));
+
+        // A later announcement is ignored while blacklisted…
+        assert!(pool.sync_discovered(&urls(&["ws://127.0.0.1:2"])).await.is_empty());
+
+        // …until the user explicitly adds the relay back.
+        pool.add_relay("ws://127.0.0.1:2").await.unwrap();
+        assert!(pool.blacklist().await.is_empty());
+        let info = pool.get_relays().await.into_iter().find(|r| r.url == "ws://127.0.0.1:2").unwrap();
+        assert!(matches!(info.source, RelaySource::UserAdded));
+    }
+
+    #[tokio::test]
+    async fn removing_a_default_relay_does_not_blacklist_it() {
+        let pool = RelayPool::new(vec!["ws://127.0.0.1:1".to_string(), "ws://127.0.0.1:2".to_string()])
+            .await
+            .unwrap();
+
+        pool.remove_relay("ws://127.0.0.1:2").await.unwrap();
+
+        assert!(pool.blacklist().await.is_empty());
+    }
+}

--- a/specs/004-mostro-p2p-client/contracts/nostr.md
+++ b/specs/004-mostro-p2p-client/contracts/nostr.md
@@ -79,8 +79,11 @@ writes where we read and reads where we write). URLs are normalised
 Applying a list is **additive only**: relays already configured (whatever
 their source) are left alone, nothing is ever disconnected, and a relay the
 node stops announcing is not removed. Only the newest generation per node is
-applied (older/replayed events from other relays are ignored). Added relays
-get `RelaySource::MostroDiscovered` and are persisted.
+applied (older/replayed events from other relays are ignored); a generation is
+`(created_at, event id)` and is ordered the way NIP-01 orders revisions of a
+replaceable event — newer `created_at` wins, and on a same-second tie the lower
+event id does. Added relays get `RelaySource::MostroDiscovered` and are
+persisted.
 
 Removing a `MostroDiscovered` relay through `remove_relay` **blacklists**
 it (persisted as `is_blacklisted = true`, `is_active = false`), so neither a
@@ -91,6 +94,11 @@ blacklist it.
 `initialize(None)` restores the persisted relay set (active, non-blacklisted
 rows) and the blacklist; only a store with no rows falls back to the
 compiled-in defaults, which are then seeded.
+
+Persistence here is the **native** (SQLite) story. On web the IndexedDB relay
+store is still a stub (#233): discovery and the blacklist work for the life of
+the session, every write is logged and ignored, and a reload starts from the
+compiled-in defaults again.
 
 ---
 

--- a/specs/004-mostro-p2p-client/contracts/nostr.md
+++ b/specs/004-mostro-p2p-client/contracts/nostr.md
@@ -65,15 +65,32 @@ Emits when any individual relay's status changes.
 
 ## Auto-Sync Functions
 
-### enable_relay_auto_sync(mostro_pubkey: String) → ()
-Subscribe to Mostro daemon's kind 10002 relay list events. When the
-daemon publishes updated relays, auto-add them locally (additive only —
-never disconnects existing relays during sync).
+### Relay auto-sync from the node's kind 10002 list (implicit)
+There is no separate `enable_relay_auto_sync` call: the kind 10002 (NIP-65)
+relay list of the **active** Mostro node is subscribed together with the
+order-book and Mostro-reply filters (stable subscription id
+`mostro-relay-list`), on pool start-up and again on every node switch, so
+an operator adding a relay reaches running clients live.
 
-**Side effects**: Creates Nostr subscription for kind 10002 from the
-specified pubkey.
+Every `r` tag is taken regardless of its read/write marker (the daemon
+writes where we read and reads where we write). URLs are normalised
+(scheme/host lower-cased, trailing slash stripped; only `ws://`/`wss://`).
 
-**Errors**: `NotConnected`.
+Applying a list is **additive only**: relays already configured (whatever
+their source) are left alone, nothing is ever disconnected, and a relay the
+node stops announcing is not removed. Only the newest generation per node is
+applied (older/replayed events from other relays are ignored). Added relays
+get `RelaySource::MostroDiscovered` and are persisted.
+
+Removing a `MostroDiscovered` relay through `remove_relay` **blacklists**
+it (persisted as `is_blacklisted = true`, `is_active = false`), so neither a
+later list nor the next start brings it back; `add_relay` of the same URL
+lifts the blacklist. Removing a default or user-added relay does not
+blacklist it.
+
+`initialize(None)` restores the persisted relay set (active, non-blacklisted
+rows) and the blacklist; only a store with no rows falls back to the
+compiled-in defaults, which are then seeded.
 
 ---
 
@@ -193,4 +210,5 @@ is transmitted.
 
 ### on_relay_auto_synced() → Stream<Vec<String>>
 Emits when new relays are auto-synced from daemon's kind 10002 events.
-Payload is the list of newly added relay URLs.
+Payload is the list of newly added relay URLs, in announcement order. Lists
+that add nothing new do not emit.

--- a/test/core/services/coalescing_loader_test.dart
+++ b/test/core/services/coalescing_loader_test.dart
@@ -1,0 +1,77 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mostro/core/services/coalescing_loader.dart';
+
+void main() {
+  group('CoalescingLoader', () {
+    test('runs the load once when nothing overlaps', () async {
+      // Arrange
+      var runs = 0;
+      final loader = CoalescingLoader(() async => runs++);
+
+      // Act
+      await loader.run();
+
+      // Assert
+      expect(runs, 1);
+    });
+
+    test('runs one extra pass when a request arrives mid-load', () async {
+      // Arrange — this is the auto-sync-during-initial-load case: the first
+      // read has already captured its snapshot when the new relay lands.
+      final gate = Completer<void>();
+      var runs = 0;
+      late CoalescingLoader loader;
+      loader = CoalescingLoader(() async {
+        runs++;
+        if (runs == 1) await gate.future;
+      });
+
+      // Act
+      final first = loader.run();
+      final duringLoad = loader.run();
+      expect(runs, 1, reason: 'the second request must not start a second load');
+      gate.complete();
+      await Future.wait([first, duringLoad]);
+
+      // Assert
+      expect(runs, 2);
+    });
+
+    test('coalesces many overlapping requests into a single extra pass',
+        () async {
+      // Arrange
+      final gate = Completer<void>();
+      var runs = 0;
+      final loader = CoalescingLoader(() async {
+        runs++;
+        if (runs == 1) await gate.future;
+      });
+
+      // Act
+      final first = loader.run();
+      final overlapping = [loader.run(), loader.run(), loader.run()];
+      gate.complete();
+      await Future.wait([first, ...overlapping]);
+
+      // Assert
+      expect(runs, 2);
+    });
+
+    test('clears the in-flight flag when the load throws', () async {
+      // Arrange
+      var runs = 0;
+      final loader = CoalescingLoader(() async {
+        runs++;
+        throw StateError('boom');
+      });
+
+      // Act / Assert
+      await expectLater(loader.run(), throwsStateError);
+      expect(loader.isRunning, isFalse);
+      await expectLater(loader.run(), throwsStateError);
+      expect(runs, 2, reason: 'a failed load must not wedge the loader');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Ports v1's relay discovery to the Rust core, following the contract already written in `specs/004-mostro-p2p-client/contracts/nostr.md` (relay auto-sync from the node's kind 10002 list, additive only, `on_relay_auto_synced` stream, `RelaySource::MostroDiscovered`, `is_blacklisted`).

- **`rust/src/nostr/relay_list.rs`** (new): NIP-65 filter + parser. Every `r` tag is taken regardless of read/write marker, as v1 does. URLs normalised (scheme/host lower-cased, trailing slash stripped), de-duplicated, only `ws://`/`wss://`.
- **`RelayPool`**: `sync_discovered()` is additive — never disconnects, never removes a relay the node stopped announcing. Removing a `MostroDiscovered` relay blacklists it; `add_relay` of the same URL lifts the blacklist. `restore_persisted()` re-applies sources and blacklist from storage.
- **`api/nostr.rs`**: the active node's list is subscribed alongside the order-book filters (stable id `mostro-relay-list`) and re-subscribed on node switch. `apply_relay_list_event` applies only the newest generation per node, persists additions, emits `on_relay_auto_synced()`. `add_relay`/`remove_relay` now persist. `initialize(None)` restores the persisted set + blacklist and seeds the defaults only on a fresh install — the `Storage` relay methods and `seeds.rs` existed on `main` with zero callers, so relays were never persisted before.
- **Bug fixed on the way**: `RelayPool::add_relay_internal` never called `connect_relay`. nostr-sdk's `add_relay` only registers, so any relay added to a running pool (user-added included) stayed `Initialized` forever. First live run showed the two discovered relays never connecting; with the fix they connect ~3 s after the auto-add.
- **Settings relay card**: reloads on auto-sync and shows "Added from the Mostro node" under node-announced relays (l10n key `relayFromMostroLabel`, en/es/fr/de/it). Removing one is allowed and blacklists it.
- **Docs**: `contracts/nostr.md` describes the implicit subscription instead of the never-implemented `enable_relay_auto_sync`; `CLAUDE.md` gets a domain gotcha.

## Deliberate divergences from v1
| v1 (MostroP2P/mobile) | Here | Why |
|---|---|---|
| Replaces the whole discovered block on each 10002 (a relay the node drops disappears) | Additive only | That is what `contracts/nostr.md` prescribes; a node dropping a relay should not take it away from the user |
| Blacklist wiped on node switch | Blacklist kept | Removal is a user decision about that relay |
| Persists relay URLs without source; user relays duplicated after restart | `RelayInfo` persisted with source | The v1 behaviour is a known bug (`_loadRelays` in `relays_notifier.dart`) |
| Bootstrap relays that never show in settings | Compiled-in `DEFAULT_RELAYS` stay visible defaults | No separate bootstrap concept in v2 |

## Test plan
- [x] Unit: parser (markers, normalisation, dedupe, rejects), `plan_relay_sync` (additive, blacklist, dedupe, never removes), pool blacklist round-trip, generation gate (newest wins, per node)
- [x] `cargo test` (351 passed), `cargo clippy -D warnings`, `cargo check --target wasm32-unknown-unknown`, `frb-generate.sh --check`, `flutter analyze`, `flutter test` (312 passed)
- [x] Linux, fresh `relays` table: starts on the 2 defaults → `kind 10002 from node=82fa8cb9: 4 relay(s) announced` → `auto-added 2 relay(s)` → both `Connecting→Connected` → rows persisted with `MostroDiscovered`
- [x] Linux, second start: pool initialised with all 4, list applied, nothing added
- [ ] Reviewer: remove a node-announced relay in Settings, restart, confirm it stays out; add it back, confirm it returns as user-added
- [ ] Web: relay persistence is a stub on IndexedDB (#233); discovery works in-session, persistence logs a warning

Note: `RelayPool::add_relay`'s `connect_relay` fix also affects user-added relays on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7QQtaUvC1KPhmazAKCpH1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Relay settings now automatically sync with relay lists announced by the active Mostro node.
  * Newly discovered relays appear in the settings screen and are labeled accordingly.
  * Relay selections persist across app restarts.
  * Removed node-announced relays remain excluded unless manually added again.
  * Relay URLs are normalized and duplicate or unsupported entries are ignored.
* **Bug Fixes**
  * Relays added while the app is running now connect immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->