### PR TITLE
Test-environment order expiry (MORTSOM_ORDER_EXPIRY_SECS)

### DIFF
--- a/docs/automation-contract.md
+++ b/docs/automation-contract.md
@@ -117,6 +117,7 @@ What the test environment changes:
 | Marker | A red `TEST ENVIRONMENT · Mortsom` banner is shown on every screen, carrying `env.marker`. The harness refuses to run against a build without it. |
 | Node | `MOSTRO_PUB_KEY` selects the daemon under test, applied before the relay pool starts and only when no node was ever chosen — so a restart keeps whatever the run picked through the UI. Without it the first subscriptions would target the production node, which cannot decrypt them, and the app would look silently idle. A malformed key is ignored rather than passed to the bridge. |
 | Startup | Missing `MORTSOM_RELAYS` fails at startup naming the define, instead of starting against the public relays and passing a test that never reached the daemon under test. |
+| Order expiry | `MORTSOM_ORDER_EXPIRY_SECS` (optional) makes every order this build creates ask the daemon to expire it that many seconds after creation, the way the protocol lets any maker do; the daemon caps it by its `max_expiration_days`. Without it the daemon's own default applies (an hour), which is what a scenario about the daemon's pending-order clock cannot wait out. Ignored outside the test environment. |
 
 Both entry points go through `bootstrapAndRun` in `lib/core/app_bootstrap.dart`,
 so a test build and a production build differ only in what they pass, never in

