### PR TITLE
Publish the remainder of a bought range order

### DIFF
--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -1280,20 +1280,23 @@ pub async fn send_fiat_sent(order_id: String) -> Result<()> {
     let sender_keys = crate::api::identity::get_active_trade_keys(trade_index).await?;
     let identity_keys = crate::api::identity::get_transport_identity_keys(&sender_keys).await?;
     let mostro_pubkey = nostr_sdk::prelude::PublicKey::from_hex(&active_mostro_pubkey())?;
+    let next_trade = next_trade_for_range_remainder(&order_id, TradeRole::Buyer).await?;
     let event_json = actions::fiat_sent(
         &identity_keys,
         &sender_keys,
         &mostro_pubkey,
         &order_id,
         trade_index,
+        next_trade.clone(),
     )
     .await?;
     publish_event_json(&event_json).await?;
     crate::api::logging::blog_info(
         "orders",
         format!(
-            "fiat_sent published for order={} trade_index={trade_index}",
+            "fiat_sent published for order={} trade_index={trade_index} next_trade_index={:?}",
             crate::api::logging::short_id(&order_id),
+            next_trade.map(|(_, index)| index),
         ),
     );
     Ok(())
@@ -1310,7 +1313,7 @@ pub async fn release_order(order_id: String) -> Result<()> {
     let sender_keys = crate::api::identity::get_active_trade_keys(trade_index).await?;
     let identity_keys = crate::api::identity::get_transport_identity_keys(&sender_keys).await?;
     let mostro_pubkey = nostr_sdk::prelude::PublicKey::from_hex(&active_mostro_pubkey())?;
-    let next_trade = next_trade_for_range_remainder(&order_id).await?;
+    let next_trade = next_trade_for_range_remainder(&order_id, TradeRole::Seller).await?;
     let event_json = actions::release(
         &identity_keys,
         &sender_keys,
@@ -1333,13 +1336,18 @@ pub async fn release_order(order_id: String) -> Result<()> {
 }
 
 /// The trade key the daemon should hand the remainder of a range order to,
-/// when the releasing seller is its maker: a fresh key, already covered by
-/// the bulk daemon-message subscription so the child's `new-order` reaches
-/// this client. `None` only once the trade row says the release leaves
-/// nothing behind: a fixed order, or a taker's. A store or row that cannot
-/// be read is an error, never `None`: a release sent without the key on a
-/// range order settles the trade and loses the remainder for good.
-async fn next_trade_for_range_remainder(order_id: &str) -> Result<Option<(String, u32)>> {
+/// when this client made the range and acts as `maker_role` on it: the
+/// seller names it in the release, the buyer in fiat-sent. A fresh key,
+/// already covered by the daemon-message subscriptions so the child's
+/// `new-order` reaches this client. `None` only once the trade row says the
+/// step leaves nothing behind: a fixed order, a taker's trade, or the other
+/// role. A store or row that cannot be read is an error, never `None`: a
+/// step sent without the key on a range order settles the trade and loses
+/// the remainder for good.
+async fn next_trade_for_range_remainder(
+    order_id: &str,
+    maker_role: TradeRole,
+) -> Result<Option<(String, u32)>> {
     let db = crate::db::app_db::db().ok_or_else(|| {
         anyhow::anyhow!("no trade store: cannot tell whether order {order_id} leaves a remainder")
     })?;
@@ -1349,7 +1357,7 @@ async fn next_trade_for_range_remainder(order_id: &str) -> Result<Option<(String
         )
     })?;
     let is_range = trade.order.fiat_amount_min.is_some() && trade.order.fiat_amount_max.is_some();
-    if !is_range || !trade.order.is_mine || trade.role != TradeRole::Seller {
+    if !is_range || !trade.order.is_mine || trade.role != maker_role {
         return Ok(None);
     }
     let next = crate::api::identity::derive_trade_key().await?;
@@ -7049,7 +7057,9 @@ mod tests {
         let db = crate::db::app_db::db().expect("store initialised");
 
         let unknown = uuid::Uuid::new_v4().to_string();
-        assert!(next_trade_for_range_remainder(&unknown).await.is_err());
+        assert!(next_trade_for_range_remainder(&unknown, TradeRole::Seller)
+            .await
+            .is_err());
 
         let fixed_id = uuid::Uuid::new_v4().to_string();
         let mut fixed = dummy_order_info(&fixed_id);
@@ -7082,7 +7092,9 @@ mod tests {
             .await
             .expect("save");
         assert_eq!(
-            next_trade_for_range_remainder(&fixed_id).await.unwrap(),
+            next_trade_for_range_remainder(&fixed_id, TradeRole::Seller)
+                .await
+                .unwrap(),
             None,
             "a fixed order leaves nothing behind"
         );
@@ -7097,7 +7109,9 @@ mod tests {
             .await
             .expect("save");
         assert_eq!(
-            next_trade_for_range_remainder(&taken_id).await.unwrap(),
+            next_trade_for_range_remainder(&taken_id, TradeRole::Seller)
+                .await
+                .unwrap(),
             None,
             "a taker's release leaves nothing behind"
         );

--- a/rust/src/mostro/actions.rs
+++ b/rust/src/mostro/actions.rs
@@ -145,16 +145,10 @@ pub async fn fiat_sent(
     mostro_pubkey: &PublicKey,
     order_id: &str,
     trade_index: u32,
+    next_trade: Option<(String, u32)>,
 ) -> Result<String> {
-    simple_action(
-        identity_keys,
-        trade_keys,
-        mostro_pubkey,
-        order_id,
-        trade_index,
-        Action::FiatSent,
-    )
-    .await
+    let msg = action_message(order_id, trade_index, Action::FiatSent, next_trade)?;
+    wrap_message(identity_keys, trade_keys, mostro_pubkey, &msg).await
 }
 
 /// Build and wrap a Release MostroMessage.
@@ -178,13 +172,24 @@ pub(crate) fn release_message(
     trade_index: u32,
     next_trade: Option<(String, u32)>,
 ) -> Result<Message> {
+    action_message(order_id, trade_index, Action::Release, next_trade)
+}
+
+/// An order action that may name the trade key for a range remainder: the
+/// seller's Release, or the buyer's FiatSent when the buyer made the range.
+pub(crate) fn action_message(
+    order_id: &str,
+    trade_index: u32,
+    action: Action,
+    next_trade: Option<(String, u32)>,
+) -> Result<Message> {
     let id = Uuid::parse_str(order_id)?;
     let payload = next_trade.map(|(pubkey, index)| Payload::NextTrade(pubkey, index));
     Ok(Message::new_order(
         Some(id),
         None,
         Some(trade_index as i64),
-        Action::Release,
+        action,
         payload,
     ))
 }
@@ -491,6 +496,15 @@ mod tests {
             kind.get_next_trade_key().unwrap(),
             Some(("ab".repeat(32), 4))
         );
+
+        // The buyer who made a range names the key in fiat-sent instead.
+        let fiat = action_message(&id, 3, Action::FiatSent, Some(("cd".repeat(32), 5))).unwrap();
+        let kind = fiat.get_inner_message_kind();
+        assert_eq!(kind.action, Action::FiatSent);
+        assert_eq!(
+            kind.get_next_trade_key().unwrap(),
+            Some(("cd".repeat(32), 5))
+        );
     }
 
     /// The NIP-13 target difficulty the event was mined at, read from its
@@ -601,6 +615,7 @@ mod tests {
                 &mostro_pubkey,
                 "94486ae3-4083-4dfe-b543-53fe761025e9",
                 5,
+                None,
             ),
         )
         .await


### PR DESCRIPTION
## Summary

Follow-up to #410 (stacked on it; rebase onto `main` once #410 merges). The buyer who made a range order names the remainder's trade key in `fiat-sent`, where mostrod expects it (`fiat_sent.rs` stores `next_trade_pubkey`/`next_trade_index`; `handle_buy_child_order` uses them at the seller's release). #410 did this for the seller's release only, so a **bought** range settled without publishing what was left of the range.

- `send_fiat_sent` resolves the next trade key with the same `next_trade_for_range_remainder`, now parameterised by the maker role (`Buyer` here, `Seller` in `release_order`), and sends `Payload::NextTrade`. The fail-closed behaviour from the #410 review is kept.
- The message builders share `action_message`; the remainder's `new-order` is adopted as a buy by the existing adoption path (its test already covered `Kind::Buy`).

## Evidence

Mortsom scenario `range_buy_order` (MostroP2P/mortsom#28): Bob buys a 1000–3000 ARS range, Alice takes at 2000 as seller, the trade settles, and the remainder appears as Bob's pending buy order, listed in his app and cancelled by him with relay confirmation. Passed live on regtest, Linux (`20260910T053658Z-e0a210deca14`) and Web (`20260910T054723Z-05e6492912c8`).

## Test plan

- [x] `cargo test --lib api::orders`, `mostro::actions` (fiat-sent carries `NextTrade` only when given)
- [x] `cargo clippy --lib -- -D warnings`, rustfmt on the touched files
- [x] Live on Linux and Web through Mortsom

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A99VnGhin3Pdii1dSYAY55