### PR TITLE
fix(ios): apply Runner.entitlements to the Runner target

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -361,6 +361,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -540,6 +541,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -562,6 +564,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;


### PR DESCRIPTION
## Problem

`ios/Runner/Runner.entitlements` exists and declares a keychain access group for `flutter_secure_storage`:

```xml
<!-- Keychain access group for flutter_secure_storage (PIN, session data) -->
<key>keychain-access-groups</key>
<array><string>$(AppIdentifierPrefix)foundation.mostro.app</string></array>
```

But `CODE_SIGN_ENTITLEMENTS` is not set on any Runner build configuration, and the file is not referenced anywhere in `project.pbxproj`. **Xcode never reads it.** The Flutter template does not create this file, so it was clearly written on purpose and then not wired up.

## Evidence

Entitlements read back from a signed device build of `main`:

```
application-identifier
com.apple.developer.team-identifier
get-task-allow
```

After this change, `keychain-access-groups` is present as declared. Checked with:

```sh
codesign -d --entitlements :- <path>/Runner.app | plutil -p -
```

## Why fix it now, given nothing is broken

Nothing is broken today: iOS falls back to the app's default access group, so `flutter_secure_storage` works either way, and I saw no `errSec` in a full session on device.

The reason to fix it now is the next step. `firebase_messaging` is already a dependency, so `aps-environment` will have to be added to this same file to enable APNs. Doing so would **silently do nothing**, with no error at build time, at signing time or at runtime. That is an expensive thing to debug, and a one-line change to prevent.

## The change

Three lines: `CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;` on the Runner target's Debug, Release and Profile configurations. The `RunnerTests` target is untouched.

Validated on an iPhone 15 Pro Max (iOS 26.6.1): app builds, signs, installs and runs; identity and settings survive a cold restart.