--- a/lib/core/app_bootstrap.dart
+++ b/lib/core/app_bootstrap.dart
@@ -119,6 +119,13 @@ Future<void> bootstrapAndRun({List<String> seedRelays = const []}) async {
     // capability fetch already resolves against them. Nothing can have written
     // them in a release build (docs/cashu/README.md §4.3).
     await escrow_api.rehydrateEscrowOverrides();
+    // A Mortsom build may ask the daemon for a short order expiry; set
+    // before any order can be created.
+    final orderExpiry = TestEnvironment.orderExpirySecs;
+    if (orderExpiry != null) {
+      settings_api.setTestOrderExpiry(secs: BigInt.from(orderExpiry));
+      debugPrint('[main] Mortsom build: orders expire after ${orderExpiry}s');
+    }
     markBridgeReady();
   } catch (e) {
     debugPrint('[main] rehydrate active Mostro node failed: $e');

--- a/lib/core/app_bootstrap.dart
+++ b/lib/core/app_bootstrap.dart
@@ -123,7 +123,7 @@ Future<void> bootstrapAndRun({List<String> seedRelays = const []}) async {
     // before any order can be created.
     final orderExpiry = TestEnvironment.orderExpirySecs;
     if (orderExpiry != null) {
-      settings_api.setTestOrderExpiry(secs: BigInt.from(orderExpiry));
+      await settings_api.setTestOrderExpiry(secs: BigInt.from(orderExpiry));
       debugPrint('[main] Mortsom build: orders expire after ${orderExpiry}s');
     }
     markBridgeReady();

--- a/lib/core/test_environment.dart
+++ b/lib/core/test_environment.dart
@@ -24,6 +24,8 @@ class TestEnvironment {
       String.fromEnvironment('MORTSOM_RELAYS', defaultValue: '');
   static const String _mostroPubkeyDefine =
       String.fromEnvironment('MOSTRO_PUB_KEY', defaultValue: '');
+  static const int _orderExpiryDefine =
+      int.fromEnvironment('MORTSOM_ORDER_EXPIRY_SECS', defaultValue: 0);
 
   static bool _armed = false;
 
@@ -61,6 +63,13 @@ class TestEnvironment {
   /// unreachable, never quietly succeed against a public one.
   static List<String> get seedRelays =>
       enabled ? parseRelays(_relaysDefine) : const [];
+
+  /// Seconds after creation every order made by this build asks the daemon
+  /// to expire it at (`MORTSOM_ORDER_EXPIRY_SECS`), so a scenario about the
+  /// daemon's pending-order clock does not wait out its hour-granular
+  /// default. Null when unset, non-positive, or outside the test environment.
+  static int? get orderExpirySecs =>
+      enabled && _orderExpiryDefine > 0 ? _orderExpiryDefine : null;
 
   /// Parses a comma-separated relay list, trimming and dropping blanks.
   @visibleForTesting

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -618,7 +618,13 @@ pub async fn create_order(params: NewOrderParams) -> Result<OrderInfo> {
         premium: params.premium,
         creator_pubkey: String::new(),
         created_at: now,
-        expires_at: Some(now + 24 * 3600),
+        // The test environment may ask the daemon for a short expiry; the
+        // daemon's own default is an hour, shown here as the day-long
+        // ceiling the app has always assumed until the book event says.
+        expires_at: Some(
+            crate::config::order_expiry_override()
+                .map_or(now + 24 * 3600, |secs| now.saturating_add(secs as i64)),
+        ),
         is_mine: true,
         // Own new order: the daemon's Kind 38383 confirmation carries the
         // real reputation snapshot; until then there is none to show.
@@ -679,6 +685,8 @@ pub async fn create_order(params: NewOrderParams) -> Result<OrderInfo> {
         rand::rngs::OsRng.next_u64().max(1) // 0 is indistinguishable from "unset"
     };
 
+    let requested_expiry = crate::config::order_expiry_override()
+        .map(|secs| crate::rt::unix_now().saturating_add(secs as i64));
     let event_json = actions::new_order(
         &identity_keys,
         &sender_keys,
@@ -686,6 +694,7 @@ pub async fn create_order(params: NewOrderParams) -> Result<OrderInfo> {
         &params_for_dispatch,
         trade_index,
         request_id,
+        requested_expiry,
     )
     .await?;
 

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -602,6 +602,11 @@ pub async fn create_order(params: NewOrderParams) -> Result<OrderInfo> {
     // after the NIP-59 message is published and acknowledged.
     let now = crate::rt::unix_now();
 
+    // One absolute expiry for both the local row and the daemon's request,
+    // so a second boundary between the two cannot make them disagree.
+    let requested_expiry = crate::config::order_expiry_override()
+        .and_then(|secs| i64::try_from(secs).ok())
+        .map(|secs| now.saturating_add(secs));
     // Clone params before the struct takes ownership of its fields.
     let params_for_dispatch = params.clone();
 
@@ -621,10 +626,7 @@ pub async fn create_order(params: NewOrderParams) -> Result<OrderInfo> {
         // The test environment may ask the daemon for a short expiry; the
         // daemon's own default is an hour, shown here as the day-long
         // ceiling the app has always assumed until the book event says.
-        expires_at: Some(
-            crate::config::order_expiry_override()
-                .map_or(now + 24 * 3600, |secs| now.saturating_add(secs as i64)),
-        ),
+        expires_at: Some(requested_expiry.unwrap_or(now + 24 * 3600)),
         is_mine: true,
         // Own new order: the daemon's Kind 38383 confirmation carries the
         // real reputation snapshot; until then there is none to show.
@@ -685,8 +687,6 @@ pub async fn create_order(params: NewOrderParams) -> Result<OrderInfo> {
         rand::rngs::OsRng.next_u64().max(1) // 0 is indistinguishable from "unset"
     };
 
-    let requested_expiry = crate::config::order_expiry_override()
-        .map(|secs| crate::rt::unix_now().saturating_add(secs as i64));
     let event_json = actions::new_order(
         &identity_keys,
         &sender_keys,

--- a/rust/src/api/settings.rs
+++ b/rust/src/api/settings.rs
@@ -182,6 +182,15 @@ pub async fn set_default_lightning_address(address: Option<String>) -> Result<()
 }
 
 /// Return the currently active Mostro node pubkey (override or default).
+/// Mortsom test environment only: every order this client creates asks
+/// the daemon to expire it `secs` after creation (`MORTSOM_ORDER_EXPIRY_SECS`),
+/// so a scenario about the daemon's pending-order clock does not wait out
+/// the daemon's hour-granular default. `None` restores that default. The
+/// daemon caps the value by its `max_expiration_days`.
+pub fn set_test_order_expiry(secs: Option<u64>) {
+    crate::config::set_order_expiry_override(secs.filter(|s| *s > 0));
+}
+
 pub fn get_mostro_pubkey() -> String {
     crate::config::active_mostro_pubkey()
 }

--- a/rust/src/api/settings.rs
+++ b/rust/src/api/settings.rs
@@ -5,8 +5,8 @@
 /// any active [`SettingsStream`] so the UI can react without polling.
 use anyhow::{bail, Result};
 use std::sync::OnceLock;
-use tokio::sync::{broadcast, RwLock};
 use tokio::sync::broadcast::error::RecvError;
+use tokio::sync::{broadcast, RwLock};
 
 use crate::api::types::{AppSettings, ThemeMode};
 use crate::db::Storage;
@@ -114,9 +114,7 @@ fn validate_lightning_address(address: &str) -> Result<()> {
             && labels.iter().all(|label| {
                 !label.is_empty()
                     && label.len() <= 63
-                    && label
-                        .chars()
-                        .all(|c| c.is_ascii_alphanumeric() || c == '-')
+                    && label.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
                     && !label.starts_with('-')
                     && !label.ends_with('-')
             });
@@ -188,7 +186,10 @@ pub async fn set_default_lightning_address(address: Option<String>) -> Result<()
 /// the daemon's hour-granular default. `None` restores that default. The
 /// daemon caps the value by its `max_expiration_days`.
 pub fn set_test_order_expiry(secs: Option<u64>) {
-    crate::config::set_order_expiry_override(secs.filter(|s| *s > 0));
+    // Bounded so `now + secs` stays a valid unix time: a value past
+    // `i64::MAX` would wrap the requested expiry into the past.
+    let bounded = secs.filter(|s| *s > 0 && i64::try_from(*s).is_ok());
+    crate::config::set_order_expiry_override(bounded);
 }
 
 pub fn get_mostro_pubkey() -> String {
@@ -347,7 +348,9 @@ mod tests {
     #[tokio::test]
     async fn set_default_fiat_code_valid() {
         let _g = settings_lock().lock().unwrap();
-        set_default_fiat_code(Some("USD".to_string())).await.unwrap();
+        set_default_fiat_code(Some("USD".to_string()))
+            .await
+            .unwrap();
         let s = get_settings().await.unwrap();
         assert_eq!(s.default_fiat_code.as_deref(), Some("USD"));
         set_default_fiat_code(None).await.unwrap();
@@ -364,7 +367,9 @@ mod tests {
     #[tokio::test]
     async fn set_default_fiat_code_none_clears() {
         let _g = settings_lock().lock().unwrap();
-        set_default_fiat_code(Some("EUR".to_string())).await.unwrap();
+        set_default_fiat_code(Some("EUR".to_string()))
+            .await
+            .unwrap();
         set_default_fiat_code(None).await.unwrap();
         let s = get_settings().await.unwrap();
         assert!(s.default_fiat_code.is_none());

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -40,6 +40,20 @@ pub fn active_mostro_pubkey() -> String {
         .unwrap_or_else(|| DEFAULT_MOSTRO_PUBKEY.to_string())
 }
 
+static ORDER_EXPIRY_OVERRIDE: RwLock<Option<u64>> = RwLock::new(None);
+
+/// Seconds after creation a new order asks the daemon to expire it, when
+/// the Mortsom test environment set one. `None` leaves the expiry to the
+/// daemon's own default, as every production build does.
+pub fn order_expiry_override() -> Option<u64> {
+    *ORDER_EXPIRY_OVERRIDE.read().unwrap()
+}
+
+/// Set (or clear) the order expiry the test environment asks for.
+pub fn set_order_expiry_override(secs: Option<u64>) {
+    *ORDER_EXPIRY_OVERRIDE.write().unwrap() = secs;
+}
+
 /// Set (or clear) the active Mostro pubkey override.
 ///
 /// Any daemon responses still in flight from a previously active

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -49,7 +49,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1377655897;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1263973758;
 
 // Section: executor
 
@@ -4825,6 +4825,41 @@ fn wire__crate__api__reputation__set_privacy_mode_impl(
         },
     )
 }
+fn wire__crate__api__settings__set_test_order_expiry_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "set_test_order_expiry",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_secs = <Option<u64>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, ()>((move || {
+                    let output_ok = Result::<_, ()>::Ok({
+                        crate::api::settings::set_test_order_expiry(api_secs);
+                    })?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__settings__set_theme_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -6995,11 +7030,17 @@ fn pde_ffi_dispatcher_primary_impl(
         118 => {
             wire__crate__api__reputation__set_privacy_mode_impl(port, ptr, rust_vec_len, data_len)
         }
-        119 => wire__crate__api__settings__set_theme_impl(port, ptr, rust_vec_len, data_len),
-        120 => wire__crate__api__disputes__submit_evidence_impl(port, ptr, rust_vec_len, data_len),
-        121 => wire__crate__api__reputation__submit_rating_impl(port, ptr, rust_vec_len, data_len),
-        122 => wire__crate__api__orders__subscribe_orders_impl(port, ptr, rust_vec_len, data_len),
-        123 => wire__crate__api__orders__take_order_impl(port, ptr, rust_vec_len, data_len),
+        119 => wire__crate__api__settings__set_test_order_expiry_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        120 => wire__crate__api__settings__set_theme_impl(port, ptr, rust_vec_len, data_len),
+        121 => wire__crate__api__disputes__submit_evidence_impl(port, ptr, rust_vec_len, data_len),
+        122 => wire__crate__api__reputation__submit_rating_impl(port, ptr, rust_vec_len, data_len),
+        123 => wire__crate__api__orders__subscribe_orders_impl(port, ptr, rust_vec_len, data_len),
+        124 => wire__crate__api__orders__take_order_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/rust/src/mostro/actions.rs
+++ b/rust/src/mostro/actions.rs
@@ -37,7 +37,20 @@ pub async fn new_order(
     params: &NewOrderParams,
     trade_index: u32,
     request_id: u64,
+    expires_at: Option<i64>,
 ) -> Result<String> {
+    let msg = new_order_message(params, trade_index, request_id, expires_at);
+    wrap_message_first_contact(identity_keys, trade_keys, mostro_pubkey, &msg).await
+}
+
+/// The NewOrder message. `expires_at` is the unix time the maker asks the
+/// daemon to expire the untaken order at; `None` leaves it to the daemon.
+pub(crate) fn new_order_message(
+    params: &NewOrderParams,
+    trade_index: u32,
+    request_id: u64,
+    expires_at: Option<i64>,
+) -> Message {
     use mostro_core::order::{Kind, SmallOrder, Status};
 
     let kind = match params.kind {
@@ -65,18 +78,17 @@ pub async fn new_order(
         None,
         None,
         None,
-        None,
+        expires_at,
     );
 
     let payload = Some(Payload::Order(small_order));
-    let msg = Message::new_order(
+    Message::new_order(
         None,
         Some(request_id),
         Some(trade_index as i64),
         Action::NewOrder,
         payload,
-    );
-    wrap_message_first_contact(identity_keys, trade_keys, mostro_pubkey, &msg).await
+    )
 }
 
 /// Build and wrap a TakeBuy MostroMessage.
@@ -481,6 +493,31 @@ pub async fn last_trade_index(
 mod tests {
     use super::*;
 
+    /// A new order carries the expiry the maker asks for, and none when the
+    /// daemon's default is wanted.
+    #[test]
+    fn a_new_order_carries_the_requested_expiry_only_when_given() {
+        let params = NewOrderParams {
+            kind: OrderKind::Sell,
+            fiat_amount: Some(10.0),
+            fiat_amount_min: None,
+            fiat_amount_max: None,
+            fiat_code: "USD".into(),
+            payment_method: "cash".into(),
+            premium: 0.0,
+            amount_sats: Some(1000),
+        };
+        let expiry_of = |msg: Message| match msg.get_inner_message_kind().payload.clone() {
+            Some(Payload::Order(order)) => order.expires_at,
+            other => panic!("not an order payload: {other:?}"),
+        };
+        assert_eq!(expiry_of(new_order_message(&params, 1, 7, None)), None);
+        assert_eq!(
+            expiry_of(new_order_message(&params, 1, 7, Some(1_800_000_600))),
+            Some(1_800_000_600)
+        );
+    }
+
     /// The seller of a range order releases with the key the daemon must
     /// assign the remainder to; an ordinary release carries no payload.
     #[test]
@@ -561,6 +598,7 @@ mod tests {
                 &sample_params(),
                 3,
                 42,
+                None,
             )
             .await
             .unwrap();
@@ -666,6 +704,7 @@ mod tests {
             &params,
             3,
             42,
+            None,
         )
         .await
         .unwrap();

--- a/test/core/automation/automation_contract_test.dart
+++ b/test/core/automation/automation_contract_test.dart
@@ -201,6 +201,15 @@ void main() {
       expect(TestEnvironment.allowInsecureRelays, isFalse);
     });
 
+    test('asks for an order expiry only when the define is set', () {
+      // The define is absent in this test build, so nothing is asked for
+      // whether or not the environment is armed.
+      TestEnvironment.arm();
+      expect(TestEnvironment.orderExpirySecs, isNull);
+      TestEnvironment.disarm();
+      expect(TestEnvironment.orderExpirySecs, isNull);
+    });
+
     test('parses a relay seed list, trimming and dropping blanks', () {
       expect(
         TestEnvironment.parseRelays(' ws://a:1 , ,ws://b:2, '),


### PR DESCRIPTION
## Summary

Mortsom's expiration family needs an untaken order to lapse inside a run. The daemon expires a pending order at its `expires_at`, which the protocol lets the maker choose (capped by the daemon's `max_expiration_days`); this client always left it unset, so the daemon's own default applied — `expiration_hours`, hour-granular.

A Mortsom build may now carry `--dart-define=MORTSOM_ORDER_EXPIRY_SECS=<n>`: every order it creates asks the daemon to expire it `n` seconds after creation. Nothing else changes; outside the test environment the define is ignored, as `MORTSOM_RELAYS` is.

- `TestEnvironment.orderExpirySecs` (Dart), handed to the core at bootstrap through `settings_api.setTestOrderExpiry`.
- `config::order_expiry_override` in the core; `create_order` sets `expires_at` on the NewOrder payload (`actions::new_order_message`) and on the local row from it.
- Documented in `docs/automation-contract.md`.

## Evidence

Mortsom scenario `pending_order_expires` (MostroP2P/mortsom, branch `feat/expiration-family`) against a regtest stack declaring `order_expiration_secs = 600`: the daemon expired the order 657 s after creation and published it as `canceled` on the book. Passed on Linux (`20260910T070452Z-25eb0c704486`) and Web (`20260910T081253Z-df98b81090c1`); every other scenario of the three accepted families ran on builds carrying the define.

## Test plan

- [x] `cargo test --lib mostro::actions` (NewOrder carries the requested expiry only when given), `api::orders`
- [x] `cargo clippy --lib -- -D warnings`
- [x] `flutter test test/core/automation/automation_contract_test.dart` (the define is absent in the test build, so nothing is asked for), `flutter analyze` on the touched files
- [x] Live on Linux and Web through Mortsom

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A99VnGhin3Pdii1dSYAY55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Test environments can configure a custom order expiration duration.
  * Newly created orders now apply the configured expiration consistently.
  * Environments without an override continue using the daemon’s default expiration behavior.

* **Documentation**
  * Added guidance for configuring order expiration in the UI automation contract.

* **Bug Fixes**
  * Improved validation and handling of configured expiration values.

* **Tests**
  * Added coverage confirming default behavior when no expiration setting is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->