### PR TITLE
fix(orders): re-target live subscriptions on node switch

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -547,6 +547,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "btreecap"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6160c957d8aa33d0a8ba1dbab98e3cb57023ad9374c501441e88559f99e6c4c9"
+
+[[package]]
 name = "build-target"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2639,6 +2645,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nostr-memory"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2b7b21ffca47ad6dc32474d06d7fd1e8f83f218f7b350f4309eb5f49e7f97d"
+dependencies = [
+ "btreecap",
+ "nostr",
+ "nostr-database",
+ "tokio",
+]
+
+[[package]]
 name = "nostr-sdk"
 version = "0.45.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2653,6 +2671,7 @@ dependencies = [
  "nostr",
  "nostr-database",
  "nostr-gossip",
+ "nostr-memory",
  "opaquerr",
  "rand 0.10.0",
  "tokio",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -112,3 +112,8 @@ getrandom_04 = { package = "getrandom", version = "0.4", features = ["wasm_js"] 
 # wasm32-unknown-unknown refuses to *link* until the final crate names a time
 # provider (see `rt::browser_clock`). Not caught by `cargo check`.
 universal-time = { version = "0.3", default-features = false }
+
+# Tests only: `MockRelay` (an in-process relay) is behind nostr-sdk's
+# `local-relay` feature. Native only — it pulls in `tokio/net`.
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+nostr-sdk = { version = "0.45", default-features = false, features = ["local-relay"] }

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -3970,7 +3970,6 @@ async fn replace_subscription(
 async fn subscribe_node_filters(
     client: &nostr_sdk::prelude::Client,
     mostro_pubkey: nostr_sdk::prelude::PublicKey,
-    trade_pubkeys: Vec<nostr_sdk::prelude::PublicKey>,
 ) -> Result<()> {
     // Two filters, not one unbounded one: relays cap how many stored events
     // they replay per REQ (relay.mostro.network: 300, oldest-first when no
@@ -4013,21 +4012,45 @@ async fn subscribe_node_filters(
     // after any downtime it must replay the full stored history so status
     // changes and late reconciliations are never lost. Only the ephemeral
     // per-trade subscription (subscribe_daemon_messages) carries a cutoff.
-    if !trade_pubkeys.is_empty() {
-        let p_count = trade_pubkeys.len();
-        let dm_filter = nostr_sdk::prelude::Filter::new()
-            .kind(nostr_sdk::prelude::Kind::PrivateDirectMessage)
-            .author(mostro_pubkey)
-            .pubkeys(trade_pubkeys);
-        replace_subscription(client, mostro_dm_subscription_id(), dm_filter).await?;
-        crate::api::logging::blog_info(
-            "relay",
-            format!(
-                "sub created id={} kinds=[14] p_count={p_count}",
-                mostro_dm_subscription_id(),
-            ),
-        );
+    replace_global_dm_filter(client, mostro_pubkey).await
+}
+
+/// Re-issue the bulk Kind-14 subscription from the full coverage map
+/// ([`global_dm_keys`]); a no-op while the map is empty.
+///
+/// Serialized: a node switch and a key joining mid-session both land here,
+/// and two interleaved CLOSE/REQ pairs either leave the filter built from an
+/// older key set or make one REQ fail with "subscription ID already exists".
+/// Reading the map under the lock means whichever replacement runs last
+/// carries every covered key.
+async fn replace_global_dm_filter(
+    client: &nostr_sdk::prelude::Client,
+    mostro_pubkey: nostr_sdk::prelude::PublicKey,
+) -> Result<()> {
+    static DM_FILTER_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+    let _guard = DM_FILTER_LOCK.lock().await;
+    let trade_pubkeys: Vec<nostr_sdk::prelude::PublicKey> = global_dm_keys()
+        .read()
+        .await
+        .keys()
+        .filter_map(|hex| nostr_sdk::prelude::PublicKey::from_hex(hex).ok())
+        .collect();
+    if trade_pubkeys.is_empty() {
+        return Ok(());
     }
+    let p_count = trade_pubkeys.len();
+    let dm_filter = nostr_sdk::prelude::Filter::new()
+        .kind(nostr_sdk::prelude::Kind::PrivateDirectMessage)
+        .author(mostro_pubkey)
+        .pubkeys(trade_pubkeys);
+    replace_subscription(client, mostro_dm_subscription_id(), dm_filter).await?;
+    crate::api::logging::blog_info(
+        "relay",
+        format!(
+            "sub replaced id={} kinds=[14] p_count={p_count}",
+            mostro_dm_subscription_id(),
+        ),
+    );
     Ok(())
 }
 
@@ -4067,9 +4090,9 @@ pub(crate) async fn refresh_subscriptions_for_active_node() {
         }
     };
 
-    let trade_pubkeys = seed_global_dm_coverage().await;
+    seed_global_dm_coverage().await;
 
-    if let Err(e) = subscribe_node_filters(&client, mostro_pubkey, trade_pubkeys).await {
+    if let Err(e) = subscribe_node_filters(&client, mostro_pubkey).await {
         log::error!("[orders] node switch: re-subscribe failed: {e}");
         return;
     }
@@ -4142,32 +4165,8 @@ async fn resubscribe_global_dm_filter() {
     let Ok(mostro_pubkey) = nostr_sdk::prelude::PublicKey::from_hex(&active_mostro_pubkey()) else {
         return;
     };
-    let trade_pubkeys: Vec<nostr_sdk::prelude::PublicKey> = global_dm_keys()
-        .read()
-        .await
-        .keys()
-        .filter_map(|hex| nostr_sdk::prelude::PublicKey::from_hex(hex).ok())
-        .collect();
-    if trade_pubkeys.is_empty() {
-        return;
-    }
-    let p_count = trade_pubkeys.len();
-    let dm_filter = nostr_sdk::prelude::Filter::new()
-        .kind(nostr_sdk::prelude::Kind::PrivateDirectMessage)
-        .author(mostro_pubkey)
-        .pubkeys(trade_pubkeys);
-    if let Err(e) =
-        replace_subscription(&pool.client(), mostro_dm_subscription_id(), dm_filter).await
-    {
+    if let Err(e) = replace_global_dm_filter(&pool.client(), mostro_pubkey).await {
         log::warn!("[orders] bulk DM filter refresh failed: {e}");
-    } else {
-        crate::api::logging::blog_info(
-            "relay",
-            format!(
-                "sub replaced id={} kinds=[14] p_count={p_count}",
-                mostro_dm_subscription_id(),
-            ),
-        );
     }
 }
 
@@ -4543,7 +4542,7 @@ async fn _run_order_subscription() {
     // status changes) and the bulk Kind-14 Mostro-reply feed, both author-pinned
     // to the active node via stable subscription IDs (so a later node switch can
     // replace them in place). Display-level filtering is handled in Dart.
-    if let Err(e) = subscribe_node_filters(&client, mostro_pubkey, trade_pubkeys).await {
+    if let Err(e) = subscribe_node_filters(&client, mostro_pubkey).await {
         log::error!("[orders] subscribe failed: {e}");
         return;
     }
@@ -5372,14 +5371,18 @@ mod tests {
             .try_connect_relay(url, std::time::Duration::from_secs(3))
             .await
             .expect("connect");
-        let trade = Keys::generate().public_key();
+        let trade = Keys::generate();
+        global_dm_keys()
+            .write()
+            .await
+            .insert(trade.public_key().to_hex(), (trade, 93));
         let previous = Keys::generate().public_key();
         let next = Keys::generate().public_key();
 
-        subscribe_node_filters(&client, previous, vec![trade])
+        subscribe_node_filters(&client, previous)
             .await
             .expect("first subscribe");
-        subscribe_node_filters(&client, next, vec![trade])
+        subscribe_node_filters(&client, next)
             .await
             .expect("node switch");
 
@@ -5416,12 +5419,84 @@ mod tests {
             .await
             .expect("add relay");
 
-        let result = subscribe_node_filters(&client, Keys::generate().public_key(), vec![]).await;
+        let result = subscribe_node_filters(&client, Keys::generate().public_key()).await;
 
         assert!(
             result.is_err(),
             "a subscription no relay accepted must not pass for a live one"
         );
+    }
+
+    /// PR #423 review: a node switch and a mid-session key joining the
+    /// coverage both replace `mostro-dm`. Interleaved, the CLOSE/REQ pairs
+    /// either leave the filter built from the stale key set or make one REQ
+    /// hit "subscription ID already exists". The last replace must win with
+    /// every covered key, and neither caller may fail.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_dm_filter_replacements_keep_every_covered_key() {
+        use nostr_sdk::local_relay::MockRelay;
+        use nostr_sdk::prelude::{Client, Keys};
+
+        const RACERS: usize = 16;
+
+        let relay = MockRelay::run().await.expect("mock relay");
+        let url = relay.url().await;
+        let client = Client::new();
+        client.add_relay(&url).await.expect("add relay");
+        client
+            .try_connect_relay(url, std::time::Duration::from_secs(3))
+            .await
+            .expect("connect");
+        let node = Keys::generate().public_key();
+        let snapshot = Keys::generate();
+        global_dm_keys()
+            .write()
+            .await
+            .insert(snapshot.public_key().to_hex(), (snapshot.clone(), 94));
+
+        // Against an in-process relay one replacement never yields, so the
+        // race only shows with real parallelism: the barrier releases every
+        // racer at once, each adding its own key and replacing `mostro-dm`.
+        let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(RACERS));
+        let joined: Vec<Keys> = (0..RACERS).map(|_| Keys::generate()).collect();
+        let racers: Vec<_> = joined
+            .iter()
+            .cloned()
+            .map(|keys| {
+                let (client, barrier) = (client.clone(), barrier.clone());
+                tokio::spawn(async move {
+                    barrier.wait().await;
+                    global_dm_keys()
+                        .write()
+                        .await
+                        .insert(keys.public_key().to_hex(), (keys, 95));
+                    replace_global_dm_filter(&client, node).await
+                })
+            })
+            .collect();
+        for racer in racers {
+            racer
+                .await
+                .expect("racer panicked")
+                .expect("a concurrent replacement failed");
+        }
+        let per_relay = client.subscription(&mostro_dm_subscription_id()).await;
+        let pubkeys = per_relay
+            .values()
+            .flatten()
+            .filter_map(|f| {
+                f.generic_tags
+                    .get(&nostr_sdk::prelude::SingleLetterTag::LOWERCASE_P)
+                    .cloned()
+            })
+            .flatten()
+            .collect::<std::collections::BTreeSet<_>>();
+        for key in std::iter::once(&snapshot).chain(&joined) {
+            assert!(
+                pubkeys.contains(&key.public_key().to_hex()),
+                "mostro-dm lost a covered key"
+            );
+        }
     }
 
     /// The truncation that keeps the daemon id under the cap must not merge

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -3916,13 +3916,57 @@ fn relay_list_subscription_id() -> nostr_sdk::prelude::SubscriptionId {
     nostr_sdk::prelude::SubscriptionId::new("mostro-relay-list")
 }
 
+/// Point the long-lived subscription `id` at `filter`, replacing whatever it
+/// carried before.
+///
+/// nostr-sdk 0.45 refuses a subscribe whose id already exists and keeps the
+/// old filters, so the id is closed first (a no-op when it was never open).
+/// The brief gap between CLOSE and REQ loses nothing: a node switch refetches
+/// the book right after, and the Kind-14 feed has no `since`, so its REQ
+/// replays history.
+///
+/// The SDK reports per-relay failures inside an `Ok` output, which is how a
+/// rejected re-subscribe used to pass for a live one. No relay accepting it is
+/// an error here; a partial failure is logged.
+async fn replace_subscription(
+    client: &nostr_sdk::prelude::Client,
+    id: nostr_sdk::prelude::SubscriptionId,
+    filter: nostr_sdk::prelude::Filter,
+) -> Result<()> {
+    if let Err(e) = client.unsubscribe(&id).await {
+        log::warn!("[orders] closing {id} before re-subscribing failed: {e}");
+    }
+    let output = client
+        .subscribe(filter)
+        .with_id(id.clone())
+        .await
+        .map_err(|e| anyhow::anyhow!("subscribe {id} failed: {e}"))?;
+    if output.success.is_empty() {
+        return Err(anyhow::anyhow!(
+            "subscribe {id} rejected by every relay: {:?}",
+            output.failed
+        ));
+    }
+    for (url, err) in &output.failed {
+        crate::api::logging::blog_warn(
+            "relay",
+            format!(
+                "sub {id} failed relay={} err={}",
+                crate::api::logging::display_relay(&url.to_string()),
+                crate::api::logging::sanitize_relay_text(err),
+            ),
+        );
+    }
+    Ok(())
+}
+
 /// (Re)subscribe the order-book (Kind 38383) and Mostro-reply (Kind 14)
 /// filters, author-pinned to `mostro_pubkey`.
 ///
 /// Uses **stable** subscription IDs so that calling this again for a different
-/// node REPLACES the existing author-pinned filters in place (the relay pool
-/// overwrites the subscription for a known ID) instead of leaking a second
-/// subscription that keeps the old node's events flowing.
+/// node replaces the existing author-pinned filters (see
+/// [`replace_subscription`]) instead of leaking a second subscription that
+/// keeps the old node's events flowing.
 async fn subscribe_node_filters(
     client: &nostr_sdk::prelude::Client,
     mostro_pubkey: nostr_sdk::prelude::PublicKey,
@@ -3933,16 +3977,8 @@ async fn subscribe_node_filters(
     // limit is given), so a bare `kind+author` filter comes back with the
     // node's dead history and none of the live book. See `pending_orders_filter`.
     let (pending_filter, recent_filter) = order_book_filters(&mostro_pubkey);
-    client
-        .subscribe(pending_filter)
-        .with_id(orders_subscription_id())
-        .await
-        .map_err(|e| anyhow::anyhow!("order subscribe failed: {e}"))?;
-    client
-        .subscribe(recent_filter)
-        .with_id(recent_orders_subscription_id())
-        .await
-        .map_err(|e| anyhow::anyhow!("recent-orders subscribe failed: {e}"))?;
+    replace_subscription(client, orders_subscription_id(), pending_filter).await?;
+    replace_subscription(client, recent_orders_subscription_id(), recent_filter).await?;
     crate::api::logging::blog_info(
         "relay",
         format!(
@@ -3956,11 +3992,12 @@ async fn subscribe_node_filters(
 
     // The node's NIP-65 relay list, kept live so an operator adding a relay
     // reaches running clients; applied additively by apply_relay_list_event.
-    client
-        .subscribe(crate::nostr::relay_list::relay_list_filter(&mostro_pubkey))
-        .with_id(relay_list_subscription_id())
-        .await
-        .map_err(|e| anyhow::anyhow!("relay-list subscribe failed: {e}"))?;
+    replace_subscription(
+        client,
+        relay_list_subscription_id(),
+        crate::nostr::relay_list::relay_list_filter(&mostro_pubkey),
+    )
+    .await?;
     crate::api::logging::blog_info(
         "relay",
         format!(
@@ -3982,11 +4019,7 @@ async fn subscribe_node_filters(
             .kind(nostr_sdk::prelude::Kind::PrivateDirectMessage)
             .author(mostro_pubkey)
             .pubkeys(trade_pubkeys);
-        client
-            .subscribe(dm_filter)
-            .with_id(mostro_dm_subscription_id())
-            .await
-            .map_err(|e| anyhow::anyhow!("dm subscribe failed: {e}"))?;
+        replace_subscription(client, mostro_dm_subscription_id(), dm_filter).await?;
         crate::api::logging::blog_info(
             "relay",
             format!(
@@ -4123,11 +4156,8 @@ async fn resubscribe_global_dm_filter() {
         .kind(nostr_sdk::prelude::Kind::PrivateDirectMessage)
         .author(mostro_pubkey)
         .pubkeys(trade_pubkeys);
-    if let Err(e) = pool
-        .client()
-        .subscribe(dm_filter)
-        .with_id(mostro_dm_subscription_id())
-        .await
+    if let Err(e) =
+        replace_subscription(&pool.client(), mostro_dm_subscription_id(), dm_filter).await
     {
         log::warn!("[orders] bulk DM filter refresh failed: {e}");
     } else {
@@ -5323,6 +5353,75 @@ mod tests {
                 "subscription id {id} is {len} chars; NIP-01 relays reject anything over 64"
             );
         }
+    }
+
+    /// A node switch re-runs `subscribe_node_filters` under the same stable
+    /// ids. nostr-sdk 0.45 refuses a subscribe whose id already exists and
+    /// keeps the old filters — reporting it per relay, not as an error — so
+    /// every live feed stayed pinned to the previous node until a restart.
+    #[tokio::test]
+    async fn a_node_switch_retargets_every_live_subscription() {
+        use nostr_sdk::local_relay::MockRelay;
+        use nostr_sdk::prelude::{Client, Keys};
+
+        let relay = MockRelay::run().await.expect("mock relay");
+        let url = relay.url().await;
+        let client = Client::new();
+        client.add_relay(&url).await.expect("add relay");
+        client
+            .try_connect_relay(url, std::time::Duration::from_secs(3))
+            .await
+            .expect("connect");
+        let trade = Keys::generate().public_key();
+        let previous = Keys::generate().public_key();
+        let next = Keys::generate().public_key();
+
+        subscribe_node_filters(&client, previous, vec![trade])
+            .await
+            .expect("first subscribe");
+        subscribe_node_filters(&client, next, vec![trade])
+            .await
+            .expect("node switch");
+
+        for id in [
+            orders_subscription_id(),
+            recent_orders_subscription_id(),
+            relay_list_subscription_id(),
+            mostro_dm_subscription_id(),
+        ] {
+            let per_relay = client.subscription(&id).await;
+            assert!(!per_relay.is_empty(), "{id} has no live subscription");
+            for filter in per_relay.values().flatten() {
+                assert_eq!(
+                    filter.authors,
+                    Some(std::collections::BTreeSet::from([next])),
+                    "{id} is still pinned to the previous node"
+                );
+            }
+        }
+    }
+
+    /// The SDK reports a subscribe that failed on every relay as an `Ok`
+    /// output. Accepting that meant a feed with no REQ anywhere was logged
+    /// as created; a relay that was never connected must make it an error.
+    #[tokio::test]
+    async fn a_subscription_no_relay_accepts_is_an_error() {
+        use nostr_sdk::local_relay::MockRelay;
+        use nostr_sdk::prelude::{Client, Keys};
+
+        let relay = MockRelay::run().await.expect("mock relay");
+        let client = Client::new();
+        client
+            .add_relay(relay.url().await)
+            .await
+            .expect("add relay");
+
+        let result = subscribe_node_filters(&client, Keys::generate().public_key(), vec![]).await;
+
+        assert!(
+            result.is_err(),
+            "a subscription no relay accepted must not pass for a live one"
+        );
     }
 
     /// The truncation that keeps the daemon id under the cap must not merge

--- a/specs/004-mostro-p2p-client/contracts/orders.md
+++ b/specs/004-mostro-p2p-client/contracts/orders.md
@@ -334,7 +334,10 @@ Coverage invariants:
   `ensure_global_dm_coverage`, which inserts the key and re-issues the
   relay filter under the same stable subscription id — closing that id
   first, since nostr-sdk 0.45 rejects a duplicate id and keeps the stale
-  filter (`replace_subscription`).
+  filter (`replace_subscription`). Every re-issue — this one and a node
+  switch's — goes through `replace_global_dm_filter`, which reads the map and
+  replaces the filter under one lock: interleaved CLOSE/REQ pairs would
+  otherwise keep an older key set or fail with a duplicate id.
 - **The relay filter is always rebuilt from the full map** — never from
   session-local state. A rebuild from a subset silently unsubscribes the
   missing trades at the relay.

--- a/specs/004-mostro-p2p-client/contracts/orders.md
+++ b/specs/004-mostro-p2p-client/contracts/orders.md
@@ -332,7 +332,9 @@ Coverage invariants:
   a create/take in flight must survive the seed.
 - **Mid-session keys join incrementally**: every derive path calls
   `ensure_global_dm_coverage`, which inserts the key and re-issues the
-  relay filter under the same stable subscription id.
+  relay filter under the same stable subscription id — closing that id
+  first, since nostr-sdk 0.45 rejects a duplicate id and keeps the stale
+  filter (`replace_subscription`).
 - **The relay filter is always rebuilt from the full map** — never from
   session-local state. A rebuild from a subset silently unsubscribes the
   missing trades at the relay.

--- a/specs/004-mostro-p2p-client/contracts/settings.md
+++ b/specs/004-mostro-p2p-client/contracts/settings.md
@@ -99,9 +99,11 @@ validates it, persists it as the active node's **identity**, updates the
 in-memory override (so outgoing events target the new node immediately), and
 re-targets the live feeds to it: the order book is cleared, the Kind 38383
 (orders) and Kind 14 (Mostro replies) filters are re-subscribed — author-pinned
-to the new node via stable subscription IDs so the old filters are replaced in
-place — the node's current orders are refetched, and its PoW requirement is
-refreshed.
+to the new node under the same stable subscription IDs, each closed before it is
+re-issued, because nostr-sdk 0.45 rejects a subscribe whose ID already exists and
+keeps the old filters — the node's current orders are refetched, and its PoW
+requirement is refreshed. A re-subscribe that no relay accepts is an error, not
+a silent success.
 
 The switch is **purely local**: no Nostr message is sent to either node. Pass
 `DEFAULT_MOSTRO_PUBKEY` to return to the default node.


### PR DESCRIPTION
## Problem

Switching the active Mostro node (Settings → node pubkey) did not refresh the order book: it kept showing the previous node's orders until the app was killed and reopened.

`set_mostro_pubkey` re-runs `subscribe_node_filters` under the same **stable** subscription ids, on the assumption that the pool replaces the filters in place. nostr-sdk 0.45 does not: a subscribe whose id already exists is rejected with `subscription ID already exists` and the **old filters stay live**. The rejection is reported per relay inside an `Ok` output, so the call looked successful and nothing was logged.

Affected feeds, all left pinned to the previous node:
- order book: Kind 38383 (pending and recent filters)
- node NIP-65 relay list (Kind 10002)
- bulk Kind 14 Mostro-reply feed (also refreshed by `resubscribe_global_dm_filter` whenever a trade key joins mid-session)

## Fix

New `replace_subscription` helper in `rust/src/api/orders.rs`:
- closes the id before re-issuing it (a no-op when it was never open). The CLOSE→REQ gap loses nothing: a node switch refetches the book right after, and the Kind 14 feed has no `since`, so its REQ replays history.
- treats a subscribe that **no** relay accepted as an error instead of a silent success; partial per-relay failures are logged.

Every stable-id call in `subscribe_node_filters` and `resubscribe_global_dm_filter` goes through it. Per-trade, per-order and per-chat subscriptions (`subscribe_daemon_messages`, `subscribe_single_order`, `subscribe_incoming_chat`) are keyed per entity and closed when their task ends, so they are left as they were.

Contracts updated: `contracts/settings.md` (node switch) and `contracts/orders.md` (global DM coverage).

## Tests

Two regression tests against nostr-sdk's in-process `MockRelay`, added as a native-only dev-dependency (`local-relay` feature) that doesn't touch the wasm build:
- `a_node_switch_retargets_every_live_subscription`: subscribes for node A, switches to B, then asserts that all four stable ids are pinned to B. Without the fix it fails with `subscription ID already exists`.
- `a_subscription_no_relay_accepts_is_an_error`: a feed with no REQ on any relay must not pass for a live one.

No public API change, so FRB bindings are unaffected (`frb-generate.sh --check` passes).

## Test plan

- [x] `cargo test` (all green)
- [x] `cargo clippy -D warnings`, `cargo check --target wasm32-unknown-unknown`
- [x] `flutter analyze`
- [x] New test fails with the `unsubscribe` removed
- [ ] Manual: on a device, switch from the default node to a local Mostro and confirm the order book shows the new node's orders without restarting the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KgxjStAAa8CVE7LcNVigFX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed subscription updates when switching active nodes, ensuring order, relay-list, and direct-message filters target the new node correctly.
  - Rejected subscription attempts when no relay accepts them, instead of reporting success.
  - Prevented stale filters from remaining active during subscription refreshes.

- **Documentation**
  - Updated order and settings documentation to describe subscription replacement behavior and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->