### PR TITLE
feat: single-owner registry for per-trade subscriptions

### DIFF
--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -1600,9 +1600,12 @@ pub(crate) async fn subscribe_daemon_messages(
     // outlives this caller's interest. If the owner is still mid-setup, the
     // claim parks until the REQ is live (or takes over if that setup fails),
     // so a bounce always means real coverage. Claiming first means every
-    // early return below must release, and the success path must mark_live.
+    // early return below must release the guard and the success path must
+    // consume it via mark_live; a panic anywhere in between frees the claim
+    // from the guard's Drop instead of wedging the key in Setup.
     let trade_pubkey_hex = trade_pubkey.to_hex();
-    if !crate::nostr::subscriptions::claim(&trade_pubkey_hex, trade_index).await {
+    let Some(setup) = crate::nostr::subscriptions::claim(&trade_pubkey_hex, trade_index).await
+    else {
         crate::api::logging::blog_info(
             "orders",
             format!(
@@ -1611,20 +1614,20 @@ pub(crate) async fn subscribe_daemon_messages(
             ),
         );
         return;
-    }
+    };
 
     let recipient_keys = match crate::api::identity::get_active_trade_keys(trade_index).await {
         Ok(k) => k,
         Err(e) => {
             log::error!("[orders] subscribe_daemon_messages: no trade keys: {e}");
-            crate::nostr::subscriptions::release(&trade_pubkey_hex).await;
+            crate::nostr::subscriptions::release(setup).await;
             return;
         }
     };
 
     let Ok(pool) = crate::api::nostr::get_pool() else {
         log::warn!("[orders] subscribe_daemon_messages: relay pool not initialized");
-        crate::nostr::subscriptions::release(&trade_pubkey_hex).await;
+        crate::nostr::subscriptions::release(setup).await;
         return;
     };
     let client = pool.client();
@@ -1634,7 +1637,7 @@ pub(crate) async fn subscribe_daemon_messages(
             Ok(pk) => pk,
             Err(e) => {
                 log::error!("[orders] subscribe_daemon_messages: invalid mostro pubkey: {e}");
-                crate::nostr::subscriptions::release(&trade_pubkey_hex).await;
+                crate::nostr::subscriptions::release(setup).await;
                 return;
             }
         };
@@ -1668,7 +1671,7 @@ pub(crate) async fn subscribe_daemon_messages(
     let sub_id = crate::nostr::subscriptions::daemon_message_subscription_id(&trade_pubkey_hex);
     if let Err(e) = client.subscribe(filter).with_id(sub_id).await {
         log::warn!("[orders] subscribe_daemon_messages subscribe failed: {e}");
-        crate::nostr::subscriptions::release(&trade_pubkey_hex).await;
+        crate::nostr::subscriptions::release(setup).await;
         return;
     }
 
@@ -1677,7 +1680,7 @@ pub(crate) async fn subscribe_daemon_messages(
     // above was obtained before subscribing, so events arriving before the
     // watcher task spawns below sit buffered in the channel — nothing leaks
     // in the gap.
-    crate::nostr::subscriptions::mark_live(&trade_pubkey_hex).await;
+    crate::nostr::subscriptions::mark_live(setup).await;
 
     crate::api::logging::blog_info(
         "orders",
@@ -5589,10 +5592,12 @@ mod tests {
         let trade_pubkey = keys.public_key();
         let hex = trade_pubkey.to_hex();
 
-        assert!(crate::nostr::subscriptions::claim(&hex, 9).await);
+        let guard = crate::nostr::subscriptions::claim(&hex, 9)
+            .await
+            .expect("first claim owns the key");
         // Live, not Setup: against a mid-setup owner the re-arm below would
         // (correctly) park instead of bouncing, and this test would hang.
-        crate::nostr::subscriptions::mark_live(&hex).await;
+        crate::nostr::subscriptions::mark_live(guard).await;
         pending_requests().lock().unwrap().insert(
             hex.clone(),
             PendingRequest {
@@ -5610,12 +5615,12 @@ mod tests {
             "a bounced re-arm must not purge the live watcher's pending request"
         );
         assert!(
-            !crate::nostr::subscriptions::claim(&hex, 9).await,
+            crate::nostr::subscriptions::claim(&hex, 9).await.is_none(),
             "the original owner must still hold the key after a bounced re-arm"
         );
 
         pending_requests().lock().unwrap().remove(&hex);
-        crate::nostr::subscriptions::release(&hex).await;
+        crate::nostr::subscriptions::teardown(&nostr_sdk::prelude::Client::default(), &hex).await;
     }
 
     /// Nothing ever displays a stranger's finished order — the book filters to

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -1668,9 +1668,15 @@ pub(crate) async fn subscribe_daemon_messages(
         .author(mostro_pubkey)
         .pubkey(trade_pubkey)
         .limit(0);
+    // `subscribe_accepted`, not a bare subscribe: the SDK reports a REQ
+    // that failed on every relay as an `Ok`, and a failed REQ is removed
+    // from the relay's registry, beyond reconnect resubscription's reach.
+    // Marking that Live would promise coverage that never exists — claims
+    // would bounce off it while the caller's request dies at its 10 s
+    // timeout with `NoDaemonResponse`.
     let sub_id = crate::nostr::subscriptions::daemon_message_subscription_id(&trade_pubkey_hex);
-    if let Err(e) = client.subscribe(filter).with_id(sub_id).await {
-        log::warn!("[orders] subscribe_daemon_messages subscribe failed: {e}");
+    if let Err(e) = subscribe_accepted(&client, sub_id, filter).await {
+        log::warn!("[orders] subscribe_daemon_messages: {e}");
         crate::nostr::subscriptions::release(setup).await;
         return;
     }
@@ -3973,26 +3979,20 @@ fn relay_list_subscription_id() -> nostr_sdk::prelude::SubscriptionId {
     nostr_sdk::prelude::SubscriptionId::new("mostro-relay-list")
 }
 
-/// Point the long-lived subscription `id` at `filter`, replacing whatever it
-/// carried before.
-///
-/// nostr-sdk 0.45 refuses a subscribe whose id already exists and keeps the
-/// old filters, so the id is closed first (a no-op when it was never open).
-/// The brief gap between CLOSE and REQ loses nothing: a node switch refetches
-/// the book right after, and the Kind-14 feed has no `since`, so its REQ
-/// replays history.
+/// Subscribe `filter` under `id`, failing when no relay accepted the REQ.
 ///
 /// The SDK reports per-relay failures inside an `Ok` output, which is how a
-/// rejected re-subscribe used to pass for a live one. No relay accepting it is
+/// rejected subscribe used to pass for a live one. Empty success is not a
+/// transient state, either: a REQ that failed on a relay is *removed* from
+/// that relay's subscription registry (nostr-sdk 0.45,
+/// `subscribe_long_lived`), so reconnect resubscription cannot revive it —
+/// the subscription exists nowhere and never will. No relay accepting it is
 /// an error here; a partial failure is logged.
-async fn replace_subscription(
+async fn subscribe_accepted(
     client: &nostr_sdk::prelude::Client,
     id: nostr_sdk::prelude::SubscriptionId,
     filter: nostr_sdk::prelude::Filter,
 ) -> Result<()> {
-    if let Err(e) = client.unsubscribe(&id).await {
-        log::warn!("[orders] closing {id} before re-subscribing failed: {e}");
-    }
     let output = client
         .subscribe(filter)
         .with_id(id.clone())
@@ -4015,6 +4015,25 @@ async fn replace_subscription(
         );
     }
     Ok(())
+}
+
+/// Point the long-lived subscription `id` at `filter`, replacing whatever it
+/// carried before.
+///
+/// nostr-sdk 0.45 refuses a subscribe whose id already exists and keeps the
+/// old filters, so the id is closed first (a no-op when it was never open).
+/// The brief gap between CLOSE and REQ loses nothing: a node switch refetches
+/// the book right after, and the Kind-14 feed has no `since`, so its REQ
+/// replays history.
+async fn replace_subscription(
+    client: &nostr_sdk::prelude::Client,
+    id: nostr_sdk::prelude::SubscriptionId,
+    filter: nostr_sdk::prelude::Filter,
+) -> Result<()> {
+    if let Err(e) = client.unsubscribe(&id).await {
+        log::warn!("[orders] closing {id} before re-subscribing failed: {e}");
+    }
+    subscribe_accepted(client, id, filter).await
 }
 
 /// (Re)subscribe the order-book (Kind 38383) and Mostro-reply (Kind 14)
@@ -5486,6 +5505,43 @@ mod tests {
         assert!(
             result.is_err(),
             "a subscription no relay accepted must not pass for a live one"
+        );
+    }
+
+    /// PR #407 CodeRabbit: the per-trade daemon REQ shares that guard via
+    /// `subscribe_accepted` — no relay accepting it must be an error, so
+    /// `subscribe_daemon_messages` releases its claim instead of marking a
+    /// coverage-less subscription Live (a failed REQ is also removed from
+    /// the relay's registry, beyond reconnect resubscription's reach).
+    #[tokio::test]
+    async fn a_per_trade_subscription_no_relay_accepts_is_an_error() {
+        use nostr_sdk::local_relay::MockRelay;
+        use nostr_sdk::prelude::{Client, Keys};
+
+        let relay = MockRelay::run().await.expect("mock relay");
+        let client = Client::new();
+        client
+            .add_relay(relay.url().await)
+            .await
+            .expect("add relay");
+        // Added but never connected: the only relay rejects the REQ.
+
+        let trade_pubkey = Keys::generate().public_key();
+        let filter = nostr_sdk::prelude::Filter::new()
+            .kind(nostr_sdk::prelude::Kind::PrivateDirectMessage)
+            .author(Keys::generate().public_key())
+            .pubkey(trade_pubkey)
+            .limit(0);
+        let result = subscribe_accepted(
+            &client,
+            crate::nostr::subscriptions::daemon_message_subscription_id(&trade_pubkey.to_hex()),
+            filter,
+        )
+        .await;
+
+        assert!(
+            result.is_err(),
+            "a per-trade REQ no relay accepted must not reach mark_live"
         );
     }
 

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -1595,12 +1595,14 @@ pub(crate) async fn subscribe_daemon_messages(
 ) {
     // ── Synchronous setup: awaited by the caller ──
     // Single-owner claim before anything else (#325): if a watcher already
-    // owns this trade key, this call is a lease refresh — the live
-    // subscription and its pending record stay untouched, and the owner
-    // outlives this caller's interest. Claiming first means every early
-    // return below must release.
+    // owns this trade key with a live REQ, this call is a lease refresh —
+    // the subscription and its pending record stay untouched, and the owner
+    // outlives this caller's interest. If the owner is still mid-setup, the
+    // claim parks until the REQ is live (or takes over if that setup fails),
+    // so a bounce always means real coverage. Claiming first means every
+    // early return below must release, and the success path must mark_live.
     let trade_pubkey_hex = trade_pubkey.to_hex();
-    if !crate::nostr::subscriptions::try_claim(&trade_pubkey_hex).await {
+    if !crate::nostr::subscriptions::claim(&trade_pubkey_hex, trade_index).await {
         crate::api::logging::blog_info(
             "orders",
             format!(
@@ -1669,6 +1671,13 @@ pub(crate) async fn subscribe_daemon_messages(
         crate::nostr::subscriptions::release(&trade_pubkey_hex).await;
         return;
     }
+
+    // The REQ is active: advance the claim to Live so claims parked on this
+    // key stop waiting and bounce against real coverage (#325). The `rx`
+    // above was obtained before subscribing, so events arriving before the
+    // watcher task spawns below sit buffered in the channel — nothing leaks
+    // in the gap.
+    crate::nostr::subscriptions::mark_live(&trade_pubkey_hex).await;
 
     crate::api::logging::blog_info(
         "orders",
@@ -5567,13 +5576,23 @@ mod tests {
     /// returns before the pending record, the live subscription, or even the
     /// relay pool are touched — the restore apply (#218) can call it twice
     /// without stranding the first watcher's waiting caller.
+    ///
+    /// The pending-record assert alone cannot distinguish a bounce from an
+    /// ordinary setup failure (no identity/pool in tests; neither early
+    /// return purges), so the test also asserts ownership was retained: a
+    /// post-call claim must still bounce. Had the call taken the non-bounce
+    /// path, its early return would have released the key and that claim
+    /// would win (review round 1).
     #[tokio::test]
     async fn rearming_a_covered_trade_key_leaves_its_pending_request_alone() {
         let keys = nostr_sdk::prelude::Keys::generate();
         let trade_pubkey = keys.public_key();
         let hex = trade_pubkey.to_hex();
 
-        assert!(crate::nostr::subscriptions::try_claim(&hex).await);
+        assert!(crate::nostr::subscriptions::claim(&hex, 9).await);
+        // Live, not Setup: against a mid-setup owner the re-arm below would
+        // (correctly) park instead of bouncing, and this test would hang.
+        crate::nostr::subscriptions::mark_live(&hex).await;
         pending_requests().lock().unwrap().insert(
             hex.clone(),
             PendingRequest {
@@ -5589,6 +5608,10 @@ mod tests {
         assert!(
             pending_requests().lock().unwrap().contains_key(&hex),
             "a bounced re-arm must not purge the live watcher's pending request"
+        );
+        assert!(
+            !crate::nostr::subscriptions::claim(&hex, 9).await,
+            "the original owner must still hold the key after a bounced re-arm"
         );
 
         pending_requests().lock().unwrap().remove(&hex);

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -14,10 +14,10 @@ use crate::db::Storage;
 use crate::mostro::actions;
 use crate::mostro::pending::{
     classify_take_reply, detach_request_waiter, may_reconcile_stored_id, order_content_key,
-    pending_local_uuid_for, pending_requests, purge_pending_request, remove_pending_request,
-    take_matching_add_invoice, take_matching_dispute, take_matching_request, take_matching_restore,
-    take_matching_take, take_pending_create_by_content_key, DaemonReply, DisputeMatch,
-    PendingRequest, PendingRequestKind, Wake,
+    pending_local_uuid_for, pending_requests, remove_pending_request, take_matching_add_invoice,
+    take_matching_dispute, take_matching_request, take_matching_restore, take_matching_take,
+    take_pending_create_by_content_key, DaemonReply, DisputeMatch, PendingRequest,
+    PendingRequestKind, Wake,
 };
 use crate::mostro::status::{
     add_invoice_sync, cancellation_wipes_history, is_hard_terminal, map_core_status,
@@ -1594,16 +1594,35 @@ pub(crate) async fn subscribe_daemon_messages(
     trade_index: u32,
 ) {
     // ── Synchronous setup: awaited by the caller ──
+    // Single-owner claim before anything else (#325): if a watcher already
+    // owns this trade key, this call is a lease refresh — the live
+    // subscription and its pending record stay untouched, and the owner
+    // outlives this caller's interest. Claiming first means every early
+    // return below must release.
+    let trade_pubkey_hex = trade_pubkey.to_hex();
+    if !crate::nostr::subscriptions::try_claim(&trade_pubkey_hex).await {
+        crate::api::logging::blog_info(
+            "orders",
+            format!(
+                "daemon-message watcher already live for trade={} — re-arm refreshed its lease",
+                &trade_pubkey_hex[..8]
+            ),
+        );
+        return;
+    }
+
     let recipient_keys = match crate::api::identity::get_active_trade_keys(trade_index).await {
         Ok(k) => k,
         Err(e) => {
             log::error!("[orders] subscribe_daemon_messages: no trade keys: {e}");
+            crate::nostr::subscriptions::release(&trade_pubkey_hex).await;
             return;
         }
     };
 
     let Ok(pool) = crate::api::nostr::get_pool() else {
         log::warn!("[orders] subscribe_daemon_messages: relay pool not initialized");
+        crate::nostr::subscriptions::release(&trade_pubkey_hex).await;
         return;
     };
     let client = pool.client();
@@ -1613,6 +1632,7 @@ pub(crate) async fn subscribe_daemon_messages(
             Ok(pk) => pk,
             Err(e) => {
                 log::error!("[orders] subscribe_daemon_messages: invalid mostro pubkey: {e}");
+                crate::nostr::subscriptions::release(&trade_pubkey_hex).await;
                 return;
             }
         };
@@ -1643,10 +1663,10 @@ pub(crate) async fn subscribe_daemon_messages(
         .author(mostro_pubkey)
         .pubkey(trade_pubkey)
         .limit(0);
-    let trade_pubkey_hex = trade_pubkey.to_hex();
-    let sub_id = daemon_message_subscription_id(&trade_pubkey_hex);
-    if let Err(e) = client.subscribe(filter).with_id(sub_id.clone()).await {
+    let sub_id = crate::nostr::subscriptions::daemon_message_subscription_id(&trade_pubkey_hex);
+    if let Err(e) = client.subscribe(filter).with_id(sub_id).await {
         log::warn!("[orders] subscribe_daemon_messages subscribe failed: {e}");
+        crate::nostr::subscriptions::release(&trade_pubkey_hex).await;
         return;
     }
 
@@ -1667,109 +1687,125 @@ pub(crate) async fn subscribe_daemon_messages(
         const IDLE_TIMEOUT_SECS: u64 = 30 * 60;
         let mut last_activity = crate::rt::time::Instant::now();
 
-        loop {
-            let remaining =
-                Duration::from_secs(IDLE_TIMEOUT_SECS).saturating_sub(last_activity.elapsed());
-            if remaining.is_zero() {
-                break;
-            }
+        // Two distinct exits (#325): an idle timeout consults the registry —
+        // a re-arm that bounced off this owner meanwhile refreshes the lease
+        // and the watcher resumes — while Shutdown/closed-channel exits tear
+        // down unconditionally, because `rx` is dead and resuming would spin
+        // on a closed channel.
+        enum Exit {
+            Idle,
+            Shutdown,
+        }
 
-            match timeout(remaining, rx.next()).await {
-                Ok(Some(ClientNotification::Event { event, .. })) => {
-                    if event.kind != nostr_sdk::prelude::Kind::PrivateDirectMessage {
-                        continue;
-                    }
-                    // Disambiguate Mostro replies from NIP-17 peer chat (also
-                    // kind 14): only the node may author a Mostro reply.
-                    if event.pubkey != mostro_pubkey {
-                        continue;
-                    }
-                    let is_for_us = event.tags.iter().any(|t| {
-                        let s = t.as_slice();
-                        s.first().map(|v| v.as_str()) == Some("p")
-                            && s.get(1).map(|v| v.as_str()) == Some(trade_pubkey_hex.as_str())
-                    });
-                    if !is_for_us {
-                        continue;
-                    }
+        'watch: loop {
+            let exit = loop {
+                let remaining =
+                    Duration::from_secs(IDLE_TIMEOUT_SECS).saturating_sub(last_activity.elapsed());
+                if remaining.is_zero() {
+                    break Exit::Idle;
+                }
 
-                    let eid = event.id.to_hex();
-                    if is_duplicate_daemon_message(&eid) {
-                        crate::api::logging::blog_debug(
-                            "daemon-msg",
-                            format!(
-                                "drop ev={} reason=duplicate",
-                                crate::api::logging::short_id(&eid)
-                            ),
-                        );
-                        continue;
-                    }
-                    crate::api::logging::blog_info(
-                        "daemon-msg",
-                        format!(
-                            "Kind 14 received (per-trade) for trade={} from={} event_id={}",
-                            &trade_pubkey_hex[..8],
-                            &event.pubkey.to_hex()[..8],
-                            &eid[..16],
-                        ),
-                    );
-                    match crate::nostr::transport::unwrap_mostro_message(&recipient_keys, &event)
-                        .await
-                    {
-                        Ok(Some(unwrapped)) => {
-                            dispatch_mostro_message(
-                                unwrapped,
-                                &eid,
-                                &trade_pubkey_hex,
-                                trade_index,
-                            )
-                            .await;
-                            last_activity = crate::rt::time::Instant::now();
+                match timeout(remaining, rx.next()).await {
+                    Ok(Some(ClientNotification::Event { event, .. })) => {
+                        if event.kind != nostr_sdk::prelude::Kind::PrivateDirectMessage {
+                            continue;
                         }
-                        Ok(None) => {
-                            // The per-trade filter already narrowed by p-tag, so this
-                            // only fires if a relay delivers a wrap whose outer NIP-44
-                            // layer doesn't decrypt under our key — not actionable, and
-                            // cheap for a hostile relay to spam. Keep it at debug.
+                        // Disambiguate Mostro replies from NIP-17 peer chat (also
+                        // kind 14): only the node may author a Mostro reply.
+                        if event.pubkey != mostro_pubkey {
+                            continue;
+                        }
+                        let is_for_us = event.tags.iter().any(|t| {
+                            let s = t.as_slice();
+                            s.first().map(|v| v.as_str()) == Some("p")
+                                && s.get(1).map(|v| v.as_str()) == Some(trade_pubkey_hex.as_str())
+                        });
+                        if !is_for_us {
+                            continue;
+                        }
+
+                        let eid = event.id.to_hex();
+                        if is_duplicate_daemon_message(&eid) {
                             crate::api::logging::blog_debug(
                                 "daemon-msg",
                                 format!(
-                                    "decrypt returned None for trade={}",
-                                    &trade_pubkey_hex[..8]
+                                    "drop ev={} reason=duplicate",
+                                    crate::api::logging::short_id(&eid)
                                 ),
                             );
+                            continue;
                         }
-                        Err(e) => crate::api::logging::blog_warn(
+                        crate::api::logging::blog_info(
                             "daemon-msg",
-                            format!("decrypt failed for trade={}: {e}", &trade_pubkey_hex[..8]),
-                        ),
+                            format!(
+                                "Kind 14 received (per-trade) for trade={} from={} event_id={}",
+                                &trade_pubkey_hex[..8],
+                                &event.pubkey.to_hex()[..8],
+                                &eid[..16],
+                            ),
+                        );
+                        match crate::nostr::transport::unwrap_mostro_message(
+                            &recipient_keys,
+                            &event,
+                        )
+                        .await
+                        {
+                            Ok(Some(unwrapped)) => {
+                                dispatch_mostro_message(
+                                    unwrapped,
+                                    &eid,
+                                    &trade_pubkey_hex,
+                                    trade_index,
+                                )
+                                .await;
+                                last_activity = crate::rt::time::Instant::now();
+                            }
+                            Ok(None) => {
+                                // The per-trade filter already narrowed by p-tag, so this
+                                // only fires if a relay delivers a wrap whose outer NIP-44
+                                // layer doesn't decrypt under our key — not actionable, and
+                                // cheap for a hostile relay to spam. Keep it at debug.
+                                crate::api::logging::blog_debug(
+                                    "daemon-msg",
+                                    format!(
+                                        "decrypt returned None for trade={}",
+                                        &trade_pubkey_hex[..8]
+                                    ),
+                                );
+                            }
+                            Err(e) => crate::api::logging::blog_warn(
+                                "daemon-msg",
+                                format!("decrypt failed for trade={}: {e}", &trade_pubkey_hex[..8]),
+                            ),
+                        }
+                    }
+                    Ok(Some(ClientNotification::Shutdown)) | Ok(None) => break Exit::Shutdown,
+                    Err(_) => break Exit::Idle,
+                    Ok(Some(_)) => continue,
+                }
+            };
+
+            // Teardown — the unsubscribe + pending purge — is the registry's
+            // job, executed under its lock so no concurrent claim can slot in
+            // between this owner's decision and the destruction (#325).
+            match exit {
+                Exit::Idle => {
+                    if crate::nostr::subscriptions::teardown_or_rearm(
+                        &unsub_client,
+                        &trade_pubkey_hex,
+                    )
+                    .await
+                    {
+                        last_activity = crate::rt::time::Instant::now();
+                        continue 'watch;
                     }
                 }
-                Ok(Some(ClientNotification::Shutdown)) | Ok(None) => break,
-                Err(_) => break, // idle timeout
-                Ok(Some(_)) => continue,
+                Exit::Shutdown => {
+                    crate::nostr::subscriptions::teardown(&unsub_client, &trade_pubkey_hex).await;
+                }
             }
+            break 'watch;
         }
-
-        // Drop the relay-side REQ. Without this the task exits but the
-        // subscription lives on: relays cap concurrent REQs, and once past the
-        // cap they answer CLOSED — which can take the order-book feed down
-        // with it.
-        if let Err(e) = unsub_client.unsubscribe(&sub_id).await {
-            crate::api::logging::blog_warn(
-                "orders",
-                format!(
-                    "daemon-message unsubscribe failed for trade={}: {e}",
-                    &trade_pubkey_hex[..8]
-                ),
-            );
-        }
-
-        // The subscription bounds the pending record's lifetime: once no
-        // reply can be delivered here anymore, a still-unconsumed record
-        // (request timed out and no genuine late reply ever arrived) is dead
-        // state — drop it, whatever attempt it belongs to.
-        purge_pending_request(&trade_pubkey_hex);
     });
 }
 
@@ -3884,21 +3920,6 @@ fn orders_subscription_id() -> nostr_sdk::prelude::SubscriptionId {
     nostr_sdk::prelude::SubscriptionId::new("mostro-orders")
 }
 
-/// Stable id for a trade's daemon-message subscription.
-///
-/// Stable so the task can drop the relay-side REQ when it exits. Keyed by
-/// trade pubkey, so unsubscribing one trade cannot close another's feed.
-///
-/// NIP-01 caps subscription ids at 64 characters and relays enforce it
-/// (`relay.mostro.network` answers CLOSED with "max length 64 chars"); the
-/// full 64-hex pubkey would push the id to 78. The first 32 hex characters
-/// (128 bits) keep it at 46 and rule out any realistic cross-trade collision.
-/// [`subscription_ids_fit_nip01`] pins the bound.
-fn daemon_message_subscription_id(trade_pubkey_hex: &str) -> nostr_sdk::prelude::SubscriptionId {
-    let key = trade_pubkey_hex.get(..32).unwrap_or(trade_pubkey_hex);
-    nostr_sdk::prelude::SubscriptionId::new(format!("mostro-daemon-{key}"))
-}
-
 /// Stable id for a single order's d-tag update subscription.
 fn single_order_subscription_id(order_id: &str) -> nostr_sdk::prelude::SubscriptionId {
     nostr_sdk::prelude::SubscriptionId::new(format!("mostro-order-{order_id}"))
@@ -5323,6 +5344,7 @@ mod tests {
     use crate::api::types::TradeRole;
     use crate::mostro::pending::register_dispute_request;
     use crate::mostro::session::session_manager;
+    use crate::nostr::subscriptions::daemon_message_subscription_id;
 
     /// Unsubscribing is only safe if each id addresses exactly one feed: a
     /// collision would have one trade's exit close another's subscription, or
@@ -5537,6 +5559,40 @@ mod tests {
             daemon_message_subscription_id(&a),
             daemon_message_subscription_id(&b)
         );
+    }
+
+    /// #325 criterion 2 at the real entry point: re-arming a trade key that
+    /// already has a live watcher must be a no-op. The single-owner claim is
+    /// the first thing `subscribe_daemon_messages` does, so the bounce
+    /// returns before the pending record, the live subscription, or even the
+    /// relay pool are touched — the restore apply (#218) can call it twice
+    /// without stranding the first watcher's waiting caller.
+    #[tokio::test]
+    async fn rearming_a_covered_trade_key_leaves_its_pending_request_alone() {
+        let keys = nostr_sdk::prelude::Keys::generate();
+        let trade_pubkey = keys.public_key();
+        let hex = trade_pubkey.to_hex();
+
+        assert!(crate::nostr::subscriptions::try_claim(&hex).await);
+        pending_requests().lock().unwrap().insert(
+            hex.clone(),
+            PendingRequest {
+                request_id: 5,
+                trade_index: 9,
+                kind: PendingRequestKind::Take,
+                tx: None,
+            },
+        );
+
+        subscribe_daemon_messages(trade_pubkey, 9).await;
+
+        assert!(
+            pending_requests().lock().unwrap().contains_key(&hex),
+            "a bounced re-arm must not purge the live watcher's pending request"
+        );
+
+        pending_requests().lock().unwrap().remove(&hex);
+        crate::nostr::subscriptions::release(&hex).await;
     }
 
     /// Nothing ever displays a stranger's finished order — the book filters to

--- a/rust/src/mostro/pending.rs
+++ b/rust/src/mostro/pending.rs
@@ -118,7 +118,7 @@ pub(crate) enum PendingRequestKind {
         /// per outstanding attempt is not worth trading that correctness for.
         ///
         /// The record's own lifetime is not bounded in the common case:
-        /// [`purge_pending_request`] runs only when a per-trade daemon
+        /// [`purge_detached_pending_request`] runs only when a per-trade daemon
         /// subscription exits, and `open_dispute` starts none — a dispute on
         /// a trade loaded from the database after a restart is answered over
         /// the global feed — so the record can live for the whole process.
@@ -276,12 +276,23 @@ pub(crate) fn remove_pending_request(trade_pubkey_hex: &str, request_id: u64) {
     }
 }
 
-/// Drop whatever pending request remains for `trade_pubkey_hex`,
-/// unconditionally. Only for the end of the per-trade subscription's
-/// lifetime, when no reply can be delivered to any attempt on this key.
-pub(crate) fn purge_pending_request(trade_pubkey_hex: &str) {
+/// Drop the pending request remaining for `trade_pubkey_hex` — but only a
+/// *detached* one (`tx: None`: its 10 s timeout ran and no genuine late
+/// reply ever consumed it). Only for the end of the per-trade
+/// subscription's lifetime, when no reply can reach a timed-out attempt on
+/// this key anymore.
+///
+/// A record whose waiter is still attached is not dead state: its caller is
+/// mid-request — it registered the record *before* calling
+/// `subscribe_daemon_messages` (the create/take ordering) and may be parked
+/// on the subscription registry's lock at this very moment, about to
+/// subscribe from scratch. Purging it here would strand that caller with a
+/// `NoDaemonResponse` on a request the daemon accepted (PR #407 round 2).
+pub(crate) fn purge_detached_pending_request(trade_pubkey_hex: &str) {
     if let Ok(mut m) = pending_requests().lock() {
-        m.remove(trade_pubkey_hex);
+        if m.get(trade_pubkey_hex).is_some_and(|p| p.tx.is_none()) {
+            m.remove(trade_pubkey_hex);
+        }
     }
 }
 
@@ -1210,6 +1221,8 @@ mod tests {
             assert_eq!(superseded.len() as u64, total - 2);
         }
 
-        purge_pending_request(key);
+        // Direct cleanup: the surviving record still has its waiter attached,
+        // so the detached-only purge would (correctly) leave it in the map.
+        pending_requests().lock().unwrap().remove(key);
     }
 }

--- a/rust/src/nostr/mod.rs
+++ b/rust/src/nostr/mod.rs
@@ -3,3 +3,4 @@ pub mod transport;
 pub mod order_events;
 pub mod relay_list;
 pub mod relay_pool;
+pub mod subscriptions;

--- a/rust/src/nostr/subscriptions.rs
+++ b/rust/src/nostr/subscriptions.rs
@@ -14,8 +14,18 @@
 //! watchers for already-covered keys, and it must be idempotent. This
 //! registry makes re-arming safe by giving the lifecycle a single owner:
 //!
-//! * **Idempotence by membership**: [`try_claim`] admits exactly one owner
-//!   per trade key. A second claim is a bounce, not a second watcher.
+//! * **Idempotence by membership**: [`claim`] admits exactly one owner per
+//!   trade key. A second claim is a bounce, not a second watcher.
+//! * **A bounce promises coverage that exists.** An entry starts in
+//!   [`State::Setup`] — claimed, but the relay-side REQ not yet active. A
+//!   concurrent claim landing there parks until the owner reaches
+//!   [`State::Live`] (its `client.subscribe` succeeded, [`mark_live`]) or
+//!   releases (setup failed, [`release`]), and only then bounces or takes
+//!   over. Bouncing during setup would return a promise the owner may never
+//!   keep — its setup can still fail, dropping the claim silently — or not
+//!   keep *yet*: the REQ is `limit(0)` live-only, so a reply published
+//!   before it is active is lost. Both end in the exact `NoDaemonResponse`
+//!   this registry exists to prevent.
 //! * **A bounce is a lease refresh, not just a dedupe**: the bouncing caller
 //!   is promised live coverage, so the bounce marks the key re-armed and the
 //!   owner's idle-timeout exit ([`teardown_or_rearm`]) honors the mark by
@@ -38,17 +48,49 @@
 //! Lock discipline: the lock is held across the teardown's `unsubscribe`
 //! await (a short send), which serializes claims of *all* keys for that
 //! moment — fine for a CLOSE message, but do not add long waits under it.
+//! Verified against the locked nostr-sdk 0.45.2 (`Relay::unsubscribe` takes
+//! the in-process subscriptions `RwLock` and queues the CLOSE via
+//! `send_msg(..., None)` — a channel push, never a socket wait); re-verify
+//! that on any nostr-sdk bump before trusting this ordering again.
 
 use std::collections::HashMap;
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 
-/// Trade pubkey hex → re-armed flag. Key present = the watcher owns the
-/// subscription; `true` = a claim bounced since the owner last checked, so
-/// its idle-timeout exit must refresh the lease instead of tearing down.
-static ACTIVE_TRADE_SUBS: OnceLock<tokio::sync::Mutex<HashMap<String, bool>>> = OnceLock::new();
+/// Where a claimed trade key is in its lifecycle.
+enum State {
+    /// Claimed, but the owner's relay-side REQ is not active yet. Concurrent
+    /// claims park on [`Entry::setup_done`] instead of bouncing — see the
+    /// module docs for why bouncing here would promise phantom coverage.
+    Setup,
+    /// REQ active, watcher running. `rearmed` = a claim bounced since the
+    /// owner last checked its idle timeout, so that exit must refresh the
+    /// lease instead of dismantling.
+    Live { rearmed: bool },
+}
 
-fn registry() -> &'static tokio::sync::Mutex<HashMap<String, bool>> {
+struct Entry {
+    state: State,
+    /// The owner's trade index, recorded to make the "same trade pubkey ⇒
+    /// same trade index" assumption checkable: a bounce whose caller brings
+    /// a different index would hand it a watcher decrypting with the wrong
+    /// recipient keys, which today can only mean an identity-derivation bug
+    /// upstream — logged loudly, never expected.
+    trade_index: u32,
+    /// Wakes claims parked on a `Setup` entry once it advances to `Live` or
+    /// is released. Notified only while the registry lock is held.
+    setup_done: Arc<tokio::sync::Notify>,
+}
+
+/// Trade pubkey hex → lifecycle entry. Key present = someone owns (or is
+/// setting up) the subscription for that trade key.
+static ACTIVE_TRADE_SUBS: OnceLock<tokio::sync::Mutex<HashMap<String, Entry>>> = OnceLock::new();
+
+fn registry() -> &'static tokio::sync::Mutex<HashMap<String, Entry>> {
     ACTIVE_TRADE_SUBS.get_or_init(|| tokio::sync::Mutex::new(HashMap::new()))
+}
+
+fn short(key: &str) -> &str {
+    key.get(..8).unwrap_or(key)
 }
 
 /// Stable, deterministic subscription id for a trade key's daemon-message
@@ -69,30 +111,123 @@ pub(crate) fn daemon_message_subscription_id(
 
 /// Claim ownership of `trade_pubkey_hex`'s subscription lifecycle.
 ///
-/// Returns `true` when the caller is now the single owner and must subscribe
-/// and run the watcher. Returns `false` when a watcher already owns the key:
-/// the relay-side subscription stays live, the pending record stays intact,
-/// and the bounce is recorded as a lease refresh so the owner outlives the
-/// caller's interest (see [`teardown_or_rearm`]).
-pub(crate) async fn try_claim(trade_pubkey_hex: &str) -> bool {
+/// Returns `true` when the caller is now the single owner: it must run the
+/// setup and then either [`mark_live`] (subscribe succeeded) or [`release`]
+/// (any earlier exit). Returns `false` when a watcher already owns the key
+/// **and its REQ is live**: the subscription and pending record stay
+/// untouched, and the bounce is recorded as a lease refresh so the owner
+/// outlives the caller's interest (see [`teardown_or_rearm`]).
+///
+/// If the key is claimed but still in setup, this call parks until the owner
+/// reaches `Live` (then bounces) or releases (then takes over and returns
+/// `true`) — a bounce is a promise of coverage, and during setup that
+/// coverage does not exist yet.
+///
+/// Cancellation caveat: if an owner's setup future is dropped between its
+/// claim and its `mark_live`/`release`, the entry leaks in `Setup` and later
+/// claims for that key park indefinitely. No caller does that today — FRB
+/// runs API futures to completion and `subscribe_daemon_messages` is awaited
+/// — but a future cancellable caller would need an RAII guard here.
+pub(crate) async fn claim(trade_pubkey_hex: &str, trade_index: u32) -> bool {
+    loop {
+        let notify = {
+            let mut map = registry().lock().await;
+            match map.get_mut(trade_pubkey_hex) {
+                None => {
+                    map.insert(
+                        trade_pubkey_hex.to_string(),
+                        Entry {
+                            state: State::Setup,
+                            trade_index,
+                            setup_done: Arc::new(tokio::sync::Notify::new()),
+                        },
+                    );
+                    return true;
+                }
+                Some(entry) => match &mut entry.state {
+                    State::Live { rearmed } => {
+                        *rearmed = true;
+                        if entry.trade_index != trade_index {
+                            crate::api::logging::blog_warn(
+                                "orders",
+                                format!(
+                                    "re-arm for trade={} carries index {} but the live watcher \
+                                     decrypts with index {} — identity derivation bug upstream?",
+                                    short(trade_pubkey_hex),
+                                    trade_index,
+                                    entry.trade_index
+                                ),
+                            );
+                        }
+                        return false;
+                    }
+                    State::Setup => entry.setup_done.clone(),
+                },
+            }
+        };
+
+        // Owner mid-setup: park until it reaches Live or releases, then
+        // retry the claim from scratch. `enable` registers interest *before*
+        // the re-check below, closing the race where the owner's
+        // `notify_waiters` (always sent under the registry lock) fires
+        // between our check above and the await: either the transition
+        // happened before the re-check (we see it and retry immediately) or
+        // after (we are already registered and the notify wakes us).
+        let notified = notify.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
+        if parked_on_current_setup(trade_pubkey_hex, &notify).await {
+            notified.await;
+        }
+    }
+}
+
+/// The predicate a parked claim re-checks after registering interest: is
+/// `notify` still the `Setup` gate of the **current** entry for this key?
+///
+/// Checking only "some entry is in Setup" is not enough. Between cloning the
+/// gate and `enable()`, the owner can release — its `notify_waiters` is lost
+/// on us, we were not registered yet — and a third claimant can insert a
+/// fresh `Setup` entry: same state, different `Notify`. Parking on the stale
+/// gate would sleep forever, because nothing ever notifies it again — and a
+/// hung claim is a hung API call, since `subscribe_daemon_messages` is
+/// awaited by its caller. Pointer identity (`Arc::ptr_eq`) pins "same
+/// entry"; ABA is impossible while the caller holds its clone, because the
+/// old allocation cannot be reused. On a mismatch the claim loop retries
+/// from scratch and does the right thing for whatever it finds: free key,
+/// live owner, or the new entry's gate.
+async fn parked_on_current_setup(
+    trade_pubkey_hex: &str,
+    notify: &Arc<tokio::sync::Notify>,
+) -> bool {
+    registry()
+        .lock()
+        .await
+        .get(trade_pubkey_hex)
+        .is_some_and(|e| matches!(e.state, State::Setup) && Arc::ptr_eq(&e.setup_done, notify))
+}
+
+/// The owner's setup succeeded: its `client.subscribe` returned, the REQ is
+/// active. Advance `Setup` → `Live` and wake any parked claims — from this
+/// point a bounce is backed by a real subscription.
+pub(crate) async fn mark_live(trade_pubkey_hex: &str) {
     let mut map = registry().lock().await;
-    match map.get_mut(trade_pubkey_hex) {
-        Some(rearmed) => {
-            *rearmed = true;
-            false
-        }
-        None => {
-            map.insert(trade_pubkey_hex.to_string(), false);
-            true
-        }
+    if let Some(entry) = map.get_mut(trade_pubkey_hex) {
+        entry.state = State::Live { rearmed: false };
+        entry.setup_done.notify_waiters();
     }
 }
 
 /// Release a claim whose watcher never started (setup failed between claim
 /// and subscribe). No teardown: there is no REQ to close, and the pending
 /// record — if any — belongs to its caller's own rollback/timeout paths.
+/// Parked claims are woken and the first to retry becomes the new owner,
+/// re-running setup from scratch.
 pub(crate) async fn release(trade_pubkey_hex: &str) {
-    registry().lock().await.remove(trade_pubkey_hex);
+    let mut map = registry().lock().await;
+    if let Some(entry) = map.remove(trade_pubkey_hex) {
+        entry.setup_done.notify_waiters();
+    }
 }
 
 /// The owner's idle-timeout exit: refresh the lease or dismantle, atomically.
@@ -114,14 +249,18 @@ pub(crate) async fn teardown_or_rearm(
     trade_pubkey_hex: &str,
 ) -> bool {
     let mut map = registry().lock().await;
-    if let Some(rearmed) = map.get_mut(trade_pubkey_hex) {
+    if let Some(Entry {
+        state: State::Live { rearmed },
+        ..
+    }) = map.get_mut(trade_pubkey_hex)
+    {
         if *rearmed {
             *rearmed = false;
             crate::api::logging::blog_info(
                 "orders",
                 format!(
                     "daemon-message watcher lease refreshed for trade={}",
-                    &trade_pubkey_hex[..8.min(trade_pubkey_hex.len())]
+                    short(trade_pubkey_hex)
                 ),
             );
             return true;
@@ -144,7 +283,7 @@ pub(crate) async fn teardown(client: &nostr_sdk::prelude::Client, trade_pubkey_h
 async fn dismantle(
     client: &nostr_sdk::prelude::Client,
     trade_pubkey_hex: &str,
-    map: &mut HashMap<String, bool>,
+    map: &mut HashMap<String, Entry>,
 ) {
     // Drop the relay-side REQ. Without this the task exits but the
     // subscription lives on: relays cap concurrent REQs, and once past the
@@ -158,7 +297,7 @@ async fn dismantle(
             "orders",
             format!(
                 "daemon-message unsubscribe failed for trade={}: {e}",
-                &trade_pubkey_hex[..8.min(trade_pubkey_hex.len())]
+                short(trade_pubkey_hex)
             ),
         );
     }
@@ -169,7 +308,12 @@ async fn dismantle(
     // whatever attempt it belongs to.
     crate::mostro::pending::purge_pending_request(trade_pubkey_hex);
 
-    map.remove(trade_pubkey_hex);
+    // Defensive: a watcher only exists past `mark_live`, so nothing should
+    // be parked here — but if an entry ever were still in Setup, leaving its
+    // waiters asleep would strand them forever.
+    if let Some(entry) = map.remove(trade_pubkey_hex) {
+        entry.setup_done.notify_waiters();
+    }
 }
 
 #[cfg(test)]
@@ -188,8 +332,9 @@ mod tests {
     #[tokio::test]
     async fn second_claim_bounces_off_the_single_owner() {
         let key = "aa".repeat(32);
-        assert!(try_claim(&key).await);
-        assert!(!try_claim(&key).await);
+        assert!(claim(&key, 1).await);
+        mark_live(&key).await;
+        assert!(!claim(&key, 1).await);
         release(&key).await;
     }
 
@@ -203,8 +348,9 @@ mod tests {
         let key = "ab".repeat(32);
         let client = offline_client();
 
-        assert!(try_claim(&key).await);
-        assert!(!try_claim(&key).await); // re-arm bounces, marks the lease
+        assert!(claim(&key, 1).await);
+        mark_live(&key).await;
+        assert!(!claim(&key, 1).await); // re-arm bounces, marks the lease
 
         // Idle timeout fires: the mark wins, the owner keeps running…
         assert!(teardown_or_rearm(&client, &key).await);
@@ -213,7 +359,7 @@ mod tests {
 
         // Fully released: the key is claimable from scratch (what #218
         // needs after an owner genuinely expires between applies).
-        assert!(try_claim(&key).await);
+        assert!(claim(&key, 1).await);
         release(&key).await;
     }
 
@@ -227,7 +373,8 @@ mod tests {
         let key = "ac".repeat(32);
         let client = offline_client();
 
-        assert!(try_claim(&key).await);
+        assert!(claim(&key, 1).await);
+        mark_live(&key).await;
         pending_requests().lock().unwrap().insert(
             key.clone(),
             PendingRequest {
@@ -239,7 +386,7 @@ mod tests {
         );
 
         // Re-arm, then idle timeout: lease refreshed, record intact.
-        assert!(!try_claim(&key).await);
+        assert!(!claim(&key, 1).await);
         assert!(teardown_or_rearm(&client, &key).await);
         assert!(pending_requests().lock().unwrap().contains_key(&key));
 
@@ -256,12 +403,13 @@ mod tests {
         let key = "ad".repeat(32);
         let client = offline_client();
 
-        assert!(try_claim(&key).await);
-        assert!(!try_claim(&key).await); // mark set
+        assert!(claim(&key, 1).await);
+        mark_live(&key).await;
+        assert!(!claim(&key, 1).await); // mark set
         teardown(&client, &key).await;
 
         // Ownership fully released despite the mark.
-        assert!(try_claim(&key).await);
+        assert!(claim(&key, 1).await);
         release(&key).await;
     }
 
@@ -273,16 +421,124 @@ mod tests {
         let key_b = "af".repeat(32);
         let client = offline_client();
 
-        assert!(try_claim(&key_a).await);
-        assert!(try_claim(&key_b).await);
+        assert!(claim(&key_a, 1).await);
+        mark_live(&key_a).await;
+        assert!(claim(&key_b, 2).await);
+        mark_live(&key_b).await;
 
         assert!(!teardown_or_rearm(&client, &key_a).await);
 
         // A is free again; B is still owned.
-        assert!(try_claim(&key_a).await);
-        assert!(!try_claim(&key_b).await);
+        assert!(claim(&key_a, 1).await);
+        assert!(!claim(&key_b, 2).await);
         assert!(teardown_or_rearm(&client, &key_b).await); // consume B's mark
         release(&key_a).await;
         assert!(!teardown_or_rearm(&client, &key_b).await);
+    }
+
+    /// The claim→subscribe window (review round 1): a claim landing while
+    /// the owner is still in Setup must not bounce — it parks until the
+    /// owner reaches Live, so the coverage it is promised exists by the
+    /// time it returns.
+    #[tokio::test]
+    async fn claim_during_setup_parks_until_the_owner_is_live() {
+        let key = "ba".repeat(32);
+
+        assert!(claim(&key, 1).await); // owner: Setup, no mark_live yet
+
+        let contender = {
+            let key = key.clone();
+            tokio::spawn(async move { claim(&key, 1).await })
+        };
+        // Give the contender every chance to (wrongly) bounce early.
+        for _ in 0..20 {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            !contender.is_finished(),
+            "a claim during setup must park, not bounce off a REQ that is not live yet"
+        );
+
+        mark_live(&key).await;
+        assert!(
+            !contender.await.unwrap(),
+            "once the owner is live, the parked claim bounces — coverage now exists"
+        );
+
+        // The parked bounce counted as a re-arm: the lease is marked.
+        let client = offline_client();
+        assert!(teardown_or_rearm(&client, &key).await);
+        assert!(!teardown_or_rearm(&client, &key).await);
+    }
+
+    /// Review round 2: the re-check a parked claim runs after `enable()`
+    /// must pin the *entry*, not just the state. If the owner released (its
+    /// notify lost before we registered) and a third claimant re-claimed the
+    /// key, the key is again in `Setup` but behind a fresh gate — parking on
+    /// the stale one would sleep forever on a `Notify` nobody will fire.
+    #[tokio::test]
+    async fn parked_recheck_rejects_a_replaced_setup_entry() {
+        let key = "bc".repeat(32);
+
+        assert!(claim(&key, 1).await); // E1: Setup
+        let stale = registry()
+            .lock()
+            .await
+            .get(&key)
+            .unwrap()
+            .setup_done
+            .clone();
+        assert!(parked_on_current_setup(&key, &stale).await);
+
+        // Owner's setup fails: entry gone, its notify lost for anyone who
+        // had not registered yet.
+        release(&key).await;
+        assert!(!parked_on_current_setup(&key, &stale).await);
+
+        // A third claimant re-claims: Setup again, but a different entry.
+        assert!(claim(&key, 1).await);
+        assert!(
+            !parked_on_current_setup(&key, &stale).await,
+            "same state, different entry: the stale gate must be rejected so the claim retries"
+        );
+        let current = registry()
+            .lock()
+            .await
+            .get(&key)
+            .unwrap()
+            .setup_done
+            .clone();
+        assert!(parked_on_current_setup(&key, &current).await);
+
+        // Once Live, nobody parks: the claim loop bounces instead.
+        mark_live(&key).await;
+        assert!(!parked_on_current_setup(&key, &current).await);
+        release(&key).await;
+    }
+
+    /// The other half of the window: the owner's setup fails and releases.
+    /// The parked claim must not be dropped with it — it retries, finds the
+    /// key free, and becomes the new owner, so somebody actually subscribes.
+    #[tokio::test]
+    async fn claim_during_setup_takes_over_when_the_owner_releases() {
+        let key = "bb".repeat(32);
+
+        assert!(claim(&key, 1).await); // owner: Setup
+
+        let contender = {
+            let key = key.clone();
+            tokio::spawn(async move { claim(&key, 1).await })
+        };
+        for _ in 0..20 {
+            tokio::task::yield_now().await;
+        }
+        assert!(!contender.is_finished());
+
+        release(&key).await; // owner's setup failed
+        assert!(
+            contender.await.unwrap(),
+            "the parked claim must take over a released key and run setup itself"
+        );
+        release(&key).await;
     }
 }

--- a/rust/src/nostr/subscriptions.rs
+++ b/rust/src/nostr/subscriptions.rs
@@ -3,8 +3,8 @@
 //! Every per-trade watcher (`subscribe_daemon_messages`) owns a relay-side
 //! subscription plus, transitively, the pending-request record for its trade
 //! key: the watcher's exit path unsubscribes the REQ and purges the record
-//! unconditionally (`purge_pending_request` is documented as "only for the
-//! end of the per-trade subscription's lifetime"). Two watchers over the same
+//! (`purge_detached_pending_request` is documented as "only for the end of
+//! the per-trade subscription's lifetime"). Two watchers over the same
 //! trade key therefore cannot coexist — the older one's teardown would kill
 //! the newer one's live subscription and strand its waiting caller with a
 //! `NoDaemonResponse` on a request the daemon actually accepted.
@@ -37,7 +37,19 @@
 //!   concurrent claim either bounces first (and the owner keeps running) or
 //!   waits and finds the key free (and subscribes from scratch). The chat
 //!   guard (`ACTIVE_CHATS`) releases before unsubscribing and leaves exactly
-//!   this window open — do not copy that ordering.
+//!   this window open — do not copy that ordering. The purge half of the
+//!   pair is *detached-only*: a record with a live waiter belongs to a
+//!   caller that registered it before claiming (the create/take ordering)
+//!   and may be the very claim parked on this lock, about to subscribe from
+//!   scratch — purging it would strand that caller with the
+//!   `NoDaemonResponse` this registry exists to prevent.
+//! * **An abandoned setup cannot wedge the key.** [`claim`] hands the owner
+//!   a [`SetupGuard`]; the normal exits ([`mark_live`], [`release`]) consume
+//!   it, and a guard dropped still armed — a panic unwinding the setup (FRB
+//!   catches it and reports the error to Dart), a cancelled future — frees
+//!   the claim from `Drop`. Without that, the entry would leak in `Setup`
+//!   and every later claim for the key — every `take_order`/`create_order`
+//!   on it — would park forever.
 //!
 //! The subscription id is recomputed from the trade pubkey
 //! ([`daemon_message_subscription_id`]), so the registry needs no
@@ -109,26 +121,75 @@ pub(crate) fn daemon_message_subscription_id(
     nostr_sdk::prelude::SubscriptionId::new(format!("mostro-daemon-{key}"))
 }
 
+/// Exclusive ownership of a key's `Setup` phase, returned by [`claim`].
+///
+/// The owner must end its setup by consuming the guard: [`mark_live`] when
+/// `client.subscribe` succeeded, [`release`] on any earlier exit. A guard
+/// dropped still armed — a panic unwinding the setup, a cancelled future —
+/// frees the claim from `Drop` instead, so parked claims take over rather
+/// than hanging forever on a `Setup` entry nobody will ever advance
+/// (PR #407 round 2).
+#[must_use = "dropping the guard releases the claim — consume it via mark_live or release"]
+pub(crate) struct SetupGuard {
+    /// `Some` while armed; [`mark_live`]/[`release`] take it, disarming
+    /// `Drop`.
+    key: Option<String>,
+}
+
+impl Drop for SetupGuard {
+    fn drop(&mut self) {
+        let Some(key) = self.key.take() else { return };
+        // Reached only when the setup was abandoned — the normal exits
+        // disarm the guard first. While the guard was armed nothing else
+        // could remove or replace the entry (claims park on Setup, and
+        // teardown paths only run for watchers, which exist past
+        // `mark_live`), so the entry is still ours. `Drop` is sync and the
+        // registry lock is async: `try_lock` covers the uncontended case,
+        // a contended lock falls back to a spawned release. Claims keep
+        // parking until that release runs — which is exactly the wake they
+        // are waiting for.
+        crate::api::logging::blog_warn(
+            "orders",
+            format!(
+                "subscription setup abandoned for trade={} without mark_live/release — freeing the claim",
+                short(&key)
+            ),
+        );
+        match registry().try_lock() {
+            Ok(mut map) => remove_and_wake(&key, &mut map),
+            Err(_) => {
+                crate::rt::spawn(async move {
+                    remove_and_wake(&key, &mut *registry().lock().await);
+                });
+            }
+        }
+    }
+}
+
+/// Remove `key`'s entry and wake anything parked on it — shared by the two
+/// release paths (explicit [`release`], guard [`Drop`]).
+fn remove_and_wake(key: &str, map: &mut HashMap<String, Entry>) {
+    if let Some(entry) = map.remove(key) {
+        entry.setup_done.notify_waiters();
+    }
+}
+
 /// Claim ownership of `trade_pubkey_hex`'s subscription lifecycle.
 ///
-/// Returns `true` when the caller is now the single owner: it must run the
-/// setup and then either [`mark_live`] (subscribe succeeded) or [`release`]
-/// (any earlier exit). Returns `false` when a watcher already owns the key
-/// **and its REQ is live**: the subscription and pending record stay
-/// untouched, and the bounce is recorded as a lease refresh so the owner
-/// outlives the caller's interest (see [`teardown_or_rearm`]).
+/// Returns `Some(guard)` when the caller is now the single owner: it must
+/// run the setup and then consume the guard via [`mark_live`] (subscribe
+/// succeeded) or [`release`] (any earlier exit); an abandoned guard frees
+/// the claim from its `Drop` (see [`SetupGuard`]). Returns `None` when a
+/// watcher already owns the key **and its REQ is live**: the subscription
+/// and pending record stay untouched, and the bounce is recorded as a lease
+/// refresh so the owner outlives the caller's interest (see
+/// [`teardown_or_rearm`]).
 ///
 /// If the key is claimed but still in setup, this call parks until the owner
 /// reaches `Live` (then bounces) or releases (then takes over and returns
-/// `true`) — a bounce is a promise of coverage, and during setup that
+/// `Some`) — a bounce is a promise of coverage, and during setup that
 /// coverage does not exist yet.
-///
-/// Cancellation caveat: if an owner's setup future is dropped between its
-/// claim and its `mark_live`/`release`, the entry leaks in `Setup` and later
-/// claims for that key park indefinitely. No caller does that today — FRB
-/// runs API futures to completion and `subscribe_daemon_messages` is awaited
-/// — but a future cancellable caller would need an RAII guard here.
-pub(crate) async fn claim(trade_pubkey_hex: &str, trade_index: u32) -> bool {
+pub(crate) async fn claim(trade_pubkey_hex: &str, trade_index: u32) -> Option<SetupGuard> {
     loop {
         let notify = {
             let mut map = registry().lock().await;
@@ -142,7 +203,9 @@ pub(crate) async fn claim(trade_pubkey_hex: &str, trade_index: u32) -> bool {
                             setup_done: Arc::new(tokio::sync::Notify::new()),
                         },
                     );
-                    return true;
+                    return Some(SetupGuard {
+                        key: Some(trade_pubkey_hex.to_string()),
+                    });
                 }
                 Some(entry) => match &mut entry.state {
                     State::Live { rearmed } => {
@@ -159,7 +222,7 @@ pub(crate) async fn claim(trade_pubkey_hex: &str, trade_index: u32) -> bool {
                                 ),
                             );
                         }
-                        return false;
+                        return None;
                     }
                     State::Setup => entry.setup_done.clone(),
                 },
@@ -209,10 +272,12 @@ async fn parked_on_current_setup(
 
 /// The owner's setup succeeded: its `client.subscribe` returned, the REQ is
 /// active. Advance `Setup` → `Live` and wake any parked claims — from this
-/// point a bounce is backed by a real subscription.
-pub(crate) async fn mark_live(trade_pubkey_hex: &str) {
+/// point a bounce is backed by a real subscription. Consumes (disarms) the
+/// guard: from here the entry belongs to the watcher's exit paths.
+pub(crate) async fn mark_live(mut guard: SetupGuard) {
+    let Some(key) = guard.key.take() else { return };
     let mut map = registry().lock().await;
-    if let Some(entry) = map.get_mut(trade_pubkey_hex) {
+    if let Some(entry) = map.get_mut(&key) {
         entry.state = State::Live { rearmed: false };
         entry.setup_done.notify_waiters();
     }
@@ -223,11 +288,9 @@ pub(crate) async fn mark_live(trade_pubkey_hex: &str) {
 /// record — if any — belongs to its caller's own rollback/timeout paths.
 /// Parked claims are woken and the first to retry becomes the new owner,
 /// re-running setup from scratch.
-pub(crate) async fn release(trade_pubkey_hex: &str) {
-    let mut map = registry().lock().await;
-    if let Some(entry) = map.remove(trade_pubkey_hex) {
-        entry.setup_done.notify_waiters();
-    }
+pub(crate) async fn release(mut guard: SetupGuard) {
+    let Some(key) = guard.key.take() else { return };
+    remove_and_wake(&key, &mut *registry().lock().await);
 }
 
 /// The owner's idle-timeout exit: refresh the lease or dismantle, atomically.
@@ -303,17 +366,20 @@ async fn dismantle(
     }
 
     // The subscription bounds the pending record's lifetime: once no reply
-    // can be delivered here anymore, a still-unconsumed record (request timed
-    // out and no genuine late reply ever arrived) is dead state — drop it,
-    // whatever attempt it belongs to.
-    crate::mostro::pending::purge_pending_request(trade_pubkey_hex);
+    // can be delivered here anymore, a still-unconsumed record (request
+    // timed out and no genuine late reply ever arrived) is dead state —
+    // drop it. But only a *detached* record (`tx: None`, its 10 s timeout
+    // ran) is dead: one with a live waiter belongs to a caller that
+    // registered it before calling `subscribe_daemon_messages` (the
+    // create/take ordering) and may be parked on this very lock, about to
+    // subscribe from scratch — purging it would strand that caller with a
+    // `NoDaemonResponse` on a request the daemon accepted.
+    crate::mostro::pending::purge_detached_pending_request(trade_pubkey_hex);
 
     // Defensive: a watcher only exists past `mark_live`, so nothing should
     // be parked here — but if an entry ever were still in Setup, leaving its
     // waiters asleep would strand them forever.
-    if let Some(entry) = map.remove(trade_pubkey_hex) {
-        entry.setup_done.notify_waiters();
-    }
+    remove_and_wake(trade_pubkey_hex, map);
 }
 
 #[cfg(test)]
@@ -332,10 +398,10 @@ mod tests {
     #[tokio::test]
     async fn second_claim_bounces_off_the_single_owner() {
         let key = "aa".repeat(32);
-        assert!(claim(&key, 1).await);
-        mark_live(&key).await;
-        assert!(!claim(&key, 1).await);
-        release(&key).await;
+        let guard = claim(&key, 1).await.expect("first claim owns the key");
+        mark_live(guard).await;
+        assert!(claim(&key, 1).await.is_none());
+        teardown(&offline_client(), &key).await;
     }
 
     /// The bounce is a lease refresh: the owner's next idle-timeout exit
@@ -348,9 +414,9 @@ mod tests {
         let key = "ab".repeat(32);
         let client = offline_client();
 
-        assert!(claim(&key, 1).await);
-        mark_live(&key).await;
-        assert!(!claim(&key, 1).await); // re-arm bounces, marks the lease
+        let guard = claim(&key, 1).await.expect("first claim owns the key");
+        mark_live(guard).await;
+        assert!(claim(&key, 1).await.is_none()); // re-arm bounces, marks the lease
 
         // Idle timeout fires: the mark wins, the owner keeps running…
         assert!(teardown_or_rearm(&client, &key).await);
@@ -359,8 +425,8 @@ mod tests {
 
         // Fully released: the key is claimable from scratch (what #218
         // needs after an owner genuinely expires between applies).
-        assert!(claim(&key, 1).await);
-        release(&key).await;
+        let guard = claim(&key, 1).await.expect("key must be free again");
+        release(guard).await;
     }
 
     /// Criterion 2 (#325): re-arming a key with a live owner must not purge
@@ -373,8 +439,8 @@ mod tests {
         let key = "ac".repeat(32);
         let client = offline_client();
 
-        assert!(claim(&key, 1).await);
-        mark_live(&key).await;
+        let guard = claim(&key, 1).await.expect("first claim owns the key");
+        mark_live(guard).await;
         pending_requests().lock().unwrap().insert(
             key.clone(),
             PendingRequest {
@@ -386,7 +452,7 @@ mod tests {
         );
 
         // Re-arm, then idle timeout: lease refreshed, record intact.
-        assert!(!claim(&key, 1).await);
+        assert!(claim(&key, 1).await.is_none());
         assert!(teardown_or_rearm(&client, &key).await);
         assert!(pending_requests().lock().unwrap().contains_key(&key));
 
@@ -403,14 +469,14 @@ mod tests {
         let key = "ad".repeat(32);
         let client = offline_client();
 
-        assert!(claim(&key, 1).await);
-        mark_live(&key).await;
-        assert!(!claim(&key, 1).await); // mark set
+        let guard = claim(&key, 1).await.expect("first claim owns the key");
+        mark_live(guard).await;
+        assert!(claim(&key, 1).await.is_none()); // mark set
         teardown(&client, &key).await;
 
         // Ownership fully released despite the mark.
-        assert!(claim(&key, 1).await);
-        release(&key).await;
+        let guard = claim(&key, 1).await.expect("key must be free again");
+        release(guard).await;
     }
 
     /// Criterion 3 (#325): teardown is targeted — dismantling one trade's
@@ -421,18 +487,18 @@ mod tests {
         let key_b = "af".repeat(32);
         let client = offline_client();
 
-        assert!(claim(&key_a, 1).await);
-        mark_live(&key_a).await;
-        assert!(claim(&key_b, 2).await);
-        mark_live(&key_b).await;
+        let guard_a = claim(&key_a, 1).await.expect("A claims");
+        mark_live(guard_a).await;
+        let guard_b = claim(&key_b, 2).await.expect("B claims");
+        mark_live(guard_b).await;
 
         assert!(!teardown_or_rearm(&client, &key_a).await);
 
         // A is free again; B is still owned.
-        assert!(claim(&key_a, 1).await);
-        assert!(!claim(&key_b, 2).await);
+        let guard_a = claim(&key_a, 1).await.expect("A must be free again");
+        assert!(claim(&key_b, 2).await.is_none());
         assert!(teardown_or_rearm(&client, &key_b).await); // consume B's mark
-        release(&key_a).await;
+        release(guard_a).await;
         assert!(!teardown_or_rearm(&client, &key_b).await);
     }
 
@@ -444,7 +510,7 @@ mod tests {
     async fn claim_during_setup_parks_until_the_owner_is_live() {
         let key = "ba".repeat(32);
 
-        assert!(claim(&key, 1).await); // owner: Setup, no mark_live yet
+        let guard = claim(&key, 1).await.expect("owner claims"); // Setup, no mark_live yet
 
         let contender = {
             let key = key.clone();
@@ -459,9 +525,9 @@ mod tests {
             "a claim during setup must park, not bounce off a REQ that is not live yet"
         );
 
-        mark_live(&key).await;
+        mark_live(guard).await;
         assert!(
-            !contender.await.unwrap(),
+            contender.await.unwrap().is_none(),
             "once the owner is live, the parked claim bounces — coverage now exists"
         );
 
@@ -480,7 +546,7 @@ mod tests {
     async fn parked_recheck_rejects_a_replaced_setup_entry() {
         let key = "bc".repeat(32);
 
-        assert!(claim(&key, 1).await); // E1: Setup
+        let guard1 = claim(&key, 1).await.expect("E1 claims"); // E1: Setup
         let stale = registry()
             .lock()
             .await
@@ -492,11 +558,11 @@ mod tests {
 
         // Owner's setup fails: entry gone, its notify lost for anyone who
         // had not registered yet.
-        release(&key).await;
+        release(guard1).await;
         assert!(!parked_on_current_setup(&key, &stale).await);
 
         // A third claimant re-claims: Setup again, but a different entry.
-        assert!(claim(&key, 1).await);
+        let guard2 = claim(&key, 1).await.expect("key is free again");
         assert!(
             !parked_on_current_setup(&key, &stale).await,
             "same state, different entry: the stale gate must be rejected so the claim retries"
@@ -511,9 +577,9 @@ mod tests {
         assert!(parked_on_current_setup(&key, &current).await);
 
         // Once Live, nobody parks: the claim loop bounces instead.
-        mark_live(&key).await;
+        mark_live(guard2).await;
         assert!(!parked_on_current_setup(&key, &current).await);
-        release(&key).await;
+        teardown(&offline_client(), &key).await;
     }
 
     /// The other half of the window: the owner's setup fails and releases.
@@ -523,7 +589,7 @@ mod tests {
     async fn claim_during_setup_takes_over_when_the_owner_releases() {
         let key = "bb".repeat(32);
 
-        assert!(claim(&key, 1).await); // owner: Setup
+        let guard = claim(&key, 1).await.expect("owner claims"); // owner: Setup
 
         let contender = {
             let key = key.clone();
@@ -534,11 +600,94 @@ mod tests {
         }
         assert!(!contender.is_finished());
 
-        release(&key).await; // owner's setup failed
-        assert!(
-            contender.await.unwrap(),
-            "the parked claim must take over a released key and run setup itself"
+        release(guard).await; // owner's setup failed
+        let takeover = contender
+            .await
+            .unwrap()
+            .expect("the parked claim must take over a released key and run setup itself");
+        release(takeover).await;
+    }
+
+    /// Review round 2 (blocking): the teardown's purge must spare a pending
+    /// record whose waiter is still attached. Its caller registered the
+    /// record *before* calling `subscribe_daemon_messages` (the create/take
+    /// ordering) and may be parked on the registry lock while this very
+    /// dismantle runs — purging its record would strand it with a
+    /// `NoDaemonResponse` on a request the daemon accepted.
+    #[tokio::test]
+    async fn dismantle_spares_a_pending_record_with_a_live_waiter() {
+        use crate::mostro::pending::{pending_requests, PendingRequest, PendingRequestKind};
+
+        let key = "ag".repeat(32);
+        let client = offline_client();
+
+        let guard = claim(&key, 1).await.expect("first claim owns the key");
+        mark_live(guard).await;
+        let (tx, _rx) = tokio::sync::oneshot::channel();
+        pending_requests().lock().unwrap().insert(
+            key.clone(),
+            PendingRequest {
+                request_id: 9,
+                trade_index: 1,
+                kind: PendingRequestKind::Take,
+                tx: Some(tx),
+            },
         );
-        release(&key).await;
+
+        // Idle timeout, no re-arm: ownership released, REQ closed…
+        assert!(!teardown_or_rearm(&client, &key).await);
+        // …but the record with a live waiter survives for its caller.
+        assert!(pending_requests().lock().unwrap().contains_key(&key));
+
+        // Once the 10 s timeout detaches the waiter, the record is dead
+        // state again and the next teardown drops it.
+        pending_requests().lock().unwrap().get_mut(&key).unwrap().tx = None;
+        let guard = claim(&key, 1).await.expect("key was released");
+        mark_live(guard).await;
+        assert!(!teardown_or_rearm(&client, &key).await);
+        assert!(!pending_requests().lock().unwrap().contains_key(&key));
+    }
+
+    /// Review round 2: a guard dropped without `mark_live`/`release` — a
+    /// panic unwinding the setup, a cancelled future — must free the key.
+    /// Leaking the `Setup` entry would park every later claim (and thus
+    /// every take/create on the key) forever, with no log and no recovery
+    /// short of a restart.
+    #[tokio::test]
+    async fn dropped_setup_guard_frees_the_key() {
+        let key = "ah".repeat(32);
+
+        let guard = claim(&key, 1).await.expect("first claim owns the key");
+        drop(guard); // abandoned setup
+
+        let guard = claim(&key, 1)
+            .await
+            .expect("an abandoned setup must leave the key claimable");
+        release(guard).await;
+    }
+
+    /// The parked contender is who the guard exists for: when the owner's
+    /// setup is abandoned, the contender must take over, not hang.
+    #[tokio::test]
+    async fn parked_claim_takes_over_when_the_owners_guard_drops() {
+        let key = "ai".repeat(32);
+
+        let guard = claim(&key, 1).await.expect("owner claims"); // Setup
+
+        let contender = {
+            let key = key.clone();
+            tokio::spawn(async move { claim(&key, 1).await })
+        };
+        for _ in 0..20 {
+            tokio::task::yield_now().await;
+        }
+        assert!(!contender.is_finished());
+
+        drop(guard); // owner's setup abandoned mid-flight
+        let takeover = contender
+            .await
+            .unwrap()
+            .expect("the parked claim must take over after the guard's Drop released the key");
+        release(takeover).await;
     }
 }

--- a/rust/src/nostr/subscriptions.rs
+++ b/rust/src/nostr/subscriptions.rs
@@ -1,0 +1,288 @@
+//! Single-owner registry for per-trade daemon-message subscriptions (#325).
+//!
+//! Every per-trade watcher (`subscribe_daemon_messages`) owns a relay-side
+//! subscription plus, transitively, the pending-request record for its trade
+//! key: the watcher's exit path unsubscribes the REQ and purges the record
+//! unconditionally (`purge_pending_request` is documented as "only for the
+//! end of the per-trade subscription's lifetime"). Two watchers over the same
+//! trade key therefore cannot coexist — the older one's teardown would kill
+//! the newer one's live subscription and strand its waiting caller with a
+//! `NoDaemonResponse` on a request the daemon actually accepted.
+//!
+//! Today every caller derives a fresh trade key first, so duplicates cannot
+//! happen; the restore apply (#218) breaks that invariant by re-arming
+//! watchers for already-covered keys, and it must be idempotent. This
+//! registry makes re-arming safe by giving the lifecycle a single owner:
+//!
+//! * **Idempotence by membership**: [`try_claim`] admits exactly one owner
+//!   per trade key. A second claim is a bounce, not a second watcher.
+//! * **A bounce is a lease refresh, not just a dedupe**: the bouncing caller
+//!   is promised live coverage, so the bounce marks the key re-armed and the
+//!   owner's idle-timeout exit ([`teardown_or_rearm`]) honors the mark by
+//!   resetting its timer instead of dismantling. Without this, a re-arm
+//!   landing at minute 29 of the owner's 30-minute idle window would be
+//!   "covered" for seconds only.
+//! * **Teardown is atomic with respect to claims**: the destructive pair
+//!   (unsubscribe + purge) runs while holding the registry lock, so a
+//!   concurrent claim either bounces first (and the owner keeps running) or
+//!   waits and finds the key free (and subscribes from scratch). The chat
+//!   guard (`ACTIVE_CHATS`) releases before unsubscribing and leaves exactly
+//!   this window open — do not copy that ordering.
+//!
+//! The subscription id is recomputed from the trade pubkey
+//! ([`daemon_message_subscription_id`]), so the registry needs no
+//! pubkey → id map. Teardown is targeted by construction: it only ever
+//! closes the one per-trade id, never the order-book or global DM
+//! subscriptions.
+//!
+//! Lock discipline: the lock is held across the teardown's `unsubscribe`
+//! await (a short send), which serializes claims of *all* keys for that
+//! moment — fine for a CLOSE message, but do not add long waits under it.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+/// Trade pubkey hex → re-armed flag. Key present = the watcher owns the
+/// subscription; `true` = a claim bounced since the owner last checked, so
+/// its idle-timeout exit must refresh the lease instead of tearing down.
+static ACTIVE_TRADE_SUBS: OnceLock<tokio::sync::Mutex<HashMap<String, bool>>> = OnceLock::new();
+
+fn registry() -> &'static tokio::sync::Mutex<HashMap<String, bool>> {
+    ACTIVE_TRADE_SUBS.get_or_init(|| tokio::sync::Mutex::new(HashMap::new()))
+}
+
+/// Stable, deterministic subscription id for a trade key's daemon-message
+/// subscription — recomputable from the pubkey, so ownership needs no id map,
+/// and keyed per trade so closing one trade's REQ cannot touch another's.
+///
+/// NIP-01 caps subscription ids at 64 characters and relays enforce it
+/// (`relay.mostro.network` answers CLOSED with "max length 64 chars"); the
+/// full 64-hex pubkey would push the id to 78. The first 32 hex characters
+/// (128 bits) keep it at 46 and rule out any realistic cross-trade collision.
+/// `subscription_ids_fit_nip01` (in `api::orders` tests) pins the bound.
+pub(crate) fn daemon_message_subscription_id(
+    trade_pubkey_hex: &str,
+) -> nostr_sdk::prelude::SubscriptionId {
+    let key = trade_pubkey_hex.get(..32).unwrap_or(trade_pubkey_hex);
+    nostr_sdk::prelude::SubscriptionId::new(format!("mostro-daemon-{key}"))
+}
+
+/// Claim ownership of `trade_pubkey_hex`'s subscription lifecycle.
+///
+/// Returns `true` when the caller is now the single owner and must subscribe
+/// and run the watcher. Returns `false` when a watcher already owns the key:
+/// the relay-side subscription stays live, the pending record stays intact,
+/// and the bounce is recorded as a lease refresh so the owner outlives the
+/// caller's interest (see [`teardown_or_rearm`]).
+pub(crate) async fn try_claim(trade_pubkey_hex: &str) -> bool {
+    let mut map = registry().lock().await;
+    match map.get_mut(trade_pubkey_hex) {
+        Some(rearmed) => {
+            *rearmed = true;
+            false
+        }
+        None => {
+            map.insert(trade_pubkey_hex.to_string(), false);
+            true
+        }
+    }
+}
+
+/// Release a claim whose watcher never started (setup failed between claim
+/// and subscribe). No teardown: there is no REQ to close, and the pending
+/// record — if any — belongs to its caller's own rollback/timeout paths.
+pub(crate) async fn release(trade_pubkey_hex: &str) {
+    registry().lock().await.remove(trade_pubkey_hex);
+}
+
+/// The owner's idle-timeout exit: refresh the lease or dismantle, atomically.
+///
+/// Under the registry lock, either a claim bounced since the last check —
+/// clear the mark and return `true`, the watcher resets its idle timer and
+/// keeps running — or nobody re-armed and the destructive pair runs while
+/// the lock is still held: unsubscribe the relay-side REQ, purge the pending
+/// record, release ownership, return `false`. Holding the lock across the
+/// pair is what makes a concurrent claim safe: it either lands before (the
+/// owner continues) or after (the key is free, it subscribes from scratch) —
+/// never in between, where it would trust a subscription about to die.
+///
+/// Only for the **idle-timeout** exit. Shutdown/channel-closed exits must use
+/// [`teardown`]: their notifications receiver is dead, so honoring a re-arm
+/// would spin on a closed channel.
+pub(crate) async fn teardown_or_rearm(
+    client: &nostr_sdk::prelude::Client,
+    trade_pubkey_hex: &str,
+) -> bool {
+    let mut map = registry().lock().await;
+    if let Some(rearmed) = map.get_mut(trade_pubkey_hex) {
+        if *rearmed {
+            *rearmed = false;
+            crate::api::logging::blog_info(
+                "orders",
+                format!(
+                    "daemon-message watcher lease refreshed for trade={}",
+                    &trade_pubkey_hex[..8.min(trade_pubkey_hex.len())]
+                ),
+            );
+            return true;
+        }
+    }
+    dismantle(client, trade_pubkey_hex, &mut map).await;
+    false
+}
+
+/// Unconditional teardown for Shutdown/channel-closed exits: the pool is
+/// going away, every subscription dies with it, and a pending re-arm mark
+/// cannot be honored (the watcher's receiver is dead). Coverage after a
+/// reconnect is the re-arm paths' job (#218/#291), not this registry's.
+pub(crate) async fn teardown(client: &nostr_sdk::prelude::Client, trade_pubkey_hex: &str) {
+    let mut map = registry().lock().await;
+    dismantle(client, trade_pubkey_hex, &mut map).await;
+}
+
+/// The destructive pair plus release, under the caller-held registry lock.
+async fn dismantle(
+    client: &nostr_sdk::prelude::Client,
+    trade_pubkey_hex: &str,
+    map: &mut HashMap<String, bool>,
+) {
+    // Drop the relay-side REQ. Without this the task exits but the
+    // subscription lives on: relays cap concurrent REQs, and once past the
+    // cap they answer CLOSED — which can take the order-book feed down
+    // with it.
+    if let Err(e) = client
+        .unsubscribe(&daemon_message_subscription_id(trade_pubkey_hex))
+        .await
+    {
+        crate::api::logging::blog_warn(
+            "orders",
+            format!(
+                "daemon-message unsubscribe failed for trade={}: {e}",
+                &trade_pubkey_hex[..8.min(trade_pubkey_hex.len())]
+            ),
+        );
+    }
+
+    // The subscription bounds the pending record's lifetime: once no reply
+    // can be delivered here anymore, a still-unconsumed record (request timed
+    // out and no genuine late reply ever arrived) is dead state — drop it,
+    // whatever attempt it belongs to.
+    crate::mostro::pending::purge_pending_request(trade_pubkey_hex);
+
+    map.remove(trade_pubkey_hex);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn offline_client() -> nostr_sdk::prelude::Client {
+        // No relays: unsubscribe is a no-op send, so teardown paths run
+        // without network.
+        nostr_sdk::prelude::Client::default()
+    }
+
+    /// Criterion 1 (#325): subscribing twice for the same trade key must
+    /// yield one owner — the second claim bounces instead of spawning a
+    /// second watcher whose exit path would destroy the first one's state.
+    #[tokio::test]
+    async fn second_claim_bounces_off_the_single_owner() {
+        let key = "aa".repeat(32);
+        assert!(try_claim(&key).await);
+        assert!(!try_claim(&key).await);
+        release(&key).await;
+    }
+
+    /// The bounce is a lease refresh: the owner's next idle-timeout exit
+    /// keeps the watcher alive instead of dismantling, so a re-arm landing
+    /// at minute 29 of the idle window still gets durable coverage
+    /// (criterion 4 — one live subscription per recovered key AFTER the
+    /// apply, not for the seconds until the old timer fires).
+    #[tokio::test]
+    async fn a_bounce_refreshes_the_owners_lease() {
+        let key = "ab".repeat(32);
+        let client = offline_client();
+
+        assert!(try_claim(&key).await);
+        assert!(!try_claim(&key).await); // re-arm bounces, marks the lease
+
+        // Idle timeout fires: the mark wins, the owner keeps running…
+        assert!(teardown_or_rearm(&client, &key).await);
+        // …and the mark is consumed: the next idle timeout dismantles.
+        assert!(!teardown_or_rearm(&client, &key).await);
+
+        // Fully released: the key is claimable from scratch (what #218
+        // needs after an owner genuinely expires between applies).
+        assert!(try_claim(&key).await);
+        release(&key).await;
+    }
+
+    /// Criterion 2 (#325): re-arming a key with a live owner must not purge
+    /// its pending request — the purge belongs exclusively to the final
+    /// teardown, after any lease refresh has been honored.
+    #[tokio::test]
+    async fn pending_record_survives_a_lease_refresh_and_dies_with_teardown() {
+        use crate::mostro::pending::{pending_requests, PendingRequest, PendingRequestKind};
+
+        let key = "ac".repeat(32);
+        let client = offline_client();
+
+        assert!(try_claim(&key).await);
+        pending_requests().lock().unwrap().insert(
+            key.clone(),
+            PendingRequest {
+                request_id: 7,
+                trade_index: 1,
+                kind: PendingRequestKind::Take,
+                tx: None,
+            },
+        );
+
+        // Re-arm, then idle timeout: lease refreshed, record intact.
+        assert!(!try_claim(&key).await);
+        assert!(teardown_or_rearm(&client, &key).await);
+        assert!(pending_requests().lock().unwrap().contains_key(&key));
+
+        // No re-arm this time: teardown purges the record with the REQ.
+        assert!(!teardown_or_rearm(&client, &key).await);
+        assert!(!pending_requests().lock().unwrap().contains_key(&key));
+    }
+
+    /// Shutdown tears down even with a re-arm mark pending: the pool is
+    /// going away and the watcher's receiver is dead, so the mark cannot be
+    /// honored — coverage after reconnect belongs to the re-arm paths.
+    #[tokio::test]
+    async fn shutdown_teardown_ignores_a_pending_rearm() {
+        let key = "ad".repeat(32);
+        let client = offline_client();
+
+        assert!(try_claim(&key).await);
+        assert!(!try_claim(&key).await); // mark set
+        teardown(&client, &key).await;
+
+        // Ownership fully released despite the mark.
+        assert!(try_claim(&key).await);
+        release(&key).await;
+    }
+
+    /// Criterion 3 (#325): teardown is targeted — dismantling one trade's
+    /// subscription releases only that key and leaves other owners intact.
+    #[tokio::test]
+    async fn teardown_of_one_key_leaves_other_owners_intact() {
+        let key_a = "ae".repeat(32);
+        let key_b = "af".repeat(32);
+        let client = offline_client();
+
+        assert!(try_claim(&key_a).await);
+        assert!(try_claim(&key_b).await);
+
+        assert!(!teardown_or_rearm(&client, &key_a).await);
+
+        // A is free again; B is still owned.
+        assert!(try_claim(&key_a).await);
+        assert!(!try_claim(&key_b).await);
+        assert!(teardown_or_rearm(&client, &key_b).await); // consume B's mark
+        release(&key_a).await;
+        assert!(!teardown_or_rearm(&client, &key_b).await);
+    }
+}

--- a/rust/src/nostr/subscriptions.rs
+++ b/rust/src/nostr/subscriptions.rs
@@ -275,8 +275,12 @@ async fn parked_on_current_setup(
 /// point a bounce is backed by a real subscription. Consumes (disarms) the
 /// guard: from here the entry belongs to the watcher's exit paths.
 pub(crate) async fn mark_live(mut guard: SetupGuard) {
-    let Some(key) = guard.key.take() else { return };
+    // Lock first, disarm after: cancellation at this await must leave the
+    // guard armed, so its `Drop` still frees the `Setup` entry instead of
+    // leaking it (its own `try_lock` fails against whoever holds this lock
+    // and falls back to the spawned release).
     let mut map = registry().lock().await;
+    let Some(key) = guard.key.take() else { return };
     if let Some(entry) = map.get_mut(&key) {
         entry.state = State::Live { rearmed: false };
         entry.setup_done.notify_waiters();
@@ -289,8 +293,10 @@ pub(crate) async fn mark_live(mut guard: SetupGuard) {
 /// Parked claims are woken and the first to retry becomes the new owner,
 /// re-running setup from scratch.
 pub(crate) async fn release(mut guard: SetupGuard) {
+    // Same ordering as `mark_live`: disarm only once the lock is held.
+    let mut map = registry().lock().await;
     let Some(key) = guard.key.take() else { return };
-    remove_and_wake(&key, &mut *registry().lock().await);
+    remove_and_wake(&key, &mut map);
 }
 
 /// The owner's idle-timeout exit: refresh the lease or dismantle, atomically.
@@ -689,5 +695,49 @@ mod tests {
             .unwrap()
             .expect("the parked claim must take over after the guard's Drop released the key");
         release(takeover).await;
+    }
+
+    /// PR #407 CodeRabbit: `mark_live`/`release` must not disarm the guard
+    /// before they hold the registry lock. Cancelled at that await with the
+    /// key already taken, the guard would drop disarmed and the `Setup`
+    /// entry would leak — every later claim parking forever. Cancel each
+    /// one exactly there (the test holds the lock, so both must be parked
+    /// on it) and assert the guard's `Drop` still frees the key.
+    #[tokio::test]
+    async fn cancelled_mark_live_and_release_still_free_the_key() {
+        use crate::rt::time::{timeout, Duration};
+
+        for consume_via_release in [false, true] {
+            let key = if consume_via_release { "ak" } else { "aj" }.repeat(32);
+            let guard = claim(&key, 1).await.expect("first claim owns the key");
+
+            // Park the consuming call on the registry lock…
+            let held = registry().lock().await;
+            let task = tokio::spawn(async move {
+                if consume_via_release {
+                    release(guard).await;
+                } else {
+                    mark_live(guard).await;
+                }
+            });
+            for _ in 0..20 {
+                tokio::task::yield_now().await;
+            }
+            assert!(!task.is_finished(), "must be parked on the held lock");
+
+            // …and cancel it right there. `task.await` returns only after
+            // the future — and with it the still-armed guard — is dropped;
+            // the guard's `Drop` finds this lock held and spawns its
+            // release, which runs once the test lets go.
+            task.abort();
+            let _ = task.await;
+            drop(held);
+
+            let guard = timeout(Duration::from_secs(5), claim(&key, 1))
+                .await
+                .expect("a cancelled consume must leave the key claimable, not park forever")
+                .expect("the freed key is claimed fresh");
+            release(guard).await;
+        }
     }
 }

--- a/specs/004-mostro-p2p-client/contracts/orders.md
+++ b/specs/004-mostro-p2p-client/contracts/orders.md
@@ -364,9 +364,12 @@ enforced by a registry in `nostr/subscriptions.rs`:
   covered key (the restore apply #218, the resume paths #291/#308) is
   idempotent.
 - **A bounce is never backed by setup alone.** A claim advances
-  `Setup → Live` only once `client.subscribe` succeeded; a claim landing
-  mid-setup parks until the owner is Live (then bounces, against a real
-  REQ) or until that setup fails and releases (then takes over and
+  `Setup → Live` only once at least one relay accepted the REQ — the SDK
+  reports a subscribe every relay rejected as an `Ok`, and a rejected REQ
+  is dropped from the relay's registry, beyond reconnect resubscription's
+  reach, so it counts as a failed setup and releases the claim. A claim
+  landing mid-setup parks until the owner is Live (then bounces, against
+  a real REQ) or until that setup fails and releases (then takes over and
   subscribes itself). A bounce is therefore always a promise of coverage
   that exists.
 - **A bounce is a lease refresh**: it re-arms the owner's 30-minute idle

--- a/specs/004-mostro-p2p-client/contracts/orders.md
+++ b/specs/004-mostro-p2p-client/contracts/orders.md
@@ -376,9 +376,17 @@ enforced by a registry in `nostr/subscriptions.rs`:
   registry under its lock: re-armed → reset the timer and keep running;
   otherwise unsubscribe that one trade's REQ and purge its pending record
   while still holding the lock, so no concurrent claim can land between
-  the decision and the destruction. Shutdown/closed-channel exits tear
+  the decision and the destruction. The purge spares a record whose
+  waiter is still attached: its caller registered it before claiming
+  (the create/take ordering) and may be parked on the registry, about to
+  subscribe from scratch — only a detached record (its 10 s timeout ran)
+  is dead state. Shutdown/closed-channel exits tear
   down unconditionally — their receiver is dead — and post-reconnect
   coverage belongs to the re-arm paths, not to the registry.
+- **An abandoned setup cannot wedge a key.** The claim is an RAII guard:
+  a setup that ends in neither mark-live nor release (a panic unwinding
+  it, a cancelled future) frees the claim on drop, so parked claims take
+  over instead of hanging every later take/create on that key.
 
 ### Inbound Kind 14 actions consumed by `dispatch_mostro_message`
 

--- a/specs/004-mostro-p2p-client/contracts/orders.md
+++ b/specs/004-mostro-p2p-client/contracts/orders.md
@@ -353,6 +353,33 @@ Coverage invariants:
   the filter. Only the ephemeral per-trade subscription carries a cutoff
   (`limit(0)`, live-only).
 
+### Per-trade watcher lifecycle (single owner, #325)
+
+The 30-minute per-trade receiver has, per trade key, exactly one owner,
+enforced by a registry in `nostr/subscriptions.rs`:
+
+- **One owner per trade key.** `subscribe_daemon_messages` claims the key
+  before any setup; a claim finding a live owner bounces — the relay-side
+  REQ and the pending-request record stay untouched — so re-arming a
+  covered key (the restore apply #218, the resume paths #291/#308) is
+  idempotent.
+- **A bounce is never backed by setup alone.** A claim advances
+  `Setup → Live` only once `client.subscribe` succeeded; a claim landing
+  mid-setup parks until the owner is Live (then bounces, against a real
+  REQ) or until that setup fails and releases (then takes over and
+  subscribes itself). A bounce is therefore always a promise of coverage
+  that exists.
+- **A bounce is a lease refresh**: it re-arms the owner's 30-minute idle
+  window, so the promised coverage lasts a full window from the bounce,
+  not whatever remained of the old one.
+- **Teardown is targeted and atomic.** The idle-timeout exit consults the
+  registry under its lock: re-armed → reset the timer and keep running;
+  otherwise unsubscribe that one trade's REQ and purge its pending record
+  while still holding the lock, so no concurrent claim can land between
+  the decision and the destruction. Shutdown/closed-channel exits tear
+  down unconditionally — their receiver is dead — and post-reconnect
+  coverage belongs to the re-arm paths, not to the registry.
+
 ### Inbound Kind 14 actions consumed by `dispatch_mostro_message`
 
 **Peer-reveal capture (#334), before the per-action arms.** Any message —

--- a/specs/004-mostro-p2p-client/plan.md
+++ b/specs/004-mostro-p2p-client/plan.md
@@ -124,7 +124,8 @@ rust/                         # Rust core
 │   ├── nostr/                # Nostr event construction + parsing
 │   │   ├── transport.rs      # Transport: NIP-44 direct (Kind 14, v2) for daemon + chat envelope (Kind 14) for peer/dispute chat
 │   │   ├── order_events.rs   # Kind 38383 event parsing
-│   │   └── relay_pool.rs     # Multi-relay connection manager
+│   │   ├── relay_pool.rs     # Multi-relay connection manager
+│   │   └── subscriptions.rs  # Single-owner registry for per-trade subscriptions (#325)
 │   ├── crypto/               # Key derivation + encryption
 │   │   ├── keys.rs           # BIP-39 mnemonic, BIP-32 derivation
 │   │   ├── ecdh.rs           # ECDH shared key computation


### PR DESCRIPTION
Close #325 

Every per-trade watcher's exit path runs a destructive pair — `unsubscribe` on its deterministic id plus `purge_pending_request` — unconditionally. Today that is safe only by accident: every caller of `subscribe_daemon_messages` derives a fresh trade key first, so two watchers can never share an id. The restore apply (#218) breaks that invariant by design: it must be idempotent, and re-applying a snapshot re-arms watchers for trade keys that already have one. The older watcher's exit would then kill the newer one's live subscription and purge its pending record — surfacing as `NoDaemonResponse` on an order the daemon actually accepted, during a restore.

## Change

New `rust/src/nostr/subscriptions.rs` — a single-owner registry for the per-trade subscription lifecycle, following the repo's own `ACTIVE_CHATS` precedent (`messages.rs`) rather than importing Mostrix's shape:

- **Idempotence by membership**: `try_claim` admits exactly one owner per trade key. A second claim bounces — the live subscription and its pending record stay untouched.
- **A bounce is a lease refresh**: the bounce marks the key re-armed; the owner's idle-timeout exit consumes the mark and resets its timer instead of dismantling. Without this, a re-arm landing at minute 29 of the 30-minute idle window would be "covered" for seconds.
- **Teardown is atomic w.r.t. claims**: the destructive pair runs under the registry lock, so a concurrent claim either bounces before it (owner keeps running) or lands after it (key is free, subscribes from scratch) — never in between. Note: `ACTIVE_CHATS` releases *before* unsubscribing and leaves exactly that window open; this module documents why not to copy that ordering.
- **Shutdown vs idle**: Shutdown/closed-channel exits tear down unconditionally even with a re-arm mark pending — the watcher's receiver is dead, honoring the mark would spin on a closed channel. Post-reconnect coverage belongs to the re-arm paths (#218/#291).

`daemon_message_subscription_id` moves into the module (id + ownership together, in line with #120). `subscribe_single_order` is out of scope: single caller, not on the #218 path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of per-trade message subscriptions by preventing duplicate watchers and restoring idle subscriptions.
  - Pending requests are preserved during subscription recovery, with cleaner shutdown and channel-closure handling.
  - Improved invoice update handling, including bond requests and settled hold-invoice messages.
  - Improved cancellation and cleanup behavior across maker, inactive-take, and active-trade states.
  - Subscription identifiers are generated consistently to reduce conflicts and improve message routing.

- **Documentation**
  - Clarified subscription recovery, teardown, relay acceptance, and cancellation behavior.

- **Tests**
  - Added coverage for subscription races, recovery, cleanup, bond handling, and identifier uniqueness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->