### PR TITLE
refactor(keys): let deriving be the mnemonic validation, and parse once

### DIFF
--- a/rust/src/api/identity.rs
+++ b/rust/src/api/identity.rs
@@ -167,7 +167,9 @@ pub async fn load_identity_from_mnemonic(
     privacy_mode: bool,
     created_at: Option<i64>,
 ) -> Result<IdentityInfo> {
-    key_ops::validate_mnemonic(&words)?;
+    // Deriving is the validation: it parses the phrase and fails on a bad word
+    // or checksum with the same `invalid mnemonic` error the explicit check
+    // used to produce.
     let keys = key_ops::derive_master_key(&words)?;
     let public_key = keys.public_key().to_hex();
 

--- a/rust/src/crypto/keys.rs
+++ b/rust/src/crypto/keys.rs
@@ -22,15 +22,12 @@ pub fn generate_mnemonic() -> Result<Vec<String>> {
     Ok(mnemonic.words().map(|w| w.to_string()).collect())
 }
 
-/// Parse and validate a mnemonic from a word list.
-/// Accepts 12 or 24 words. Returns error on invalid words or checksum.
-pub fn validate_mnemonic(words: &[String]) -> Result<()> {
-    let phrase = words.join(" ");
-    Mnemonic::parse(&phrase).map_err(|e| anyhow!("invalid mnemonic: {e}"))?;
-    Ok(())
-}
-
 /// Derive the identity (`N=0`) Nostr `Keys` from a mnemonic.
+///
+/// **This is also the validation.** Deriving parses the phrase, so a word list
+/// with a bad word or a bad checksum fails here with `invalid mnemonic: …`.
+/// There is no separate validate-then-derive pair: two parses of the same
+/// phrase is two places for "what counts as a valid mnemonic" to be answered.
 pub fn derive_master_key(mnemonic_words: &[String]) -> Result<Keys> {
     derive_at_index(mnemonic_words, 0)
 }
@@ -78,6 +75,38 @@ mod tests {
         let k1 = derive_master_key(&words).unwrap();
         let k2 = derive_master_key(&words).unwrap();
         assert_eq!(k1.public_key(), k2.public_key());
+    }
+
+    /// The import path relies on derivation to reject a bad phrase — it no
+    /// longer validates separately first. If that ever stops being true, a
+    /// typo'd word becomes some other user's key rather than an error.
+    #[test]
+    fn deriving_refuses_a_phrase_that_is_not_a_mnemonic() {
+        // Arrange — real BIP-39 words, wrong checksum; then a word that is not
+        // in the list at all. The dialog that feeds this only checks the shape
+        // (12 or 24 alphabetic words), so both reach Rust.
+        let bad_checksum: Vec<String> = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon"
+            .split(' ')
+            .map(str::to_string)
+            .collect();
+        let not_a_word: Vec<String> = "mostro abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+            .split(' ')
+            .map(str::to_string)
+            .collect();
+
+        // Act / Assert
+        for words in [&bad_checksum, &not_a_word] {
+            let err = derive_master_key(words).unwrap_err();
+            assert!(
+                err.to_string().contains("invalid mnemonic"),
+                "got {err}"
+            );
+            assert!(derive_trade_key(words, 1).is_err());
+        }
+
+        // And an empty list is not a mnemonic either — an nsec-imported
+        // identity stores no words.
+        assert!(derive_master_key(&[]).is_err());
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to a review observation on #235: the mnemonic import path parses the same phrase twice.

## The duplication

`load_identity_from_mnemonic` — behind the account screen's **import user** button — did:

```rust
key_ops::validate_mnemonic(&words)?;
let keys = key_ops::derive_master_key(&words)?;
```

Both call `Mnemonic::parse` on the same phrase, and both fail with the same `invalid mnemonic: …`. The second parse is not a safety net over the first; it is the first, run again. What it does create is a second place to answer "what counts as a valid mnemonic here", which is the kind of pair that drifts: change one of them and the two disagree, silently, on the one input where being wrong costs the user their account.

## The change

- The explicit call goes away. **Deriving is the validation** — it has to parse to derive — and the error the caller sees is byte-identical.
- `validate_mnemonic` goes with its only caller. It was `pub` but not on the bridge and had no other user anywhere in the repo (checked across every remote branch, where the single hit is this same line). Three lines to bring back the day something needs validation without derivation.
- `derive_master_key`'s doc now says it validates, so the next person does not add the pair back.

## Why the test

Removing an explicit check is only safe if the implicit one holds, so `deriving_refuses_a_phrase_that_is_not_a_mnemonic` pins it: a phrase of real BIP-39 words with a wrong checksum, a phrase with a word that is not in the list, and an empty list (an nsec-imported identity stores no words). Both kinds do reach Rust — the import dialog only checks the *shape*, 12 or 24 alphabetic words — so this is the layer that has to say no.

Without it, the failure mode is not a crash: a typo'd word whose checksum happens to pass would derive *some other* valid identity, and the user would be looking at an empty account rather than an error.

## Test plan

- [x] `cargo test` — 366 pass
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo check --target wasm32-unknown-unknown`
- [x] `flutter analyze` — no new issues
- [x] `./scripts/frb-generate.sh` produces no diff (neither function is on the bridge)
- [ ] Manual: Account → import user, with a valid phrase (imports), a wrong-checksum phrase and a nonsense word (both rejected with the same message as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012VCrukiZdZo2HfZczSaQ8U
