### PR TITLE
fix(orders): refuse status writes from an out-of-order kind-14 replay

### DIFF
--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -1547,12 +1547,18 @@ async fn dispatch_mostro_message(
     //
     // A forger cannot sign a kind-14 event as the node, so `sender == mostro`
     // is the authoritative check.
+    //
+    // `created_at` is the kind-14 event's own timestamp, not an inner field
+    // (`unwrap_message_nip44` sets it from `event.created_at`) — the very key
+    // relays order their stored events by. It is the only thing that separates
+    // a live daemon reply from one being replayed out of a startup backlog,
+    // and until now it was dropped here.
     let mostro_core::nip59::UnwrappedMessage {
         message: msg,
         sender,
         identity: _,
         signature: _,
-        created_at: _,
+        created_at: event_created_at,
     } = unwrapped;
 
     // Daemon authentication: the kind-14 event author (`sender`) must be the
@@ -1622,9 +1628,21 @@ async fn dispatch_mostro_message(
         Some(other) => format!("{other:?}"),
         None => "None".to_string(),
     };
+    // `age` is the event's timestamp against the local clock. A live reply reads
+    // ~0; the global kind-14 feed carries no `since`, so on every start it
+    // replays the node's full history and those read hours or days. Relays hand
+    // that backlog back newest-first while the arms below apply each message as
+    // if it had just arrived, so a large age marks writes that are about to
+    // overwrite fresher state. Negative means the node's clock runs ahead.
+    let event_age_secs = crate::rt::unix_now().saturating_sub(event_created_at.as_secs() as i64);
     crate::api::logging::blog_info("daemon-msg", format!(
-        "action={:?} order_id={:?} trade_index={:?} trade_pubkey={} payload={}",
-        kind.action, kind.id, kind.trade_index, &trade_pubkey_hex[..8], payload_desc
+        "action={:?} order_id={:?} trade_index={:?} trade_pubkey={} age={}s payload={}",
+        kind.action,
+        kind.id,
+        kind.trade_index,
+        &trade_pubkey_hex[..8],
+        event_age_secs,
+        payload_desc
     ));
 
     // Everything below is serialized against other handlers of this order id:

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -1345,7 +1345,13 @@ pub async fn cancel_order(order_id: String) -> Result<()> {
             )
             .await
         {
-            log::warn!("[orders] failed to optimistically update cancel status for {order_id}: {e}");
+            crate::api::logging::blog_warn(
+                "orders",
+                format!(
+                    "cancel status not persisted for order={}: {e}",
+                    crate::api::logging::short_id(&order_id),
+                ),
+            );
         }
     }
 
@@ -2036,7 +2042,13 @@ async fn dispatch_mostro_message(
                             )
                             .await
                         {
-                            log::warn!("[orders] failed to sync Canceled status for {oid}: {e}");
+                            crate::api::logging::blog_warn(
+                                "orders",
+                                format!(
+                                    "Canceled status not persisted for order={}: {e}",
+                                    crate::api::logging::short_id(&oid),
+                                ),
+                            );
                         }
                     }
                 }
