### PR TITLE
feat: tag the dispute screen back button for automation

### DIFF
--- a/lib/features/disputes/screens/dispute_chat_screen.dart
+++ b/lib/features/disputes/screens/dispute_chat_screen.dart
@@ -3,6 +3,8 @@ import 'package:mostro/l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:mostro/core/app_theme.dart';
+import 'package:mostro/core/automation/automation_id.dart';
+import 'package:mostro/core/automation/automation_ids.dart';
 import 'package:mostro/features/disputes/providers/disputes_providers.dart';
 import 'package:mostro/features/disputes/widgets/dispute_message_input.dart';
 import 'package:mostro/features/disputes/widgets/dispute_messages_list.dart';
@@ -77,7 +79,10 @@ class _DisputeChatScreenState extends ConsumerState<DisputeChatScreen> {
     if (dispute == null) {
       final l10n = AppLocalizations.of(context);
       return Scaffold(
-        appBar: AppBar(title: Text(l10n.disputeScreenTitle)),
+        appBar: AppBar(
+          title: Text(l10n.disputeScreenTitle),
+          leading: const BackButton().withAutomationId(AutomationIds.appBarBack),
+        ),
         body: Center(child: Text(l10n.disputeNotFound)),
       );
     }
@@ -93,6 +98,9 @@ class _DisputeChatScreenState extends ConsumerState<DisputeChatScreen> {
       appBar: AppBar(
         title: _HeaderTitle(dispute: dispute, colors: colors),
         titleSpacing: 0,
+        // The dispute screen is pushed over the trade detail; automation
+        // leaves it the way it leaves every other screen (`appbar.back`).
+        leading: const BackButton().withAutomationId(AutomationIds.appBarBack),
       ),
       body: Column(
         children: [


### PR DESCRIPTION
## Summary
- The dispute screen (`DisputeChatScreen`) is pushed over the trade detail when a party opens a dispute. Its default `AppBar` exposed no `appbar.back` automation id, so Mortsom could not leave it and every later observation of the trade failed.
- Both `AppBar`s of the screen now carry `BackButton().withAutomationId(AutomationIds.appBarBack)`, the same id every other pushed screen exposes (`docs/automation-contract.md`). No behaviour change for users.

## Test plan
- [x] `flutter analyze` on the file: no issues
- [x] Mortsom dispute family (`dispute_settled_by_solver`, `dispute_canceled_by_solver`, `dispute_released_by_seller`) accepted live on Linux and Web with clients built from this branch (MostroP2P/mortsom PR "feat: dispute family")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A99VnGhin3Pdii1dSYAY55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility & Testing**
  * Added an automation identifier to the back button on the dispute chat screen, including the “dispute not found” view, improving automated interaction and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->