### PR TITLE
fix(orders): publish the book on EOSE so an empty book leaves the skeleton

### DIFF
--- a/lib/features/home/providers/home_order_providers.dart
+++ b/lib/features/home/providers/home_order_providers.dart
@@ -280,6 +280,10 @@ final orderBookProvider = StreamProvider.autoDispose<List<OrderItem>>((
   // Fast-exit shimmer only if the cache already has orders. If the cache is
   // empty we stay in loading state until the relay delivers the first update,
   // preventing an "No orders available" flash before any relay data arrives.
+  // An empty book is confirmed by the relay's EOSE on the pending-book
+  // subscription, which Rust publishes as an (empty) update — without that
+  // this would wait forever whenever the book is empty, both on a cold start
+  // and every time this provider is re-created after the last order left.
   final snapshot = await orders_api.getOrders(filters: null);
   debugPrint('[orderBook] initial snapshot: ${snapshot.length} orders');
   if (snapshot.isNotEmpty) {

--- a/rust/src/api/orders.rs
+++ b/rust/src/api/orders.rs
@@ -330,6 +330,30 @@ impl OrderBook {
         });
     }
 
+    /// Publish the current book when a relay reports the end of stored events
+    /// for the pending-book subscription. Returns whether it published.
+    ///
+    /// Every other emission is driven by an order arriving, so a node with
+    /// no pending orders never emits: the UI (which stays in its loading
+    /// state until the first emission, so an empty book is not flashed
+    /// before the relay answers) then waits forever — on a cold start
+    /// against an empty book, and every time the book screen remounts after
+    /// the last order left the book. EOSE is the relay confirming there is
+    /// nothing more to send, which is exactly the signal the UI is waiting
+    /// on. Only the pending feed counts: the recent-changes and Kind 14
+    /// feeds end their stored events too, and publishing on each would send
+    /// the whole book once per relay per subscription.
+    pub(crate) async fn publish_on_stored_events_end(
+        &self,
+        sub_id: &nostr_sdk::prelude::SubscriptionId,
+    ) -> bool {
+        if *sub_id != orders_subscription_id() {
+            return false;
+        }
+        self.publish().await;
+        true
+    }
+
     /// Publish the current book to subscribers.
     pub(crate) async fn publish(&self) {
         let snapshot = self.orders.read().await.clone();
@@ -4633,6 +4657,10 @@ async fn _run_order_subscription() {
                                 crate::api::logging::display_relay(&relay_url.to_string()),
                             ),
                         );
+                        // An empty book is only ever confirmed by this: the
+                        // stream otherwise emits on ingest alone, and the UI
+                        // shows its loading state until the first emission.
+                        order_book().publish_on_stored_events_end(&sub_id).await;
                     }
                     RelayMessage::Closed {
                         subscription_id,
@@ -5666,6 +5694,44 @@ mod tests {
             misses.len() <= TRADE_KEY_MISS_CAPACITY,
             "miss cache grew to {}",
             misses.len()
+        );
+    }
+
+    /// The relay's EOSE on the pending-book subscription is the only signal
+    /// that an empty book is *confirmed* empty. Without it the UI has nothing
+    /// to leave its loading state on: the stream publishes on ingest alone,
+    /// and a node with no pending orders never ingests anything.
+    #[tokio::test]
+    async fn eose_on_the_pending_subscription_publishes_the_empty_book() {
+        let book = OrderBook::new();
+        let mut rx = book.subscribe();
+
+        let published = book
+            .publish_on_stored_events_end(&orders_subscription_id())
+            .await;
+
+        assert!(published);
+        let snapshot = rx.try_recv().expect("EOSE must publish the current book");
+        assert!(snapshot.is_empty(), "an empty book is published as empty");
+    }
+
+    /// Only the pending-book feed is the "book loaded" signal. The recent
+    /// changes feed and the Kind 14 feed end their stored events too, and
+    /// re-publishing on each would send the whole book across the bridge
+    /// once per relay per subscription.
+    #[tokio::test]
+    async fn eose_on_other_subscriptions_does_not_publish() {
+        let book = OrderBook::new();
+        let mut rx = book.subscribe();
+
+        let published = book
+            .publish_on_stored_events_end(&recent_orders_subscription_id())
+            .await;
+
+        assert!(!published);
+        assert!(
+            matches!(rx.try_recv(), Err(broadcast::error::TryRecvError::Empty)),
+            "EOSE on another subscription must not publish"
         );
     }
 


### PR DESCRIPTION
## Problem

After completing a trade (the only order in the book), the Book tab in both apps showed the loading skeleton forever instead of the empty state.

`orderBookProvider` deliberately stays in loading while the initial snapshot is empty (93caf47, avoids flashing "No orders" before the relay answers) and waits for the first Rust emission. But Rust only emitted on ingest, a refetch (node switch / manual refresh) or a clear. With no pending orders on the node nothing is ever ingested, so nothing is emitted:

- on a cold start against an empty book, and
- every time the tab remounts (the provider is `autoDispose`) after the last order left the book — the completed order stays cached as ours but `get_orders` only returns `pending`.

## Fix

Publish the current book when a relay reports `EOSE` on the pending-book subscription (`mostro-orders`). That is the relay confirming there is nothing more to send, which is exactly the signal the UI waits for. Only that feed counts — the recent-changes and Kind 14 feeds also end their stored events, and publishing on each would send the whole book once per relay per subscription.

No bridge surface change (no FRB regen needed). The Dart provider is untouched apart from a comment explaining the dependency.

## Tests

- `eose_on_the_pending_subscription_publishes_the_empty_book` (written first, RED → GREEN)
- `eose_on_other_subscriptions_does_not_publish`

`cargo test --lib`: 459 passed. `cargo clippy` / `cargo fmt --check`: no new findings (the pre-existing ones are on `main`). `flutter analyze lib/features/home`: clean.

## Test plan

- [ ] Node with zero orders: open the app → Book shows the empty state, not the skeleton
- [ ] Create + complete the only order, go to Trades and back to Book → empty state
- [ ] Node with orders: Book still populates and live updates keep working

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDMrXpsJZ7ErvBxXdw6DwN
