### PR TITLE
fix(#404): cover every locale tag the sanitizer handles, and what it leaves behind

### DIFF
--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -43,6 +43,16 @@ jobs:
       contents: read
     # The first uncached run compiles std from source (-Z build-std), which is slow.
     timeout-minutes: 60
+    env:
+      # What a negative control must find in its output to count as "died of
+      # the bug the sanitizer fixes", rather than of any of the five unrelated
+      # reasons smoke.mjs exits non-zero for. Two messages because Intl.Locale
+      # words the empty tag differently from a malformed one — both are the
+      # engine refusing a locale before runApp, and matching only the first
+      # would report the empty case as an unexplained failure. Kept exact
+      # rather than loosened to something like "locale": a lax pattern is what
+      # lets a control celebrate an unrelated crash.
+      LOCALE_CRASH_SIGNATURE: "Incorrect locale information provided|Intl.Locale constructor can't be empty"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -198,10 +208,11 @@ jobs:
       # navigator.language(s). This reruns the same smoke test forcing an
       # invalid locale so the fix can't silently regress.
       #
-      # Only "C" is actually covered here: Playwright normalizes the locale it
-      # is given before the page sees it, so "en_US" reaches the browser as a
-      # valid "en-US" and "" falls back to the default. The sanitizer handles
-      # all three; CI can only exercise the first.
+      # This step covers "C" only, and does so through Playwright's `locale`
+      # option — the one path where the tag reaches the page as the browser's
+      # own locale rather than as a shadow this repo installed. Kept for that
+      # reason. The other broken tags cannot travel this way (Playwright
+      # normalizes them first) and are covered by the locale matrix below.
       #
       # The crash itself only exists on Flutter >= 3.38, where the engine's
       # parseBrowserLanguages started building the locale through
@@ -209,6 +220,28 @@ jobs:
       # validated nothing. If FLUTTER_VERSION ever moves back below that, or
       # the engine stops using Intl, this step passes for the wrong reason —
       # revalidate it against a build without the sanitizer before trusting it.
+      # Built once and reused by every negative control below. Copying the
+      # built bundle and cutting the sanitizer out of its HTML — rather than
+      # building a second time — is what makes the comparison mean something:
+      # both sides come from one build, so the sanitizer is the only difference.
+      - name: Build the control bundle — the same build, sanitizer removed (#227)
+        run: |
+          set -euo pipefail
+          control_dir="${RUNNER_TEMP}/web-no-sanitizer"
+          rm -rf "$control_dir"
+          cp -r "${GITHUB_WORKSPACE}/build/web" "$control_dir"
+          # Delete the marker comment through the end of the inline script it
+          # introduces. The script contains no literal </script>, so the first
+          # one after the marker closes it.
+          sed -i '/<!-- locale-sanitizer/,/<\/script>/d' "$control_dir/index.html"
+          # Never let a silent no-op turn the controls into a rubber stamp: if
+          # the marker is ever renamed, this cuts nothing and every control
+          # below would be comparing the bundle against itself.
+          if grep -q 'locale-sanitizer' "$control_dir/index.html"; then
+            echo "::error::failed to strip the sanitizer — the controls prove nothing"
+            exit 1
+          fi
+
       - name: Smoke test the release bundle under an invalid locale (#227)
         working-directory: test/web/smoke
         env:
@@ -240,17 +273,6 @@ jobs:
         run: |
           set -euo pipefail
           control_dir="${RUNNER_TEMP}/web-no-sanitizer"
-          rm -rf "$control_dir"
-          cp -r "${GITHUB_WORKSPACE}/build/web" "$control_dir"
-          # Delete the marker comment through the end of the inline script it
-          # introduces. The script contains no literal </script>, so the first
-          # one after the marker closes it.
-          sed -i '/<!-- locale-sanitizer/,/<\/script>/d' "$control_dir/index.html"
-          # Never let a silent no-op turn this control into a rubber stamp.
-          if grep -q 'locale-sanitizer' "$control_dir/index.html"; then
-            echo "::error::failed to strip the sanitizer — the control proves nothing"
-            exit 1
-          fi
           control_log="${RUNNER_TEMP}/control-smoke.log"
           if BUNDLE_DIR="$control_dir" BASE_PATH="/${GITHUB_REPOSITORY#*/}/" node smoke.mjs >"$control_log" 2>&1; then
             cat "$control_log"
@@ -260,7 +282,7 @@ jobs:
           fi
           # It failed — but smoke.mjs fails for five reasons that have nothing
           # to do with this bug. Only the locale RangeError proves the control.
-          if ! grep -q 'Incorrect locale information provided' "$control_log"; then
+          if ! grep -Eq "$LOCALE_CRASH_SIGNATURE" "$control_log"; then
             cat "$control_log"
             echo "::error::the control failed, but not with the locale RangeError —"
             echo "::error::it proves nothing about this fix (see #227)"
@@ -271,6 +293,74 @@ jobs:
           # failure does not upload this expected one as its evidence.
           rm -f smoke-failure.png
           echo "control failed as expected — the locale guard is load-bearing"
+
+      # The two steps above only ever exercise "C". Playwright's `locale`
+      # option normalizes the tag before the page sees it, so "en_US" arrives
+      # as a valid "en-US" and "" falls back to the system locale — a limit of
+      # that option, not of the browser. SMOKE_NAVIGATOR_LANGUAGES shadows
+      # navigator.language(s) from an init script instead, which runs inside
+      # the page before any of its own scripts, so the engine is handed a tag
+      # Playwright would never deliver.
+      #
+      # That closes the gap on #227's second acceptance criterion, which names
+      # three tags, and covers the mixed list nothing tested at all: with
+      # "C,es-AR" the correct result is not the fallback but "es-AR" — the
+      # sanitizer must drop the broken tag and keep the good one.
+      #
+      # Which is why each case also states the locale it expects to find
+      # afterwards. "The view mounted" cannot tell a sanitizer that kept
+      # "es-AR" from one that dropped the whole list for the fallback: both
+      # boot fine, and only the second silently costs the user their language.
+      #
+      # Each tag runs twice: against the shipped bundle it must pass, against
+      # the control bundle it must fail with the locale signature. The control
+      # half costs ~20s per tag (it waits out SMOKE_TIMEOUT_MS for a view that
+      # will never mount), which is the price of the guard being self-validating.
+      - name: Locale matrix — every tag the sanitizer claims to handle (#227)
+        working-directory: test/web/smoke
+        env:
+          SMOKE_TIMEOUT_MS: "20000"
+        run: |
+          set -euo pipefail
+          control_dir="${RUNNER_TEMP}/web-no-sanitizer"
+          base="/${GITHUB_REPOSITORY#*/}/"
+          # Deliberately includes the empty string; it is one of the broken
+          # tags, and smoke.mjs distinguishes unset from empty for that reason.
+          # "<injected tags>|<languages expected after the sanitizer>".
+          for case in "C|en-US" "en_US|en-US" "|en-US" "C,es-AR|es-AR"; do
+            langs="${case%%|*}"
+            expected="${case##*|}"
+            label="${langs:-<empty>}"
+
+            echo "::group::locale [$label] — with the sanitizer, must pass and leave [$expected]"
+            SMOKE_NAVIGATOR_LANGUAGES="$langs" SMOKE_EXPECT_LANGUAGES="$expected" \
+              BUNDLE_DIR="${GITHUB_WORKSPACE}/build/web" \
+              BASE_PATH="$base" node smoke.mjs
+            echo "::endgroup::"
+
+            echo "::group::locale [$label] — without the sanitizer, must fail"
+            log="${RUNNER_TEMP}/control-${label//[^A-Za-z0-9]/_}.log"
+            if SMOKE_NAVIGATOR_LANGUAGES="$langs" BUNDLE_DIR="$control_dir" \
+                 BASE_PATH="$base" node smoke.mjs >"$log" 2>&1; then
+              cat "$log"
+              echo "::error::locale [$label] passed without the sanitizer —"
+              echo "::error::the matrix above is no longer testing this bug (see #227)"
+              exit 1
+            fi
+            if ! grep -Eq "$LOCALE_CRASH_SIGNATURE" "$log"; then
+              cat "$log"
+              echo "::error::locale [$label] failed, but not with a locale error —"
+              echo "::error::it proves nothing about this fix (see #227)"
+              exit 1
+            fi
+            cat "$log"
+            echo "::endgroup::"
+
+            # Each failing control leaves a screenshot behind; drop it so a
+            # later, real failure does not upload an expected one as evidence.
+            rm -f smoke-failure.png
+            echo "locale [$label]: sanitized to [$expected] with the sanitizer, dies without it"
+          done
 
       - name: Upload smoke test failure screenshot
         if: failure()

--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -199,27 +199,6 @@ jobs:
         env:
           BUNDLE_DIR: ${{ github.workspace }}/build/web
         run: BASE_PATH="/${GITHUB_REPOSITORY#*/}/" node smoke.mjs
-
-      # Regression guard for issue #227: an unparseable browser locale (the
-      # POSIX "C" locale, an underscored "en_US", empty) crashed the Flutter
-      # web engine's own bootstrap before runApp, with no error path — an
-      # unrecoverable blank page. Fixed by the locale sanitizer in
-      # web/index.html, which runs before flutter_bootstrap.js and normalizes
-      # navigator.language(s). This reruns the same smoke test forcing an
-      # invalid locale so the fix can't silently regress.
-      #
-      # This step covers "C" only, and does so through Playwright's `locale`
-      # option — the one path where the tag reaches the page as the browser's
-      # own locale rather than as a shadow this repo installed. Kept for that
-      # reason. The other broken tags cannot travel this way (Playwright
-      # normalizes them first) and are covered by the locale matrix below.
-      #
-      # The crash itself only exists on Flutter >= 3.38, where the engine's
-      # parseBrowserLanguages started building the locale through
-      # Intl.Locale (@JS binding) instead of a pure-Dart ui.Locale that
-      # validated nothing. If FLUTTER_VERSION ever moves back below that, or
-      # the engine stops using Intl, this step passes for the wrong reason —
-      # revalidate it against a build without the sanitizer before trusting it.
       # Built once and reused by every negative control below. Copying the
       # built bundle and cutting the sanitizer out of its HTML — rather than
       # building a second time — is what makes the comparison mean something:
@@ -242,6 +221,26 @@ jobs:
             exit 1
           fi
 
+      # Regression guard for issue #227: an unparseable browser locale (the
+      # POSIX "C" locale, an underscored "en_US", empty) crashed the Flutter
+      # web engine's own bootstrap before runApp, with no error path — an
+      # unrecoverable blank page. Fixed by the locale sanitizer in
+      # web/index.html, which runs before flutter_bootstrap.js and normalizes
+      # navigator.language(s). This reruns the same smoke test forcing an
+      # invalid locale so the fix can't silently regress.
+      #
+      # This step covers "C" only, and does so through Playwright's `locale`
+      # option — the one path where the tag reaches the page as the browser's
+      # own locale rather than as a shadow this repo installed. Kept for that
+      # reason. The other broken tags cannot travel this way (Playwright
+      # normalizes them first) and are covered by the locale matrix below.
+      #
+      # The crash itself only exists on Flutter >= 3.38, where the engine's
+      # parseBrowserLanguages started building the locale through
+      # Intl.Locale (@JS binding) instead of a pure-Dart ui.Locale that
+      # validated nothing. If FLUTTER_VERSION ever moves back below that, or
+      # the engine stops using Intl, this step passes for the wrong reason —
+      # revalidate it against a build without the sanitizer before trusting it.
       - name: Smoke test the release bundle under an invalid locale (#227)
         working-directory: test/web/smoke
         env:
@@ -318,8 +317,6 @@ jobs:
       # will never mount), which is the price of the guard being self-validating.
       - name: Locale matrix — every tag the sanitizer claims to handle (#227)
         working-directory: test/web/smoke
-        env:
-          SMOKE_TIMEOUT_MS: "20000"
         run: |
           set -euo pipefail
           control_dir="${RUNNER_TEMP}/web-no-sanitizer"
@@ -340,7 +337,13 @@ jobs:
 
             echo "::group::locale [$label] — without the sanitizer, must fail"
             log="${RUNNER_TEMP}/control-${label//[^A-Za-z0-9]/_}.log"
-            if SMOKE_NAVIGATOR_LANGUAGES="$langs" BUNDLE_DIR="$control_dir" \
+            # Scoped to the control, not the step: this run is expected to die
+            # in engine bootstrap, so it always waits the selector out, and the
+            # default 120s would cost two idle minutes per tag. The positive
+            # run above keeps that default — same reason as the single-tag
+            # control before it, which must not be unified with it either.
+            if SMOKE_TIMEOUT_MS="20000" SMOKE_NAVIGATOR_LANGUAGES="$langs" \
+                 BUNDLE_DIR="$control_dir" \
                  BASE_PATH="$base" node smoke.mjs >"$log" 2>&1; then
               cat "$log"
               echo "::error::locale [$label] passed without the sanitizer —"

--- a/test/web/smoke/selftest.mjs
+++ b/test/web/smoke/selftest.mjs
@@ -41,11 +41,39 @@ const CASES = [
     expected: 1,
     what: 'one uncaught page error fails the run',
   },
+  // The locale check is the one assertion "the view mounted" cannot make for
+  // itself: with a mixed list, a sanitizer that keeps "es-AR" and one that
+  // drops the whole list both boot fine, and only the second costs the user
+  // their language. So the comparison behind it needs holding down from both
+  // sides — a check that never fires and one that always fires each pass one
+  // of these cases and fail the other.
+  //
+  // The healthy fixture has no sanitizer, so whatever is injected is what
+  // navigator.languages still reads at the end. That is what makes the first
+  // case a mismatch and the second a match, with no bundle to build.
+  {
+    fixture: 'healthy',
+    expected: 1,
+    env: {
+      SMOKE_NAVIGATOR_LANGUAGES: 'C,es-AR',
+      SMOKE_EXPECT_LANGUAGES: 'es-AR',
+    },
+    what: 'a locale left unsanitized fails the run',
+  },
+  {
+    fixture: 'healthy',
+    expected: 0,
+    env: {
+      SMOKE_NAVIGATOR_LANGUAGES: 'es-AR',
+      SMOKE_EXPECT_LANGUAGES: 'es-AR',
+    },
+    what: 'the expected locale passes — and the init script reached the page',
+  },
 ];
 
 let failures = 0;
 
-for (const { fixture, expected, what } of CASES) {
+for (const { fixture, expected, what, env } of CASES) {
   const result = spawnSync(process.execPath, [join(here, 'smoke.mjs')], {
     cwd: here,
     encoding: 'utf8',
@@ -56,6 +84,8 @@ for (const { fixture, expected, what } of CASES) {
       // Static fixtures load instantly; no reason to wait out the bundle's
       // budget when something is wrong.
       SMOKE_TIMEOUT_MS: '30000',
+      // Last, so a case can set the knobs it exists to exercise.
+      ...env,
     },
   });
 

--- a/test/web/smoke/smoke.mjs
+++ b/test/web/smoke/smoke.mjs
@@ -184,10 +184,14 @@ async function main() {
     // `!== undefined`, not a truthiness check: SMOKE_NAVIGATOR_LANGUAGES=''
     // is the empty-tag case, one of the broken ones this exists to cover.
     //
-    // `configurable: true` is load-bearing. The sanitizer bails out when either
-    // property is already locked down (#370 review), so a non-configurable
-    // shadow would make it skip the very path under test and the run would pass
-    // for the wrong reason.
+    // `configurable: true` is load-bearing, but not as a false-green guard.
+    // The sanitizer bails out when either property is already locked down
+    // (#370 review), so a non-configurable shadow makes it skip the very path
+    // under test — the engine then gets the raw tag and the positive run
+    // *fails*, with the same `Incorrect locale information provided` a real
+    // regression produces. Measured both ways on `C` and `C,es-AR` (#406
+    // review). What this flag prevents is a red matrix that reads as a broken
+    // sanitizer when it is really a broken harness.
     const forcedLanguages = process.env.SMOKE_NAVIGATOR_LANGUAGES;
     if (forcedLanguages !== undefined) {
       await page.addInitScript((langs) => {

--- a/test/web/smoke/smoke.mjs
+++ b/test/web/smoke/smoke.mjs
@@ -165,12 +165,42 @@ async function main() {
     // after it — hence the 'en-US' default. web-build.yml also runs this
     // script once with SMOKE_LOCALE=C: a regression guard for issue #227,
     // fixed by the locale sanitizer in web/index.html. The pin stays for
-    // determinism; it is no longer load-bearing for that bug.
+    // determinism; it is no longer load-bearing for that bug. The other broken
+    // tags cannot be delivered this way — see SMOKE_NAVIGATOR_LANGUAGES below.
     //
     // `??`, not `||`: the empty string is one of the broken tags this guards
     // against, and `||` would silently turn SMOKE_LOCALE='' into 'en-US' —
     // the one case the knob exists for, passing green without testing it.
     const page = await browser.newPage({ locale: process.env.SMOKE_LOCALE ?? 'en-US' });
+
+    // SMOKE_LOCALE goes through Playwright, which normalizes the tag before the
+    // page sees it: 'en_US' arrives as 'en-US' and '' falls back to the system
+    // locale, so only 'C' survives the trip. That is a limit of that option,
+    // not of the browser — an init script runs inside the page, before any of
+    // its own scripts, so it can hand the engine a tag Playwright would never
+    // deliver. Comma-separated, used verbatim; unset means "do not touch",
+    // which is every run except the locale matrix in web-build.yml.
+    //
+    // `!== undefined`, not a truthiness check: SMOKE_NAVIGATOR_LANGUAGES=''
+    // is the empty-tag case, one of the broken ones this exists to cover.
+    //
+    // `configurable: true` is load-bearing. The sanitizer bails out when either
+    // property is already locked down (#370 review), so a non-configurable
+    // shadow would make it skip the very path under test and the run would pass
+    // for the wrong reason.
+    const forcedLanguages = process.env.SMOKE_NAVIGATOR_LANGUAGES;
+    if (forcedLanguages !== undefined) {
+      await page.addInitScript((langs) => {
+        Object.defineProperty(navigator, 'languages', {
+          get: () => langs,
+          configurable: true,
+        });
+        Object.defineProperty(navigator, 'language', {
+          get: () => langs[0] ?? '',
+          configurable: true,
+        });
+      }, forcedLanguages.split(','));
+    }
 
     const record = (origin, text) => {
       (isIgnorable(text) ? ignored : errors).push(`[${origin}] ${text}`);
@@ -247,6 +277,28 @@ async function main() {
       })
       .catch(() => fail('the Flutter view never mounted'));
     console.log('✓ Flutter view mounted');
+
+    // 2b. The sanitizer left the locale it was supposed to leave.
+    //
+    //     Opt-in, and only meaningful alongside SMOKE_NAVIGATOR_LANGUAGES.
+    //     "The view mounted" is enough for a tag with no valid part — the page
+    //     could not have booted unless the sanitizer replaced it. It is not
+    //     enough for a mixed list: with "C,es-AR" a sanitizer that dropped the
+    //     whole list for the fallback boots exactly as happily as one that
+    //     kept "es-AR", and the user silently loses their language. Only
+    //     reading the result back tells those two apart.
+    if (process.env.SMOKE_EXPECT_LANGUAGES !== undefined) {
+      const expected = process.env.SMOKE_EXPECT_LANGUAGES;
+      const actual = (
+        await page.evaluate(() => Array.from(navigator.languages ?? []))
+      ).join(',');
+      if (actual !== expected) {
+        await fail(
+          `navigator.languages is "${actual}", expected "${expected}"`,
+        );
+      }
+      console.log(`✓ locale sanitized to [${actual}]`);
+    }
 
     // 3. The Rust bridge answered. Poll for either outcome so a broken bridge
     //    fails immediately with its reason instead of timing out silently.


### PR DESCRIPTION
# fix(#404): cover every locale tag the sanitizer handles, and what it leaves behind

Closes #404. Follow-up to #370, from @grunch's third finding there.

No app code changes: `lib/`, `web/` and `rust/` are untouched, and the bundle that ships is byte-identical to main's. What changes is what CI checks before letting a change through.

## The gap

The locale guard added in #370 only ever exercised `C`. Playwright's `locale` option normalizes the tag before the page sees it — `en_US` arrives as a valid `en-US`, `""` falls back to the system locale — so two of the three tags named in #227's acceptance criterion were handled by the sanitizer but never reached it in CI. The mixed list (`["C","es-AR"]` → `["es-AR"]`) was tested by nothing at all.

That is a limit of that one Playwright option, not of the browser. `addInitScript` runs inside the page before any of its own scripts, so it can hand the engine a tag Playwright would never deliver.

## What this adds

**`SMOKE_NAVIGATOR_LANGUAGES`** shadows `navigator.language(s)` from an init script. Comma-separated, used verbatim, unset means "do not touch" — so every existing run is unaffected. `!== undefined` rather than a truthiness check, because the empty string is one of the broken tags. `configurable: true` is load-bearing, though not as a false-green guard: the sanitizer bails out when either property is locked down, so a non-configurable shadow makes it skip the very path under test and the positive run *fails*, with the same message a real regression produces. What it prevents is a red matrix that reads as a broken sanitizer when it is really a broken harness. Measured both ways on `C` and `C,es-AR` (review round).

**`SMOKE_EXPECT_LANGUAGES`** asserts what `navigator.languages` reads after the sanitizer ran. This is what makes the mixed list worth running — see below.

**The matrix** in `web-build.yml` runs `C`, `en_US`, `""` and `C,es-AR`, each against the shipped bundle (must pass, with the expected locale) and against the control bundle (must fail with a locale error).

**`selftest.mjs` holds that second check down** (review round). Two cases against the existing `healthy` fixture, which has no sanitizer, so whatever is injected is what `navigator.languages` still reads at the end: `C,es-AR` expecting `es-AR` must fail, `es-AR` expecting `es-AR` must pass. A comparison that never fires and one that always fires each pass one of those and fail the other, so neither case is redundant. The passing one also proves the init script reaches the page at all. `SMOKE_NAVIGATOR_LANGUAGES` is what makes this testable without a bundle — before it, the comparison was a gate nothing in CI held down.

**The control bundle is now built once** in its own step instead of being rebuilt inside the control, since two places would otherwise duplicate the strip and drift. The "did the strip actually happen" check moved with it: if the marker is ever renamed, the cut is a no-op and every control silently compares the bundle against itself.

**The `SMOKE_LOCALE=C` step and its control stay.** It is the one path where the tag reaches the page as the browser's own locale rather than as a shadow this repo installed.

## Two things this turned up

**1. The empty tag crashes with a different message.** Three of the four controls die with `Incorrect locale information provided`; the empty one dies with `First argument to Intl.Locale constructor can't be empty or missing`. Both are the engine refusing a locale before `runApp`, but the control introduced in #370 required the first string exactly — so the empty case would have reported *"the control failed, but not with the locale RangeError"*, a false negative on a control that worked perfectly.

That check is not wrong today: it only ever runs `C`, and for `C` the signature is right. It becomes too narrow the moment this PR starts feeding it the other tags, so widening it belongs here rather than in a follow-up. The accepted signatures are now a job-level `LOCALE_CRASH_SIGNATURE`, kept exact rather than loosened to something like `locale` — a lax pattern is what lets a control celebrate an unrelated crash.

**2. "The view mounted" cannot judge the mixed list.** With `C,es-AR`, a sanitizer that keeps `es-AR` and one that drops the whole list for the fallback both boot perfectly; only the second silently costs the user their language. Without reading the result back, that case tests nothing `C` does not already test.

Hence `SMOKE_EXPECT_LANGUAGES`. Mutation-checked: patching the sanitizer to discard the whole list whenever any tag is invalid leaves `C`, `en_US` and `""` green and fails only the mixed case, with `navigator.languages is "en-US", expected "es-AR"`.

## Verified

Against a release bundle built on this branch (`build-web.sh --release` + `flutter build web --release`, Flutter 3.38.2), running the matrix exactly as the workflow does:

| tag | expected after | with sanitizer | without |
|---|---|---|---|
| `C` | `en-US` | passes | dies with the locale signature |
| `en_US` | `en-US` | passes | dies with the locale signature |
| `""` | `en-US` | passes | dies with the locale signature |
| `C,es-AR` | **`es-AR`** | passes | dies with the locale signature |

Eight for eight. Plus `selftest.mjs` 5/5: the two new cases hold the `SMOKE_EXPECT_LANGUAGES` comparison down from both sides, and each is mutation-checked — `if (false)` fails the mismatch case only, `if (true)` fails the match case only, so neither is redundant and neither passes on a broken check. `pages_bundle_test.dart` also still passes 17/17, but it asserts the sanitizer's position in the bundle and the shape of these workflows; it does not reach the matrix or either new variable.

Verified by hand too, in a real browser window against that same bundle. With `C` forced, the control is a blank page with `RangeError: Incorrect locale information provided` while the shipped bundle loads. With `['C','es-AR']` injected, three bundles side by side: no sanitizer is blank, the shipped one opens in Spanish, and one with the sanitizer mutated to discard the whole list opens in English — no error, no blank page, nothing logged, the user simply loses their language. That middle window is what `SMOKE_EXPECT_LANGUAGES` exists to catch, and what every other assertion here reports as green.

## Cost

Four extra control runs at ~20s each — each waits out `SMOKE_TIMEOUT_MS`, set inline on the control invocation rather than on the step, for a view that will never mount — so roughly 80s added per PR. The positive runs are ~1s each. That is the price of the guard being self-validating; the alternative is a matrix that can go green for the wrong reason.

## For #227

Its acceptance criteria carry no caveat to remove: the *"the CI step only exercises `C`"* note lives in #370's body, which is a record of what was true when it merged and is better left alone. What #227 does have is two criteria this PR satisfies and that are still unticked — the app rendering under `C`, `en_US` and `""`, and a CI case asserting the view mounts under an invalid locale. Ticking those is the honest version of #404's fourth criterion; happy to do it, or leave it to whoever merges.