@@ -2103,8 +2115,12 @@ async fn dispatch_mostro_message(
                         .update_trade_fields(&order_id, Some(new_status.clone()), None, None)
                         .await
                     {
-                        log::warn!(
-                            "[orders] failed to sync status for order={order_id}: {e}"
+                        crate::api::logging::blog_warn(
+                            "orders",
+                            format!(
+                                "status not persisted for order={}: {e}",
+                                crate::api::logging::short_id(&order_id),
+                            ),
                         );
                     }
                 }
@@ -2247,8 +2263,12 @@ async fn dispatch_mostro_message(
                     )
                     .await
                 {
-                    log::warn!(
-                        "[orders] failed to save hold invoice for order={order_id}: {e}"
+                    crate::api::logging::blog_warn(
+                        "orders",
+                        format!(
+                            "hold invoice and status not persisted for order={}: {e}",
+                            crate::api::logging::short_id(&order_id),
+                        ),
                     );
                 }
             }
@@ -2306,8 +2326,12 @@ async fn dispatch_mostro_message(
                         .update_trade_fields(&order_id, Some(status.clone()), None, None)
                         .await
                     {
-                        log::warn!(
-                            "[orders] failed to sync trade status for order={order_id}: {e}"
+                        crate::api::logging::blog_warn(
+                            "orders",
+                            format!(
+                                "status not persisted for order={}: {e}",
+                                crate::api::logging::short_id(&order_id),
+                            ),
                         );
                     }
                 }
@@ -2964,9 +2988,12 @@ async fn subscribe_single_order(order_id: &str) {
                                     )
                                     .await
                                 {
-                                    log::warn!(
-                                        "[orders] failed to sync d-tag trade status for order={}: {e}",
-                                        order.id
+                                    crate::api::logging::blog_warn(
+                                        "orders",
+                                        format!(
+                                            "d-tag status not persisted for order={}: {e}",
+                                            crate::api::logging::short_id(&order.id),
+                                        ),
                                     );
                                 }
                             }
@@ -3879,9 +3906,12 @@ async fn ingest_order_event_with(event: &nostr_sdk::prelude::Event, publish: Pub
                             )
                             .await
                         {
-                            log::warn!(
-                                "[orders] failed to sync trade status for order={}: {e}",
-                                info.id
+                            crate::api::logging::blog_warn(
+                                "orders",
+                                format!(
+                                    "status not persisted for order={}: {e}",
+                                    crate::api::logging::short_id(&info.id),
+                                ),
                             );
                         }
                     }

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -2531,25 +2531,52 @@ async fn load_status_cursor(order_id: &str) -> Option<i64> {
 /// Record that a daemon message dated `event_created_at` was allowed to write
 /// `order_id`'s status.
 ///
-/// Clamped to the local clock for the same reason the chat cursor is: a node
-/// dating an event in the future would otherwise push the mark past every
-/// message that follows and freeze the order's status for good.
+/// The mark is stored **raw**, in the node's own time domain, because that is
+/// the domain [`status_write_blocked`] compares against. Clamping it to the
+/// local clock — as the chat cursor does — is wrong here: there the cursor is a
+/// subscription `since`, where a low value only asks for more than needed, but
+/// here it is an ordering comparator. With a local clock behind the node's, a
+/// newest event at 3000 would store 1000 and a *later, older* event at 2000
+/// would then pass `2000 < 1000` and overwrite it — the very replay regression
+/// this guard exists to stop (PR #396 review).
+///
+/// The freedom that costs is bounded by a skew check instead: an event dated
+/// implausibly far ahead of the local clock does not move the mark, so one
+/// malformed timestamp cannot silence an order's status for good. Same
+/// tolerance the chat envelope already applies to node-adjacent events. A node
+/// whose clock is genuinely further ahead makes the guard inert for that order
+/// rather than wrong — logged, because that is a silent degradation otherwise.
+/// Ordering between the node's own events survives any uniform skew: they all
+/// carry the same clock.
 ///
 /// The read-modify-write is safe because every caller runs under this order's
-/// dispatch lock. The `>=` check is not redundant with [`status_write_blocked`]:
-/// the clamp can pull an accepted event *below* the current mark when the local
-/// clock runs behind the node's, and the mark must never move backwards.
+/// dispatch lock.
 ///
 /// Best-effort, like every other write here: losing it costs the durability of
 /// the guard, not its correctness within the session.
 async fn record_status_event(order_id: &str, event_created_at: i64) {
-    let accepted = event_created_at.min(crate::rt::unix_now());
-    if load_status_cursor(order_id).await.is_some_and(|c| c >= accepted) {
+    let horizon = crate::rt::unix_now()
+        .saturating_add(crate::nostr::transport::MAX_CLOCK_SKEW_SECS as i64);
+    if event_created_at > horizon {
+        crate::api::logging::blog_warn(
+            "orders",
+            format!(
+                "status cursor not advanced for order={}: event is {}s ahead of the local clock",
+                crate::api::logging::short_id(order_id),
+                event_created_at.saturating_sub(horizon),
+            ),
+        );
+        return;
+    }
+    if load_status_cursor(order_id)
+        .await
+        .is_some_and(|c| c >= event_created_at)
+    {
         return;
     }
     if let Some(db) = crate::db::app_db::db() {
         let key = crate::db::settings_keys::status_cursor(order_id);
-        if let Err(e) = db.set_setting(&key, &accepted.to_string()).await {
+        if let Err(e) = db.set_setting(&key, &event_created_at.to_string()).await {
             crate::api::logging::blog_warn(
                 "orders",
                 format!(
@@ -2577,6 +2604,18 @@ async fn record_status_event(order_id: &str, event_created_at: i64) {
 /// Strictly older is what is refused: the daemon emits several messages for one
 /// order within the same second (the `PayInvoice` reputation follow-up, for
 /// one), and those are genuine, in-order traffic.
+///
+/// That strictness is also why the callers record the mark *before* the writes
+/// they gate, rather than after a successful one (PR #396 review). The mark
+/// answers "which message have I decided to accept", not "which write
+/// succeeded" — every write here is best-effort, `record_status_event`
+/// included, and there is no transaction spanning the settings key and the
+/// trade row. Recording afterwards would leave the mark unmoved when a write
+/// fails, and then a *strictly older* message from the same backlog would be
+/// applied over the row that just failed to update — trading a fault that
+/// heals for one that corrupts. It heals because the failed message is not
+/// blocked on its next delivery: its timestamp equals the mark, and equal
+/// passes. The global feed carries no `since`, so the next start replays it.
 async fn status_write_blocked(
     order_id: &str,
     action: &mostro_core::message::Action,
@@ -6167,6 +6206,119 @@ mod tests {
             emitted,
             vec![crate::api::types::OrderStatus::Dispute],
             "a refused replay must not emit a TradeUpdate",
+        );
+    }
+
+    /// The ordering mark must live in the node's time domain, not the local
+    /// one. Clamping it to the local clock (as the chat cursor does, where it
+    /// is a subscription `since` and not a comparator) breaks the guard
+    /// whenever the local clock runs behind the node's: the newest event
+    /// stores a clamped, smaller value, and the next *older* event then
+    /// compares above it and wins — the replay regression, restored.
+    ///
+    /// Both events here are dated ahead of the local clock, replayed
+    /// newest-first, and inside the skew tolerance so the mark may move.
+    #[tokio::test]
+    async fn a_cursor_behind_the_local_clock_still_orders_future_dated_events() {
+        use mostro_core::message::{Action, Message};
+
+        let path = std::env::temp_dir()
+            .join(format!("mostro_status_skew_{}.db", std::process::id()));
+        let _ = crate::db::app_db::init_db(path.to_str().unwrap()).await;
+        let db = crate::db::app_db::db().expect("store initialised");
+
+        let order_uuid = uuid::Uuid::new_v4();
+        let order_id = order_uuid.to_string();
+        let order_info = dummy_order_info(&order_id);
+        order_book().upsert_order(order_info.clone()).await;
+        db.save_trade(&crate::api::types::TradeInfo {
+            id: order_id.clone(),
+            order: order_info,
+            role: TradeRole::Seller,
+            counterparty_pubkey: String::new(),
+            current_step: crate::api::types::TradeStep::Seller(
+                crate::api::types::SellerStep::OrderPublished,
+            ),
+            hold_invoice: None,
+            buyer_invoice: None,
+            trade_key_index: 1,
+            cooperative_cancel_state: None,
+            timeout_at: None,
+            started_at: 1,
+            completed_at: None,
+            outcome: None,
+            peer_rating: None,
+            peer_reviews: None,
+            peer_days: None,
+            rated_at: None,
+        })
+        .await
+        .expect("save the trade row");
+
+        let sender = nostr_sdk::prelude::PublicKey::from_hex(&active_mostro_pubkey())
+            .expect("valid mostro pubkey");
+        let now = crate::rt::unix_now() as u64;
+        let newest = now + 6;
+        let oldest = now + 3;
+
+        for (action, created_at) in [
+            (Action::DisputeInitiatedByYou, newest),
+            (Action::WaitingBuyerInvoice, oldest),
+        ] {
+            dispatch_mostro_message(
+                mostro_core::nip59::UnwrappedMessage {
+                    message: Message::new_order(Some(order_uuid), None, None, action, None),
+                    signature: None,
+                    sender,
+                    identity: sender,
+                    created_at: nostr_sdk::prelude::Timestamp::from(created_at),
+                },
+                &format!("test-skew-{created_at}"),
+                "ff00ff11",
+                1,
+            )
+            .await;
+        }
+
+        assert_eq!(
+            db.get_trade_by_order_id(&order_id)
+                .await
+                .expect("trade lookup")
+                .expect("trade row")
+                .order
+                .status,
+            crate::api::types::OrderStatus::Dispute,
+            "a future-dated newest event must still outrank an older one",
+        );
+        assert_eq!(
+            db.get_setting(&crate::db::settings_keys::status_cursor(&order_id))
+                .await
+                .unwrap()
+                .as_deref(),
+            Some(newest.to_string().as_str()),
+            "the mark must be stored raw, in the node's time domain",
+        );
+    }
+
+    /// One malformed timestamp must not be able to silence an order for good:
+    /// an event far beyond the skew tolerance is still applied, but it does not
+    /// move the mark, so the messages that follow it are not all refused.
+    #[tokio::test]
+    async fn an_absurdly_future_event_does_not_move_the_cursor() {
+        let path = std::env::temp_dir()
+            .join(format!("mostro_status_skew_{}.db", std::process::id()));
+        let _ = crate::db::app_db::init_db(path.to_str().unwrap()).await;
+        let db = crate::db::app_db::db().expect("store initialised");
+
+        let order_id = format!("skew-{}", uuid::Uuid::new_v4());
+        record_status_event(&order_id, crate::rt::unix_now() + 365 * 24 * 3600).await;
+
+        assert_eq!(
+            db.get_setting(&crate::db::settings_keys::status_cursor(&order_id))
+                .await
+                .unwrap(),
+            None,
+            "an event a year ahead must not become the high-water mark",
         );
     }
 

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -1634,7 +1634,8 @@ async fn dispatch_mostro_message(
     // that backlog back newest-first while the arms below apply each message as
     // if it had just arrived, so a large age marks writes that are about to
     // overwrite fresher state. Negative means the node's clock runs ahead.
-    let event_age_secs = crate::rt::unix_now().saturating_sub(event_created_at.as_secs() as i64);
+    let event_ts = event_created_at.as_secs() as i64;
+    let event_age_secs = crate::rt::unix_now().saturating_sub(event_ts);
     crate::api::logging::blog_info("daemon-msg", format!(
         "action={:?} order_id={:?} trade_index={:?} trade_pubkey={} age={}s payload={}",
         kind.action,
@@ -1972,9 +1973,10 @@ async fn dispatch_mostro_message(
                 // and completed — must not overwrite the terminal outcome.
                 // The wipe path below is unaffected: it starts from
                 // pending/waiting, which are not terminal.
-                if status_sync_blocked_by_terminal(&oid, &kind.action).await {
+                if status_write_blocked(&oid, &kind.action, event_ts).await {
                     return;
                 }
+                record_status_event(&oid, event_ts).await;
                 // Deliberately NOT removed from the order book. The book is
                 // fed only by the daemon's Kind 38383 events, and on a
                 // taker-responsible timeout mostrod republishes the order as
@@ -2061,9 +2063,10 @@ async fn dispatch_mostro_message(
             // own copy of this guard.) The legit re-take of a
             // timeout-canceled order is unaffected: its wiped row leaves the
             // book's `pending` as the local status, which passes.
-            if status_sync_blocked_by_terminal(&order_id, &kind.action).await {
+            if status_write_blocked(&order_id, &kind.action, event_ts).await {
                 return;
             }
+            record_status_event(&order_id, event_ts).await;
             let small_order = match &kind.payload {
                 Some(mostro_core::message::Payload::Order(o)) => o,
                 _ => {
@@ -2135,9 +2138,10 @@ async fn dispatch_mostro_message(
                 }
                 return;
             };
-            if status_sync_blocked_by_terminal(&order_id, &kind.action).await {
+            if status_write_blocked(&order_id, &kind.action, event_ts).await {
                 return;
             }
+            record_status_event(&order_id, event_ts).await;
             crate::api::logging::blog_info(
                 "orders",
                 format!(
@@ -2220,9 +2224,10 @@ async fn dispatch_mostro_message(
                 bolt11.len(),
                 amount
             );
-            if status_sync_blocked_by_terminal(&order_id, &kind.action).await {
+            if status_write_blocked(&order_id, &kind.action, event_ts).await {
                 return;
             }
+            record_status_event(&order_id, event_ts).await;
             // Save the hold invoice and update status to WaitingPayment.
             crate::api::logging::blog_info(
                 "orders",
@@ -2283,9 +2288,10 @@ async fn dispatch_mostro_message(
             // reply classification).
             let new_status = status_for_action(&kind.action);
             if let Some(status) = new_status {
-                if status_sync_blocked_by_terminal(&order_id, &kind.action).await {
+                if status_write_blocked(&order_id, &kind.action, event_ts).await {
                     return;
                 }
+                record_status_event(&order_id, event_ts).await;
                 crate::api::logging::blog_info(
                     "orders",
                     format!(
@@ -2480,6 +2486,93 @@ async fn status_sync_blocked_by_terminal(
             ),
         );
         return true;
+    }
+    false
+}
+
+/// Newest daemon-message timestamp already applied to `order_id`'s status.
+///
+/// `None` when nothing was ever recorded, or when there is no durable store
+/// (web, until #233) — both mean "no high-water mark", which fails open.
+async fn load_status_cursor(order_id: &str) -> Option<i64> {
+    let db = crate::db::app_db::db()?;
+    db.get_setting(&crate::db::settings_keys::status_cursor(order_id))
+        .await
+        .ok()
+        .flatten()?
+        .parse()
+        .ok()
+}
+
+/// Record that a daemon message dated `event_created_at` was allowed to write
+/// `order_id`'s status.
+///
+/// Clamped to the local clock for the same reason the chat cursor is: a node
+/// dating an event in the future would otherwise push the mark past every
+/// message that follows and freeze the order's status for good.
+///
+/// The read-modify-write is safe because every caller runs under this order's
+/// dispatch lock. The `>=` check is not redundant with [`status_write_blocked`]:
+/// the clamp can pull an accepted event *below* the current mark when the local
+/// clock runs behind the node's, and the mark must never move backwards.
+///
+/// Best-effort, like every other write here: losing it costs the durability of
+/// the guard, not its correctness within the session.
+async fn record_status_event(order_id: &str, event_created_at: i64) {
+    let accepted = event_created_at.min(crate::rt::unix_now());
+    if load_status_cursor(order_id).await.is_some_and(|c| c >= accepted) {
+        return;
+    }
+    if let Some(db) = crate::db::app_db::db() {
+        let key = crate::db::settings_keys::status_cursor(order_id);
+        if let Err(e) = db.set_setting(&key, &accepted.to_string()).await {
+            crate::api::logging::blog_warn(
+                "orders",
+                format!(
+                    "status cursor persist failed order={}: {e}",
+                    crate::api::logging::short_id(order_id),
+                ),
+            );
+        }
+    }
+}
+
+/// Whether a daemon message may write `order_id`'s status.
+///
+/// Two independent reasons to refuse, both about the same thing — the startup
+/// backlog:
+///
+/// * the trade already sits in a hard-terminal status
+///   ([`status_sync_blocked_by_terminal`]), and
+/// * the message is **older** than one whose write was already applied.
+///
+/// The second is the general rule and the first is defence in depth, kept
+/// because it is the only one that still works without a durable store (web),
+/// where it reads the in-memory book.
+///
+/// Strictly older is what is refused: the daemon emits several messages for one
+/// order within the same second (the `PayInvoice` reputation follow-up, for
+/// one), and those are genuine, in-order traffic.
+async fn status_write_blocked(
+    order_id: &str,
+    action: &mostro_core::message::Action,
+    event_created_at: i64,
+) -> bool {
+    if status_sync_blocked_by_terminal(order_id, action).await {
+        return true;
+    }
+    if let Some(cursor) = load_status_cursor(order_id).await {
+        if event_created_at < cursor {
+            crate::api::logging::blog_info(
+                "orders",
+                format!(
+                    "skip replayed {action:?} order={}: event is {}s older than the last applied",
+                    crate::api::logging::short_id(order_id),
+                    cursor.saturating_sub(event_created_at),
+                ),
+            );
+            return true;
+        }
     }
     false
 }
@@ -5929,6 +6022,122 @@ mod tests {
             }
         }
         assert!(!leaked, "stale Canceled must not emit a TradeUpdate");
+    }
+
+    /// The startup backlog must not walk a trade's status backwards.
+    ///
+    /// The global kind-14 subscription carries no `since`, so every start
+    /// replays the node's whole history for the order, and relays serve stored
+    /// events newest-first. Applied blindly, the *oldest* message lands last
+    /// and wins: a disputed trade came back as `waiting-buyer-invoice` on every
+    /// restart, with the intermediate states emitted to the UI on the way down.
+    ///
+    /// Replays in that exact order — newest first, none of them terminal, so
+    /// only the ordering rule can refuse them.
+    #[tokio::test]
+    async fn a_replayed_backlog_cannot_walk_the_status_backwards() {
+        use mostro_core::message::{Action, Message};
+
+        let path = std::env::temp_dir()
+            .join(format!("mostro_status_replay_{}.db", std::process::id()));
+        let _ = crate::db::app_db::init_db(path.to_str().unwrap()).await;
+        let db = crate::db::app_db::db().expect("store initialised");
+
+        let order_uuid = uuid::Uuid::new_v4();
+        let order_id = order_uuid.to_string();
+        let order_info = dummy_order_info(&order_id);
+        order_book().upsert_order(order_info.clone()).await;
+        db.save_trade(&crate::api::types::TradeInfo {
+            id: order_id.clone(),
+            order: order_info,
+            role: TradeRole::Seller,
+            counterparty_pubkey: String::new(),
+            current_step: crate::api::types::TradeStep::Seller(
+                crate::api::types::SellerStep::OrderPublished,
+            ),
+            hold_invoice: None,
+            buyer_invoice: None,
+            trade_key_index: 1,
+            cooperative_cancel_state: None,
+            timeout_at: None,
+            started_at: 1,
+            completed_at: None,
+            outcome: None,
+            peer_rating: None,
+            peer_reviews: None,
+            peer_days: None,
+            rated_at: None,
+        })
+        .await
+        .expect("save the trade row");
+
+        let mut rx = trade_updates_tx().subscribe();
+        let sender = nostr_sdk::prelude::PublicKey::from_hex(&active_mostro_pubkey())
+            .expect("valid mostro pubkey");
+
+        // Newest first, exactly how the relay hands the backlog back.
+        for (action, created_at) in [
+            (Action::DisputeInitiatedByYou, 3_000u64),
+            (Action::FiatSentOk, 2_000),
+            (Action::WaitingBuyerInvoice, 1_000),
+        ] {
+            dispatch_mostro_message(
+                mostro_core::nip59::UnwrappedMessage {
+                    message: Message::new_order(Some(order_uuid), None, None, action, None),
+                    signature: None,
+                    sender,
+                    identity: sender,
+                    created_at: nostr_sdk::prelude::Timestamp::from(created_at),
+                },
+                &format!("test-backlog-{created_at}"),
+                "ff00ff10",
+                1,
+            )
+            .await;
+        }
+
+        // The newest message is the one that stuck, in both the book...
+        assert_eq!(
+            order_book()
+                .get_order(&order_id)
+                .await
+                .expect("order still cached")
+                .status,
+            crate::api::types::OrderStatus::Dispute,
+            "the newest replayed message must own the status",
+        );
+        // ...and the row My Trades reads.
+        assert_eq!(
+            db.get_trade_by_order_id(&order_id)
+                .await
+                .expect("trade lookup")
+                .expect("trade row")
+                .order
+                .status,
+            crate::api::types::OrderStatus::Dispute,
+            "the persisted status must not walk backwards across a restart",
+        );
+        // The cursor is the high-water mark that survives the restart.
+        assert_eq!(
+            db.get_setting(&crate::db::settings_keys::status_cursor(&order_id))
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("3000"),
+            "the applied event's timestamp must be recorded",
+        );
+        // Nothing older reached the UI on the way down: one update, not three.
+        let mut emitted = Vec::new();
+        while let Ok(update) = rx.try_recv() {
+            if update.order_id == order_id {
+                emitted.push(update.status);
+            }
+        }
+        assert_eq!(
+            emitted,
+            vec![crate::api::types::OrderStatus::Dispute],
+            "a refused replay must not emit a TradeUpdate",
+        );
     }
 
     /// #326: the fingerprint-restore path must NOT overwrite the authoritative

--- a/rust/src/db/mod.rs
+++ b/rust/src/db/mod.rs
@@ -62,6 +62,28 @@ pub mod settings_keys {
     pub fn dispute_mine(order_id: &str) -> String {
         format!("{DISPUTE_MINE_PREFIX}{order_id}")
     }
+
+    /// Per-order status replay cursor — the `created_at` (unix seconds,
+    /// decimal string) of the newest daemon message whose status write was
+    /// applied, clamped to the local clock. Full key is
+    /// `status_cursor:<order_id>`; build it with [`status_cursor`].
+    pub const STATUS_CURSOR_PREFIX: &str = "status_cursor:";
+
+    /// Build the settings key holding the status replay cursor for `order_id`.
+    ///
+    /// Same shape and purpose as [`chat_cursor`], for the other channel: the
+    /// global kind-14 subscription carries no `since`, so every start replays
+    /// the node's full history, and relays serve stored events newest-first.
+    /// Without a durable high-water mark the oldest message in that backlog is
+    /// applied last and wins, walking a trade's status back to where it began.
+    ///
+    /// Deliberately **not** cleared with the trade row: a cancel before the
+    /// trade went active wipes that row (`cancellation_wipes_history`), and the
+    /// cursor is precisely what still refuses the older messages afterwards.
+    /// One tiny row per order ever traded, like the chat cursor.
+    pub fn status_cursor(order_id: &str) -> String {
+        format!("{STATUS_CURSOR_PREFIX}{order_id}")
+    }
 }
 
 /// Storage trait — implemented by both SQLite (native) and IndexedDB (WASM).

--- a/rust/src/db/sqlite.rs
+++ b/rust/src/db/sqlite.rs
@@ -771,6 +771,33 @@ mod tests {
         );
     }
 
+    /// The companion to the no-row check: a *genuine* storage failure must
+    /// still reach the caller. Reading the result to count affected rows put a
+    /// binding between `execute` and the `?` that propagates the error — the
+    /// shape a later "simplification" turns into `.ok()`, which would restore
+    /// exactly the silence this stopped. A closed pool is a real, deterministic
+    /// failure, so it pins the propagation without corrupting anything.
+    #[tokio::test]
+    async fn a_trade_update_that_fails_is_not_reported_as_a_write() {
+        let path = temp_db_path();
+        let storage = SqliteStorage::open(path.to_str().unwrap()).await.unwrap();
+        storage.pool.close().await;
+
+        let result = storage
+            .update_trade_fields(
+                "any-order",
+                Some(crate::api::types::OrderStatus::Dispute),
+                None,
+                None,
+            )
+            .await;
+
+        assert!(
+            result.is_err(),
+            "a failed write must surface as Err, never as Ok(())",
+        );
+    }
+
     /// `foreign_keys` is a per-connection pragma, so running it once through
     /// the pool leaves the other connections with enforcement off — whichever
     /// one a given write lands on decides whether constraints apply.

--- a/rust/src/db/sqlite.rs
+++ b/rust/src/db/sqlite.rs
@@ -637,7 +637,23 @@ impl Storage for SqliteStorage {
             query = query.bind(format!("{s:?}"));
         }
         query = query.bind(order_id);
-        query.execute(&self.pool).await?;
+        let result = query.execute(&self.pool).await?;
+
+        // Matching no row is not an error SQLite reports — the statement
+        // succeeds and updates nothing — but for every caller it is a silent
+        // loss: the status moved in the book and in the UI while the row My
+        // Trades reads kept the old value. Nothing here can repair it (the row
+        // is gone, or was never written), so the only useful thing to do is
+        // say so out loud instead of returning `Ok(())` like a real write.
+        if result.rows_affected() == 0 {
+            crate::api::logging::blog_warn(
+                "db",
+                format!(
+                    "update_trade_fields matched no row for order={}",
+                    crate::api::logging::short_id(order_id),
+                ),
+            );
+        }
         Ok(())
     }
 
@@ -717,6 +733,42 @@ mod tests {
         static COUNTER: AtomicU32 = AtomicU32::new(0);
         let n = COUNTER.fetch_add(1, Ordering::Relaxed);
         std::env::temp_dir().join(format!("mostro_test_{}_{n}.db", std::process::id()))
+    }
+
+    /// A status sync that matches no row used to be indistinguishable from one
+    /// that wrote: SQLite reports success for an `UPDATE` that touches nothing,
+    /// the result was discarded, and the caller's only failure report was a
+    /// `log::warn!` this app never emits. The write is unrecoverable either
+    /// way — the point is that it stops being silent.
+    #[tokio::test]
+    async fn a_trade_update_that_matches_no_row_is_reported() {
+        // The verbosity filter defaults to `Off`, so nothing reaches any sink
+        // until this runs — the same call `init_app` makes in the app.
+        crate::api::logging::install_log_bridge();
+
+        let path = temp_db_path();
+        let storage = SqliteStorage::open(path.to_str().unwrap()).await.unwrap();
+
+        let order_id = format!("ghost-{}", uuid::Uuid::new_v4());
+        storage
+            .update_trade_fields(
+                &order_id,
+                Some(crate::api::types::OrderStatus::Dispute),
+                None,
+                None,
+            )
+            .await
+            .expect("a no-op update is not an error, and never was");
+
+        let short = crate::api::logging::short_id(&order_id);
+        assert!(
+            crate::api::logging::recent_logs().iter().any(|e| {
+                e.tag == "db"
+                    && matches!(e.level, crate::api::types::LogLevel::Warning)
+                    && e.message.contains(&short)
+            }),
+            "a trade update matching no row must warn, not pass as a write",
+        );
     }
 
     /// `foreign_keys` is a per-connection pragma, so running it once through

--- a/specs/004-mostro-p2p-client/contracts/orders.md
+++ b/specs/004-mostro-p2p-client/contracts/orders.md
@@ -386,10 +386,18 @@ escrow-locked arm).
 
 **Ordering.** Each order carries a persisted high-water mark,
 `status_cursor:<order_id>` — the `created_at` of the newest daemon
-message whose status write was applied, clamped to the local clock so a
-node dating an event ahead cannot push the mark past everything that
-follows and freeze the order. A message **strictly older** than the mark
-is skipped. Strictly older: the daemon emits several messages for one
+message whose status write was applied, stored **raw, in the node's time
+domain**, which is the domain the comparison uses. It is deliberately not
+clamped to the local clock the way the chat cursor is: there the value is
+a subscription `since`, where a low one only asks for more than needed,
+while here it is an ordering comparator, and a local clock behind the
+node's would make a newest event store a smaller mark that the next older
+one then outranks. The mark is instead not advanced at all by an event
+dated beyond the clock-skew tolerance, so one malformed timestamp cannot
+silence an order for good; a node genuinely further ahead makes the rule
+inert for that order rather than wrong, and says so in the log. Ordering
+between the node's own events survives any uniform skew — they share one
+clock. A message **strictly older** than the mark is skipped. Strictly older: the daemon emits several messages for one
 order inside the same second (the `PayInvoice` reputation follow-up, for
 one) and those are genuine in-order traffic. Without this rule the oldest
 message of the backlog is applied last and wins — a disputed trade came

--- a/specs/004-mostro-p2p-client/contracts/orders.md
+++ b/specs/004-mostro-p2p-client/contracts/orders.md
@@ -331,6 +331,14 @@ Coverage invariants:
 - The temporary 30-minute per-trade receivers (see #182) are an
   additional delivery path, not a substitute: they exist only for trades
   touched this session and mask coverage gaps while they run.
+- **The bulk filter is unbounded on purpose** — no `since`, no `limit`, so
+  after any downtime it replays the node's full stored history instead of a
+  window, and nothing is lost to a cutoff derived from an unreliable local
+  clock. The cost is that relays serve that backlog **newest-first**;
+  ordering is settled downstream, by the per-order `status_cursor:`
+  high-water mark described under the status-sync rules, not by narrowing
+  the filter. Only the ephemeral per-trade subscription carries a cutoff
+  (`limit(0)`, live-only).
 
 ### Inbound Kind 14 actions consumed by `dispatch_mostro_message`
 
@@ -368,18 +376,48 @@ what rebuilds sessions after one.
 | `AdminSettled` / `AdminCanceled`   | (status sync)                                       | `status → SettledByAdmin` / `CanceledByAdmin`                                    |
 | `Canceled`                         | (none)                                              | Never-active trade (pending/waiting): row + in-memory session **deleted**; otherwise `status → Canceled` (history kept). See below. |
 
-A sync that would move a trade out of a **hard-terminal** status
-(`Canceled` / `CanceledByAdmin` / `CooperativelyCanceled` / `Expired` /
-`Success` / `SettledByAdmin` / `CompletedByAdmin`) is skipped entirely —
-no book/DB write, no emission, and no session side effect either (the
-guard runs before the peer-key/chat setup of the escrow-locked arm). Relays deliver the startup backlog
-newest-first, so such a message is an out-of-order replay, not a real
-transition; mostrod never reopens a finished trade. `SettledHoldInvoice`
-and `Dispute` still progress and are deliberately not in the set.
-`Canceled` applies the same guard — a stale timeout-cancel replayed over
-an order that was later re-taken and completed must not overwrite the
-outcome; its wipe path is unaffected, since it starts from non-terminal
-waiting states.
+Two rules gate every status sync in the table, and both exist for the
+same reason: the global kind-14 subscription carries no `since`, so every
+start replays the node's whole history for an order, and relays serve
+stored events **newest-first**. A skipped sync is skipped entirely — no
+book write, no DB write, no `TradeUpdate`, and no session side effect
+either (both guards run before the peer-key/chat setup of the
+escrow-locked arm).
+
+**Ordering.** Each order carries a persisted high-water mark,
+`status_cursor:<order_id>` — the `created_at` of the newest daemon
+message whose status write was applied, clamped to the local clock so a
+node dating an event ahead cannot push the mark past everything that
+follows and freeze the order. A message **strictly older** than the mark
+is skipped. Strictly older: the daemon emits several messages for one
+order inside the same second (the `PayInvoice` reputation follow-up, for
+one) and those are genuine in-order traffic. Without this rule the oldest
+message of the backlog is applied last and wins — a disputed trade came
+back as `waiting-buyer-invoice` on the next start, with every state in
+between emitted to the UI on the way down.
+
+The mark is deliberately **not** cleared with the trade row: a `Canceled`
+before the trade went active wipes that row, which is exactly where the
+terminal rule below goes blind, and the mark is what still refuses the
+replay afterwards. One settings row per order ever traded, the same shape
+and lifetime as the `chat_cursor:` that bounds the other channel.
+
+**Terminal status.** A sync that would move a trade out of a
+**hard-terminal** status (`Canceled` / `CanceledByAdmin` /
+`CooperativelyCanceled` / `Expired` / `Success` / `SettledByAdmin` /
+`CompletedByAdmin`) is skipped: mostrod never reopens a finished trade,
+so such a message is an out-of-order replay whatever its timestamp says.
+This is not redundant with the ordering rule — it reads the in-memory
+book, so it is the only one of the two that still holds where there is no
+durable store (web, #233). `Canceled` applies it too: a stale
+timeout-cancel replayed over an order that was later re-taken and
+completed must not overwrite the outcome; its wipe path is unaffected,
+since it starts from non-terminal waiting states.
+
+`SettledHoldInvoice` and `Dispute` are deliberately **not** in the
+terminal set — they still progress, to `Success` and to admin
+resolutions respectively — so it is the ordering rule, not this one, that
+keeps a replay from walking them backwards.
 
 Every arm above that syncs a status also emits a `TradeUpdate` (see
 `on_trade_updated`) after the in-memory book update and the DB


### PR DESCRIPTION
Closes #393.

## Problem

The global kind-14 subscription carries no `since`, so every start replays the
node's full history for an order, and relays serve stored events
**newest-first**. The dispatch arms applied each message as if it had just
arrived, so the **oldest** one landed last and won.

A disputed trade came back as `waiting-buyer-invoice` after a restart, with
every state in between written to the DB and emitted to the UI on the way down:

```
23:27:37  →Dispute              (session 1, correct)
          ── restart ──
23:28:42  wire=InProgress local=Dispute applies=false   ← the persisted state was still right
23:28:42  →Dispute              (newest, applied first)
23:28:42  →Active
23:28:42  →WaitingPayment
23:28:42  →WaitingBuyerInvoice  (oldest, applied last ⇒ wins)
```

Introduced on 2026-08-07 by #292: before it, the startup path never seeded
`global_dm_keys()`, so every replayed message was dropped undecrypted and the
backlog could not corrupt anything. Nineteen minutes later, in the same PR,
`7582162` added a guard for the case it had just made visible — but only for
hard-terminal statuses, and its own message records that `SettledHoldInvoice`
and `Dispute` were left out on purpose because they still progress. Sound
reasoning, missing the piece that makes it safe: comparing timestamps.

## Change

**`created_at` was already there and thrown away.** `UnwrappedMessage` carries
the kind-14 event's own timestamp (`unwrap_message_nip44` sets it from
`event.created_at`, the key relays order by) and `dispatch_mostro_message`
discarded it with `created_at: _`. No signature plumbing was needed.

- **`refactor(orders)`** — bind it and report it as `age` on the per-message log
  line. No behaviour change; it makes a replayed message distinguishable from a
  live one in the field.
- **`fix(orders)`** — persist a per-order high-water mark,
  `status_cursor:<order_id>`, and refuse any status write from a **strictly
  older** message. Strictly older, because the daemon emits several messages for
  one order within the same second. Same shape as the `chat_cursor:` that
  already bounds the other channel, so no schema or trait change.
- The hard-terminal guard stays. It is not redundant: it reads the in-memory
  book, so it is the only one of the two that still protects a session with no
  durable store (web, #233).
- The cursor is deliberately **not** cleared with the trade row. A cancel before
  the trade went active wipes that row, which is exactly where the terminal
  guard goes blind; living in settings, the cursor outlives the wipe.
- **`docs(specs)`** — the orders contract described the terminal guard as the
  whole story and quoted the gap without saying what covered it. Split into the
  two rules, and record that the bulk filter is unbounded on purpose so the
  missing `since` is not read as an oversight.
- **`fix(db)` + `test(db)`** — collateral finding, folded in because it is the
  reason this class of bug was invisible: `update_trade_fields` matched on
  `WHERE json_extract(...)` and discarded the result, so a write against a row
  that is gone returned `Ok(())`; and the seven callers reported failures with
  `log::warn!`, which this app never emits (`install_log_bridge` is not wired,
  so the global filter stays `Off`). Now it warns on `rows_affected == 0` and
  reports through `blog_warn`.

## Test plan

Unit tests, all pinned by mutation (reverting the code under test makes them
fail):

- [x] `a_replayed_backlog_cannot_walk_the_status_backwards` — replays a backlog
      newest-first through the real dispatch path and asserts the book, the
      persisted row, the cursor, and that no intermediate `TradeUpdate` is
      emitted. Without the fix: `left: WaitingBuyerInvoice, right: Dispute`.
- [x] `a_trade_update_that_matches_no_row_is_reported`
- [x] `a_trade_update_that_fails_is_not_reported_as_a_write`
- [x] `cargo test --locked` — 406 passed
- [x] `cargo clippy --locked -- -D warnings` — clean
- [x] `cargo check --locked --target wasm32-unknown-unknown` — clean

**Validated against a real database**, not only the tests. Three orders already
corrupted by this bug healed on the first launch, with the outcome predicted
before running:

| order | before | after |
|---|---|---|
| `625eef22` | `WaitingBuyerInvoice` | `Dispute` |
| `916d0dc5` | `WaitingPayment` | `Active` |
| `84599f9e` | `WaitingBuyerInvoice` | `SettledHoldInvoice` |

Same startup, before and after:

| | messages | status writes | refused (order) | refused (terminal) |
|---|---|---|---|---|
| before | 198 | **78** | 0 | 53 |
| after, 1st start | 187 | **39** | 37 | 47 |
| after, 2nd start | 187 | **22** | 54 | 47 |

Half the status writes were backwards steps. The second start moved **no**
status at all — the cursor is durable, so refusal happens from the first
message. Backlog ages ranged from 5.7 h to 706 h, now visible on every line.

The guard does not over-block: `d4969423` received its messages in ascending
order (ages 100338 → 100319 → 100303 → 100243) and applied all four writes,
ending at `Dispute`. Only strictly older messages are refused.

A full take → restart cycle was run as well. The live reply logged `age=0s`, the
same message came back in the next start's replay at `age=35s` and was applied
once, and no trade changed status across the restart.
order (ages 100338 → 100319 → 100303 → 100243) and applied all four writes,
ending at `Dispute`. Only strictly older messages are refused.

A full take → restart cycle was run as well. The live reply logged `age=0s`, the
same message came back in the next start's replay at `age=35s` and was applied
once, and no trade changed status across the restart.

## Two residual findings, deliberately not fixed here

Both pre-existed and were silent; the new `rows_affected == 0` warning is what
surfaced them. Filed separately:

- **#394** — a daemon message for an order with no trade row has no defined
  behaviour. 7 orders whose row a cancel deleted still have their history
  replayed and re-applied on every start; the write lands nowhere and a
  `TradeUpdate` is still emitted. The cursor trims what it can (9 warnings → 7
  on the second start) but this is not an ordering problem: the trade does not
  exist. The same issue covers the opposite case — a create or take whose
  confirmation timed out while the daemon proceeded, where the message is the
  only recovery signal there is — and the content-fingerprint heuristic that
  stands in for it today. Also carries the idempotent-rewrite note: 10 of the 22
  remaining writes rewrite the value the row already holds.
- **#395** — `trades.id` and `data.order.id` diverge in 10 of 36 rows. Not
  reached by this PR's paths (they all key on the JSON id), but `get_trade`
  keys on the primary key and would return `None` for those rows.

Neither is a regression.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented order statuses from moving backward when delayed or replayed updates are received.
  - Preserved completed and canceled order states against later conflicting updates.
  - Improved reliability when recovering order history after downtime.
  - Added clearer warnings when order updates cannot be matched or saved.

- **Documentation**
  - Clarified order-status synchronization, replay behavior, ordering rules, and terminal-state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->