### PR TITLE
fix(disputes): persist the origin marker on a late-accepted open

### DIFF
--- a/rust/src/api/disputes.rs
+++ b/rust/src/api/disputes.rs
@@ -495,9 +495,13 @@ pub(crate) async fn record_late_acceptance(trade_id: &str, dispute_id: Option<St
         .await;
 
     match result {
-        Ok(()) => log::info!(
-            "[disputes] reconciled late daemon acceptance for trade={trade_id}"
-        ),
+        Ok(()) => {
+            // Same as the on-time path: this side opened it, and the replay
+            // can never restore that, so the marker must be written here too
+            // or a restart would rehydrate the record as peer-opened.
+            persist_dispute_origin(trade_id).await;
+            log::info!("[disputes] reconciled late daemon acceptance for trade={trade_id}");
+        }
         Err(e) => log::warn!(
             "[disputes] could not reconcile late acceptance for trade={trade_id}: {e}"
         ),
@@ -1546,6 +1550,12 @@ mod tests {
     /// with no dispute to open and no solver to reach.
     #[tokio::test]
     async fn a_late_acceptance_is_reconciled_into_a_record() {
+        // Any SqliteStorage serves (process-wide OnceCell, first caller wins):
+        // this test only reads back its own key.
+        let path = std::env::temp_dir()
+            .join(format!("mostro_dispute_late_{}.db", std::process::id()));
+        let _ = crate::db::app_db::init_db(path.to_str().unwrap()).await;
+        let db = crate::db::app_db::db().expect("store initialised");
         let trade_id = format!("t-{}", uuid::Uuid::new_v4());
         let daemon_dispute_id = uuid::Uuid::new_v4().to_string();
 
@@ -1553,11 +1563,23 @@ mod tests {
 
         record_late_acceptance(&trade_id, Some(daemon_dispute_id.clone())).await;
 
-        let d = get_dispute(trade_id).await.unwrap().expect("record created");
+        let d = get_dispute(trade_id.clone()).await.unwrap().expect("record created");
         assert_eq!(d.id, daemon_dispute_id, "the daemon's id must be adopted");
         assert_eq!(d.status, DisputeStatus::Open);
         assert!(d.initiated_by_me, "we did open it, late reply or not");
         assert!(!d.is_read, "the caller was told it failed — this is news");
+
+        // PR #256 review: the origin must be persisted on this path too, or a
+        // restart rehydrates the dispute as peer-opened.
+        assert_eq!(
+            db.get_setting(&crate::db::settings_keys::dispute_mine(&trade_id))
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("1"),
+            "a late acceptance must persist the origin marker"
+        );
+        clear_dispute_keys(&trade_id).await;
     }
 
     /// PR #275 review: `Dispute.id` is contractually the daemon's, so an


### PR DESCRIPTION
Follow-up to #256, which merged while this fix was in flight (CodeRabbit's last round on that PR; the reply there cites a commit that never reached `main`).

## Problem

`record_late_acceptance` — the path for an `open_dispute` that timed out and was accepted by the daemon later — builds the record with `initiated_by_me: true` but never wrote `dispute_mine:<order_id>`. The on-time path does. So after a restart, rehydration restored that dispute as **peer-opened**, which is exactly the wrong description #256 persisted the origin to avoid.

## Change

`record_late_acceptance` calls `persist_dispute_origin` on its success path, same as `open_dispute`. Best-effort like every other persistence write.

`a_late_acceptance_is_reconciled_into_a_record` now initialises the process-wide store (any `SqliteStorage` serves, first caller wins — same pattern as the rehydration tests) and reads the marker back, then clears its own keys.

## Test plan

- [x] `cargo test --locked` — 385 passed
- [x] `cargo clippy --locked -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MV8X5ZDur4kqUEG1s6REiE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Late-accepted disputes now retain their correct origin after a restart.
  * Dispute state is rehydrated consistently as initiator-opened rather than peer-opened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->