### PR TITLE
ci: bump Flutter to 3.41.9 and migrate containsSemantics to isSemantics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FLUTTER_VERSION: "3.38.2"
+  FLUTTER_VERSION: "3.41.9"
   FRB_VERSION: "2.11.1"
   CARGO_EXPAND_VERSION: "1.0.123"
 

--- a/.github/workflows/update-goldens.yml
+++ b/.github/workflows/update-goldens.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FLUTTER_VERSION: "3.38.2"
+  FLUTTER_VERSION: "3.41.9"
   FRB_VERSION: "2.11.1"
   CARGO_EXPAND_VERSION: "1.0.123"
 

--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -25,7 +25,7 @@ permissions: {}
 
 env:
   # Keep in sync with ci.yml.
-  FLUTTER_VERSION: "3.38.2"
+  FLUTTER_VERSION: "3.41.9"
   RUST_VERSION: "1.97.0"
   FRB_VERSION: "2.11.1"
   CARGO_EXPAND_VERSION: "1.0.123"

--- a/test/core/automation/automation_contract_test.dart
+++ b/test/core/automation/automation_contract_test.dart
@@ -69,7 +69,7 @@ void main() {
       // accessibility bridge exposes as a `resource-id`.
       expect(
         tester.getSemantics(find.byType(ElevatedButton)),
-        containsSemantics(
+        isSemantics(
           identifier: AutomationIds.orderCreateSubmit,
           label: 'Submit',
           isButton: true,
@@ -96,7 +96,7 @@ void main() {
       // which changes with the locale.
       expect(
         tester.getSemantics(find.text('Esperando pago…')),
-        containsSemantics(
+        isSemantics(
           identifier: AutomationIds.orderStatus,
           label: 'waiting-payment',
         ),
@@ -130,7 +130,7 @@ void main() {
       // automation could no longer choose which relay to remove.
       expect(
         tester.getSemantics(find.byType(IconButton)),
-        containsSemantics(
+        isSemantics(
           identifier:
               AutomationIds.settingsRelayDelete('ws://10.0.2.2:7000'),
           hasTapAction: true,

--- a/test/core/automation/linux_label_test.dart
+++ b/test/core/automation/linux_label_test.dart
@@ -54,7 +54,7 @@ void main() {
       );
       expect(
         tester.getSemantics(find.byType(ElevatedButton)),
-        containsSemantics(
+        isSemantics(
           identifier: AutomationIds.tradeRelease,
           label: 'Release',
           hasTapAction: true,
@@ -92,7 +92,7 @@ void main() {
       expect(button.getSemanticsData().label, contains('Release'));
       expect(
         button,
-        containsSemantics(
+        isSemantics(
           identifier: AutomationIds.tradeRelease,
           isEnabled: true,
           hasTapAction: true,
@@ -159,7 +159,7 @@ void main() {
         );
         expect(
           tab,
-          containsSemantics(
+          isSemantics(
             identifier: AutomationIds.orderBookTabSell,
             hasTapAction: true,
             isSelected: false,
@@ -169,7 +169,7 @@ void main() {
         await tester.pumpAndSettle();
         expect(
           tester.getSemantics(semantic(AutomationIds.orderBookTabSell)),
-          containsSemantics(isSelected: true),
+          isSemantics(isSelected: true),
         );
       } finally {
         semantics.dispose();
@@ -227,7 +227,7 @@ void main() {
       }
       expect(
         tester.getSemantics(semantic(AutomationIds.navTrades)),
-        containsSemantics(hasTapAction: true),
+        isSemantics(hasTapAction: true),
       );
       await tester.tap(semantic(AutomationIds.navTrades));
       await tester.pumpAndSettle();

--- a/test/features/account/widgets/public_key_card_test.dart
+++ b/test/features/account/widgets/public_key_card_test.dart
@@ -39,7 +39,7 @@ void main() {
     // the placeholder must not leak into it as if it were a key.
     expect(
       tester.getSemantics(find.byType(PublicKeyCard)),
-      containsSemantics(identifier: AutomationIds.keysPublicKey, label: ''),
+      isSemantics(identifier: AutomationIds.keysPublicKey, label: ''),
     );
   });
 
@@ -50,7 +50,7 @@ void main() {
     // The visible text ellipsizes at the card's width; the readout does not.
     expect(
       tester.getSemantics(find.byType(PublicKeyCard)),
-      containsSemantics(identifier: AutomationIds.keysPublicKey, label: key),
+      isSemantics(identifier: AutomationIds.keysPublicKey, label: key),
     );
   });
 
@@ -63,7 +63,7 @@ void main() {
     expect(find.text(key), findsNothing);
     expect(
       tester.getSemantics(find.byType(PublicKeyCard)),
-      containsSemantics(
+      isSemantics(
         identifier: AutomationIds.keysPublicKey,
         label: replacement,
       ),

--- a/test/features/drawer/screens/drawer_menu_test.dart
+++ b/test/features/drawer/screens/drawer_menu_test.dart
@@ -131,7 +131,7 @@ void main() {
         expect(find.text(label), findsOneWidget);
         expect(
           tester.getSemantics(_semantic(id)),
-          containsSemantics(isButton: true, isSelected: false),
+          isSemantics(isButton: true, isSelected: false),
         );
       }
       semantics.dispose();
@@ -205,11 +205,11 @@ void main() {
 
       expect(
         tester.getSemantics(_semantic(AutomationIds.navOrderBook)),
-        containsSemantics(isSelected: true),
+        isSemantics(isSelected: true),
       );
       expect(
         tester.getSemantics(_semantic(AutomationIds.drawerSettings)),
-        containsSemantics(isSelected: false),
+        isSemantics(isSelected: false),
       );
       expect(find.text('ALPHA'), findsOneWidget);
       semantics.dispose();

--- a/test/features/order/screens/pay_lightning_invoice_identity_test.dart
+++ b/test/features/order/screens/pay_lightning_invoice_identity_test.dart
@@ -90,7 +90,7 @@ void main() {
           );
           expect(
             tester.getSemantics(id('appbar.back')),
-            containsSemantics(hasTapAction: true),
+            isSemantics(hasTapAction: true),
           );
           await tester.tap(id('appbar.back'));
           await tester.pumpAndSettle();

--- a/test/shared/widgets/nwc_invoice_widget_test.dart
+++ b/test/shared/widgets/nwc_invoice_widget_test.dart
@@ -60,7 +60,7 @@ void main() {
 
     expect(
       tester.getSemantics(find.byType(NwcInvoiceWidget)),
-      containsSemantics(
+      isSemantics(
         identifier: AutomationIds.invoiceNwcText,
         label: invoice,
       ),


### PR DESCRIPTION
## Summary

CI pinned **Flutter 3.38.2** while development runs **3.41.x**. That gap broke PR #421: the local analyzer reports `containsSemantics` as deprecated (since 3.40) and suggests `isSemantics`, which doesn't exist on 3.38, so migrating failed CI's `Analyze` step with `undefined_function`.

This PR aligns CI with the local toolchain:

- **`FLUTTER_VERSION: 3.38.2 → 3.41.9`** in all three workflows that pin it, which must move together:
  - `ci.yml`: analyze / test
  - `web-build.yml`: builds the bundle CI smoke-tests and `deploy-pages.yml` ships
  - `update-goldens.yml`: renders the PNGs `flutter test` compares against
- **`containsSemantics` → `isSemantics`** at all 16 call sites (6 test files). `isSemantics` is the documented drop-in replacement: only the properties passed are checked. Without this, `flutter analyze` exits non-zero on the deprecation infos under 3.41.

3.41.9 (2026-04-30, Dart 3.11.5) rather than the latest stable 3.47.3, so CI matches the version developers run today; moving to 3.47 can be a separate bump.

The `web-build.yml` note about the locale crash "only on Flutter >= 3.38" stays valid.

## Test plan
- [x] Local, Flutter 3.41.9: `flutter analyze`: no issues.
- [x] Local, Flutter 3.41.9: `flutter test`: 392 passed (golden tests included).
- [ ] CI `Flutter (analyze / test)` green on 3.41.9.
- [ ] CI `Web (wasm build / smoke test)` green: bundle builds and the smoke test sees the Rust bridge call return.
- [ ] If golden comparisons differ on the CI runner, run **Update goldens** (`gh workflow run update-goldens.yml --ref ci/bump-flutter`) and re-check.
