### PR TITLE
fix(ios): declare NSCameraUsageDescription

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -45,5 +45,7 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>Mostro uses the camera to scan QR codes when you connect a Lightning wallet.</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Problem

`mobile_scanner` opens the camera from the NWC wallet screen (`lib/features/settings/screens/connect_wallet_screen.dart:108` → `lib/shared/widgets/platform_aware_qr_scanner.dart`), but `ios/Runner/Info.plist` carries no `NSCameraUsageDescription`.

iOS terminates the process on the spot. **Connecting a Lightning wallet by QR code is impossible on iPhone today.**

## Reproduction

iPhone 15 Pro Max (iOS 26.6.1) and iPhone 17 Pro simulator (iOS 26.5), both on `main`:

Menu → Settings → **NWC wallet** → **Scan QR** → the app dies immediately (`Lost connection to device`).

The system log names the cause verbatim:

```
Runner[54164] [com.apple.TCC:access] This app has crashed because it attempted to
access privacy-sensitive data without a usage description.  The app's Info.plist
must contain an NSCameraUsageDescription key with a string value explaining to
the user how the app uses this data.
```

Read it back with:

```sh
xcrun simctl spawn <udid> log show --predicate 'process == "Runner"' --last 3m --style compact
```

## Why it also blocks the App Store

App Review guideline 2.1(a): *"We will reject incomplete app bundles and binaries that crash or exhibit obvious technical problems."*

## The change

Two lines in `ios/Runner/Info.plist`. Verified in the built bundle, and the scanner now opens normally after the permission prompt.

## One open question for maintainers

The string is **English-only**. iOS purpose strings live in `Info.plist`, outside the Flutter l10n pipeline; localising them requires per-locale `InfoPlist.strings` files, which this repository does not have. That felt like too much for a crash fix, but I am happy to add that infrastructure in a follow-up if you would rather ship it localised in all five languages.

---

Context: I am working on making the iOS target build and keep working. v2 does compile and run on iOS unmodified — a fuller baseline report will follow as an issue.