### PR TITLE
feat(bond): PR-3a — bond payout claim store (SQLite and IndexedDB)

### DIFF
--- a/rust/src/api/identity.rs
+++ b/rust/src/api/identity.rs
@@ -797,6 +797,22 @@ mod tests {
         ) -> Result<()> {
             unimplemented!()
         }
+        async fn save_bond_claim(&self, _claim: &crate::api::types::BondClaim) -> Result<()> {
+            unimplemented!()
+        }
+        async fn get_bond_claim(
+            &self,
+            _node_pubkey: &str,
+            _order_id: &str,
+        ) -> Result<Option<crate::api::types::BondClaim>> {
+            unimplemented!()
+        }
+        async fn list_bond_claims(&self) -> Result<Vec<crate::api::types::BondClaim>> {
+            unimplemented!()
+        }
+        async fn delete_bond_claim(&self, _node_pubkey: &str, _order_id: &str) -> Result<()> {
+            unimplemented!()
+        }
         async fn save_queued_message(
             &self,
             _msg: &crate::queue::outbox::QueuedMessage,

--- a/rust/src/api/types.rs
+++ b/rust/src/api/types.rs
@@ -741,6 +741,79 @@ pub struct BondSlashedEvent {
     pub cause: SlashCause,
 }
 
+/// Where a payout claim stands (docs/ANTI_ABUSE_BOND.md §6.4): the daemon
+/// asked for an invoice, the user sent one, the daemon accepted it, the
+/// share was paid — or the claim window closed first.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum BondClaimPhase {
+    /// `add-bond-invoice` received, no invoice sent (or the daemon re-prompted).
+    Pending,
+    /// The user's bolt11 was published; the daemon has not answered yet.
+    Submitted,
+    /// `bond-invoice-accepted`: the payout is in progress.
+    Acknowledged,
+    /// `bond-payout-completed`: the share was paid.
+    Completed,
+    /// The claim window closed unclaimed.
+    Expired,
+}
+
+impl BondClaimPhase {
+    /// A phase nothing follows: the daemon stops retrying and the kind-14
+    /// filter no longer needs the issuing node for this claim.
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, BondClaimPhase::Completed | BondClaimPhase::Expired)
+    }
+}
+
+/// The counterparty's share of a slashed bond this user may claim
+/// (docs/ANTI_ABUSE_BOND.md §6.4, §7.1). Independent of the trade row: the
+/// winner's trade may be completed, cancelled or wiped by the time the
+/// daemon asks for an invoice. Keyed by `(node_pubkey, order_id)`: the user
+/// can switch nodes while a claim is open, and the submission always
+/// addresses the daemon that issued it.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct BondClaim {
+    pub order_id: String,
+    /// The daemon that issued the claim; the submission target.
+    pub node_pubkey: String,
+    /// The share on offer, in satoshis; the invoice must be for exactly this.
+    pub amount_sats: u64,
+    /// Unix seconds when the daemon slashed the bond, from the request.
+    pub slashed_at: i64,
+    /// `slashed_at + claim window`, frozen when the claim is first persisted:
+    /// a later policy change cannot move a deadline the user was shown.
+    pub deadline_at: i64,
+    pub phase: BondClaimPhase,
+    /// The bolt11 sent, kept so the screen can show it while the daemon answers.
+    pub submitted_invoice: Option<String>,
+    /// Display only, from the request's order.
+    pub fiat_code: String,
+    pub fiat_amount: Option<f64>,
+    pub payment_method: String,
+    /// Unix seconds of the last change, the list's sort key.
+    pub updated_at: i64,
+}
+
+impl BondClaim {
+    /// The storage key: `<node_pubkey>:<order_id>`.
+    pub fn storage_id(&self) -> String {
+        bond_claim_key(&self.node_pubkey, &self.order_id)
+    }
+}
+
+/// The `bond_claims` key for a node / order pair.
+pub fn bond_claim_key(node_pubkey: &str, order_id: &str) -> String {
+    format!("{node_pubkey}:{order_id}")
+}
+
+/// A claim's phase changed (new claim, submission, ack, payout, expiry).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct BondClaimUpdate {
+    pub order_id: String,
+    pub phase: BondClaimPhase,
+}
+
 /// Connected wallet information returned by `connect_wallet` and `get_wallet`.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct NwcWalletInfo {

--- a/rust/src/db/indexeddb.rs
+++ b/rust/src/db/indexeddb.rs
@@ -27,7 +27,7 @@ use crate::db::{trade_json, web_lock, Storage};
 use crate::queue::outbox::QueuedMessage;
 
 /// Bumped when a store is added; `open_db` creates whatever is missing.
-const DB_VERSION: u32 = 3;
+const DB_VERSION: u32 = 4;
 const MESSAGES_STORE: &str = "messages";
 const SETTINGS_STORE: &str = "settings";
 const TRADES_STORE: &str = "trades";
@@ -36,13 +36,14 @@ const ORDERS_STORE: &str = "orders";
 const RELAYS_STORE: &str = "relays";
 const IDENTITY_STORE: &str = "identity";
 const OUTBOX_STORE: &str = "queued_messages";
+const BOND_CLAIMS_STORE: &str = "bond_claims";
 /// The single identity document's key, mirroring SQLite's `id = 1` row.
 const IDENTITY_KEY: &str = "1";
 /// Origin-wide lock names (see [`web_lock`]): one per store whose documents
 /// are read, changed and written back as a whole.
 const TRADES_LOCK: &str = "mostro:db:trades";
 const OUTBOX_LOCK: &str = "mostro:db:queued_messages";
-const ALL_STORES: [&str; 8] = [
+const ALL_STORES: [&str; 9] = [
     MESSAGES_STORE,
     SETTINGS_STORE,
     TRADES_STORE,
@@ -51,6 +52,7 @@ const ALL_STORES: [&str; 8] = [
     RELAYS_STORE,
     IDENTITY_STORE,
     OUTBOX_STORE,
+    BOND_CLAIMS_STORE,
 ];
 
 /// Map an opaque JS-side error into an `anyhow` error the trait can carry.
@@ -580,6 +582,55 @@ impl Storage for IndexedDbStorage {
         self.patch_trade_by_order_id(order_id, |doc| {
             trade_json::set_counterparty(doc, counterparty_pubkey)
         })
+        .await
+    }
+
+    // ── Bond payout claims — whole-document, keyed by node:order ────────────
+
+    async fn save_bond_claim(&self, claim: &crate::api::types::BondClaim) -> Result<()> {
+        let json = serde_json::to_string(claim)?;
+        self.put_string(BOND_CLAIMS_STORE, &claim.storage_id(), &json)
+            .await
+    }
+
+    async fn get_bond_claim(
+        &self,
+        node_pubkey: &str,
+        order_id: &str,
+    ) -> Result<Option<crate::api::types::BondClaim>> {
+        Ok(self
+            .get_string(
+                BOND_CLAIMS_STORE,
+                &crate::api::types::bond_claim_key(node_pubkey, order_id),
+            )
+            .await?
+            .map(|json| serde_json::from_str(&json))
+            .transpose()?)
+    }
+
+    async fn list_bond_claims(&self) -> Result<Vec<crate::api::types::BondClaim>> {
+        let mut claims: Vec<crate::api::types::BondClaim> = self
+            .get_all_strings(BOND_CLAIMS_STORE)
+            .await?
+            .into_iter()
+            .filter_map(|json| match serde_json::from_str(&json) {
+                Ok(claim) => Some(claim),
+                Err(e) => {
+                    log::warn!("[db] skipping bond claim: deserialization failed: {e}");
+                    None
+                }
+            })
+            .collect();
+        // Same order as SQLite: most recently changed first.
+        claims.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+        Ok(claims)
+    }
+
+    async fn delete_bond_claim(&self, node_pubkey: &str, order_id: &str) -> Result<()> {
+        self.delete_key(
+            BOND_CLAIMS_STORE,
+            &crate::api::types::bond_claim_key(node_pubkey, order_id),
+        )
         .await
     }
 }

--- a/rust/src/db/mod.rs
+++ b/rust/src/db/mod.rs
@@ -304,4 +304,22 @@ pub trait Storage: Send + Sync {
         order_id: &str,
         counterparty_pubkey: &str,
     ) -> Result<()>;
+
+    // ── Bond payout claims (docs/ANTI_ABUSE_BOND.md §6.4) ───────────────────
+
+    /// Insert or replace the claim keyed by its `(node_pubkey, order_id)`.
+    async fn save_bond_claim(&self, claim: &crate::api::types::BondClaim) -> Result<()>;
+
+    /// The claim a node issued for an order, if any.
+    async fn get_bond_claim(
+        &self,
+        node_pubkey: &str,
+        order_id: &str,
+    ) -> Result<Option<crate::api::types::BondClaim>>;
+
+    /// Every claim, most recently changed first.
+    async fn list_bond_claims(&self) -> Result<Vec<crate::api::types::BondClaim>>;
+
+    /// Remove one claim. No-op when absent.
+    async fn delete_bond_claim(&self, node_pubkey: &str, order_id: &str) -> Result<()>;
 }

--- a/rust/src/db/schema.rs
+++ b/rust/src/db/schema.rs
@@ -1,6 +1,6 @@
 /// Database schema version. Currently unused at runtime — kept as a reference
 /// for future migration logic (e.g. ALTER TABLE guards or schema-diff checks).
-pub const SCHEMA_VERSION: u32 = 3;
+pub const SCHEMA_VERSION: u32 = 4;
 
 /// One-off rebuild for databases created while `messages` still carried a
 /// foreign key to `trades(id)` (schema v2). SQLite cannot drop a FK in place,
@@ -116,4 +116,18 @@ CREATE TABLE IF NOT EXISTS trade_keys (
     order_id        TEXT PRIMARY KEY,
     key_index       INTEGER NOT NULL
 );
+
+-- Payout claims on slashed bonds (docs/ANTI_ABUSE_BOND.md §6.4, §7.3).
+-- Independent of `trades`: the winner's row may be gone by the time the
+-- daemon asks for an invoice. Keyed by the issuing node and the order,
+-- since the user can switch nodes while a claim is open.
+CREATE TABLE IF NOT EXISTS bond_claims (
+    id              TEXT PRIMARY KEY NOT NULL,   -- "<node_pubkey>:<order_id>"
+    node_pubkey     TEXT NOT NULL,
+    data            TEXT NOT NULL,               -- JSON-serialised BondClaim
+    phase           TEXT NOT NULL,
+    deadline_at     INTEGER NOT NULL,
+    updated_at      INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_bond_claims_node ON bond_claims(node_pubkey, phase);
 "#;

--- a/rust/src/db/sqlite.rs
+++ b/rust/src/db/sqlite.rs
@@ -701,6 +701,60 @@ impl Storage for SqliteStorage {
         Ok(())
     }
 
+    async fn save_bond_claim(&self, claim: &crate::api::types::BondClaim) -> Result<()> {
+        let data = serde_json::to_string(claim)?;
+        sqlx::query(
+            "INSERT OR REPLACE INTO bond_claims \
+             (id, node_pubkey, data, phase, deadline_at, updated_at) \
+             VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(claim.storage_id())
+        .bind(&claim.node_pubkey)
+        .bind(&data)
+        .bind(format!("{:?}", claim.phase))
+        .bind(claim.deadline_at)
+        .bind(claim.updated_at)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn get_bond_claim(
+        &self,
+        node_pubkey: &str,
+        order_id: &str,
+    ) -> Result<Option<crate::api::types::BondClaim>> {
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT data FROM bond_claims WHERE id = ?")
+                .bind(crate::api::types::bond_claim_key(node_pubkey, order_id))
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(row.map(|(data,)| serde_json::from_str(&data)).transpose()?)
+    }
+
+    async fn list_bond_claims(&self) -> Result<Vec<crate::api::types::BondClaim>> {
+        let rows: Vec<(String, String)> =
+            sqlx::query_as("SELECT id, data FROM bond_claims ORDER BY updated_at DESC")
+                .fetch_all(&self.pool)
+                .await?;
+        let mut claims = Vec::with_capacity(rows.len());
+        for (id, data) in rows {
+            match serde_json::from_str::<crate::api::types::BondClaim>(&data) {
+                Ok(claim) => claims.push(claim),
+                Err(e) => log::warn!("[db] skipping bond claim {id}: deserialization failed: {e}"),
+            }
+        }
+        Ok(claims)
+    }
+
+    async fn delete_bond_claim(&self, node_pubkey: &str, order_id: &str) -> Result<()> {
+        sqlx::query("DELETE FROM bond_claims WHERE id = ?")
+            .bind(crate::api::types::bond_claim_key(node_pubkey, order_id))
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
     async fn mark_trade_rated(&self, order_id: &str, rated_at: i64) -> Result<()> {
         // Bind via json(?) so SQLite stores the timestamp as a JSON number, not
         // a string — a string would fail to deserialize back into Option<i64>.
@@ -750,6 +804,60 @@ mod tests {
         static COUNTER: AtomicU32 = AtomicU32::new(0);
         let n = COUNTER.fetch_add(1, Ordering::Relaxed);
         std::env::temp_dir().join(format!("mostro_test_{}_{n}.db", std::process::id()))
+    }
+
+    fn claim(node: &str, order: &str, phase: crate::api::types::BondClaimPhase, updated_at: i64)
+        -> crate::api::types::BondClaim {
+        crate::api::types::BondClaim {
+            order_id: order.to_string(),
+            node_pubkey: node.to_string(),
+            amount_sats: 1_500,
+            slashed_at: 1_000,
+            deadline_at: 1_000 + 15 * 86_400,
+            phase,
+            submitted_invoice: None,
+            fiat_code: "VES".to_string(),
+            fiat_amount: Some(100.0),
+            payment_method: "PagoMovil".to_string(),
+            updated_at,
+        }
+    }
+
+    /// docs/ANTI_ABUSE_BOND.md §7.3: a claim round-trips whole, keyed by
+    /// `(node, order)`, so the same order slashed on two nodes is two claims
+    /// and a save on an existing key replaces it.
+    #[tokio::test]
+    async fn bond_claims_round_trip_keyed_by_node_and_order() {
+        use crate::api::types::BondClaimPhase;
+        let path = temp_db_path();
+        let storage = SqliteStorage::open(path.to_str().unwrap()).await.unwrap();
+
+        let a = claim("node-a", "order-1", BondClaimPhase::Pending, 10);
+        let b = claim("node-b", "order-1", BondClaimPhase::Acknowledged, 20);
+        storage.save_bond_claim(&a).await.unwrap();
+        storage.save_bond_claim(&b).await.unwrap();
+
+        assert_eq!(storage.get_bond_claim("node-a", "order-1").await.unwrap(), Some(a.clone()));
+        assert_eq!(storage.get_bond_claim("node-b", "order-1").await.unwrap(), Some(b.clone()));
+        assert_eq!(storage.get_bond_claim("node-a", "order-2").await.unwrap(), None);
+
+        // Newest change first.
+        let listed = storage.list_bond_claims().await.unwrap();
+        assert_eq!(listed, vec![b.clone(), a.clone()]);
+
+        // Same key: replaced, not duplicated.
+        let mut a2 = a.clone();
+        a2.phase = BondClaimPhase::Submitted;
+        a2.submitted_invoice = Some("lnbc1x".to_string());
+        a2.updated_at = 30;
+        storage.save_bond_claim(&a2).await.unwrap();
+        let listed = storage.list_bond_claims().await.unwrap();
+        assert_eq!(listed, vec![a2.clone(), b.clone()]);
+
+        // Delete removes only the matching key; absent keys are a no-op.
+        storage.delete_bond_claim("node-a", "order-1").await.unwrap();
+        storage.delete_bond_claim("node-a", "order-1").await.unwrap();
+        assert_eq!(storage.list_bond_claims().await.unwrap(), vec![b]);
     }
 
     /// A status sync that matches no row used to be indistinguishable from one

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -49,7 +49,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 713723940;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -415503637;
 
 // Section: executor
 
@@ -1630,6 +1630,112 @@ fn wire__crate__api__nostr__add_relay_impl(
                     })()
                     .await,
                 )
+            }
+        },
+    )
+}
+fn wire__crate__api__types__bond_claim_key_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "bond_claim_key",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_node_pubkey = <String>::sse_decode(&mut deserializer);
+            let api_order_id = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, ()>((move || {
+                    let output_ok = Result::<_, ()>::Ok(crate::api::types::bond_claim_key(
+                        &api_node_pubkey,
+                        &api_order_id,
+                    ))?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__types__bond_claim_phase_is_terminal_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "bond_claim_phase_is_terminal",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <crate::api::types::BondClaimPhase>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, ()>((move || {
+                    let output_ok = Result::<_, ()>::Ok(
+                        crate::api::types::BondClaimPhase::is_terminal(&api_that),
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__types__bond_claim_storage_id_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "bond_claim_storage_id",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <crate::api::types::BondClaim>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, ()>((move || {
+                    let output_ok =
+                        Result::<_, ()>::Ok(crate::api::types::BondClaim::storage_id(&api_that))?;
+                    Ok(output_ok)
+                })())
             }
         },
     )
@@ -6164,6 +6270,51 @@ impl SseDecode for crate::api::types::BondApplyTo {
     }
 }
 
+impl SseDecode for crate::api::types::BondClaim {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_orderId = <String>::sse_decode(deserializer);
+        let mut var_nodePubkey = <String>::sse_decode(deserializer);
+        let mut var_amountSats = <u64>::sse_decode(deserializer);
+        let mut var_slashedAt = <i64>::sse_decode(deserializer);
+        let mut var_deadlineAt = <i64>::sse_decode(deserializer);
+        let mut var_phase = <crate::api::types::BondClaimPhase>::sse_decode(deserializer);
+        let mut var_submittedInvoice = <Option<String>>::sse_decode(deserializer);
+        let mut var_fiatCode = <String>::sse_decode(deserializer);
+        let mut var_fiatAmount = <Option<f64>>::sse_decode(deserializer);
+        let mut var_paymentMethod = <String>::sse_decode(deserializer);
+        let mut var_updatedAt = <i64>::sse_decode(deserializer);
+        return crate::api::types::BondClaim {
+            order_id: var_orderId,
+            node_pubkey: var_nodePubkey,
+            amount_sats: var_amountSats,
+            slashed_at: var_slashedAt,
+            deadline_at: var_deadlineAt,
+            phase: var_phase,
+            submitted_invoice: var_submittedInvoice,
+            fiat_code: var_fiatCode,
+            fiat_amount: var_fiatAmount,
+            payment_method: var_paymentMethod,
+            updated_at: var_updatedAt,
+        };
+    }
+}
+
+impl SseDecode for crate::api::types::BondClaimPhase {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <i32>::sse_decode(deserializer);
+        return match inner {
+            0 => crate::api::types::BondClaimPhase::Pending,
+            1 => crate::api::types::BondClaimPhase::Submitted,
+            2 => crate::api::types::BondClaimPhase::Acknowledged,
+            3 => crate::api::types::BondClaimPhase::Completed,
+            4 => crate::api::types::BondClaimPhase::Expired,
+            _ => unreachable!("Invalid variant for BondClaimPhase: {}", inner),
+        };
+    }
+}
+
 impl SseDecode for crate::api::types::BondInfo {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -7840,297 +7991,307 @@ fn pde_ffi_dispatcher_primary_impl(
             wire__crate__api__nodes__add_custom_mostro_node_impl(port, ptr, rust_vec_len, data_len)
         }
         29 => wire__crate__api__nostr__add_relay_impl(port, ptr, rust_vec_len, data_len),
-        30 => wire__crate__api__types__bond_policy_default_impl(port, ptr, rust_vec_len, data_len),
-        31 => wire__crate__api__types__bond_policy_info_default_impl(
+        30 => wire__crate__api__types__bond_claim_key_impl(port, ptr, rust_vec_len, data_len),
+        31 => wire__crate__api__types__bond_claim_phase_is_terminal_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        32 => wire__crate__api__orders__cancel_order_impl(port, ptr, rust_vec_len, data_len),
-        33 => wire__crate__api__cashu__cashu_connect_impl(port, ptr, rust_vec_len, data_len),
-        34 => wire__crate__api__cashu__cashu_create_token_impl(port, ptr, rust_vec_len, data_len),
-        35 => wire__crate__api__cashu__cashu_disconnect_impl(port, ptr, rust_vec_len, data_len),
-        36 => wire__crate__api__cashu__cashu_get_balance_impl(port, ptr, rust_vec_len, data_len),
-        37 => wire__crate__api__cashu__cashu_receive_token_impl(port, ptr, rust_vec_len, data_len),
-        38 => wire__crate__api__cashu__cashu_status_impl(port, ptr, rust_vec_len, data_len),
-        39 => wire__crate__api__cashu__cashu_sweep_spent_proofs_impl(
+        32 => {
+            wire__crate__api__types__bond_claim_storage_id_impl(port, ptr, rust_vec_len, data_len)
+        }
+        33 => wire__crate__api__types__bond_policy_default_impl(port, ptr, rust_vec_len, data_len),
+        34 => wire__crate__api__types__bond_policy_info_default_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        40 => {
+        35 => wire__crate__api__orders__cancel_order_impl(port, ptr, rust_vec_len, data_len),
+        36 => wire__crate__api__cashu__cashu_connect_impl(port, ptr, rust_vec_len, data_len),
+        37 => wire__crate__api__cashu__cashu_create_token_impl(port, ptr, rust_vec_len, data_len),
+        38 => wire__crate__api__cashu__cashu_disconnect_impl(port, ptr, rust_vec_len, data_len),
+        39 => wire__crate__api__cashu__cashu_get_balance_impl(port, ptr, rust_vec_len, data_len),
+        40 => wire__crate__api__cashu__cashu_receive_token_impl(port, ptr, rust_vec_len, data_len),
+        41 => wire__crate__api__cashu__cashu_status_impl(port, ptr, rust_vec_len, data_len),
+        42 => wire__crate__api__cashu__cashu_sweep_spent_proofs_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        43 => {
             wire__crate__api__invoice__check_buyer_invoice_impl(port, ptr, rust_vec_len, data_len)
         }
-        41 => wire__crate__api__invoice__classify_payment_destination_impl(
+        44 => wire__crate__api__invoice__classify_payment_destination_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        42 => wire__crate__api__logging__clear_logs_impl(port, ptr, rust_vec_len, data_len),
-        43 => wire__crate__api__bond__close_expired_bond_window_impl(
+        45 => wire__crate__api__logging__clear_logs_impl(port, ptr, rust_vec_len, data_len),
+        46 => wire__crate__api__bond__close_expired_bond_window_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        44 => wire__crate__api__nwc__connect_wallet_impl(port, ptr, rust_vec_len, data_len),
-        45 => wire__crate__api__identity__create_identity_impl(port, ptr, rust_vec_len, data_len),
-        46 => wire__crate__api__orders__create_order_impl(port, ptr, rust_vec_len, data_len),
-        47 => wire__crate__api__invoice__decode_bolt11_impl(port, ptr, rust_vec_len, data_len),
-        48 => wire__crate__api__identity__delete_identity_impl(port, ptr, rust_vec_len, data_len),
-        49 => wire__crate__api__identity__derive_trade_key_impl(port, ptr, rust_vec_len, data_len),
-        50 => wire__crate__api__nwc__disconnect_wallet_impl(port, ptr, rust_vec_len, data_len),
-        51 => {
+        47 => wire__crate__api__nwc__connect_wallet_impl(port, ptr, rust_vec_len, data_len),
+        48 => wire__crate__api__identity__create_identity_impl(port, ptr, rust_vec_len, data_len),
+        49 => wire__crate__api__orders__create_order_impl(port, ptr, rust_vec_len, data_len),
+        50 => wire__crate__api__invoice__decode_bolt11_impl(port, ptr, rust_vec_len, data_len),
+        51 => wire__crate__api__identity__delete_identity_impl(port, ptr, rust_vec_len, data_len),
+        52 => wire__crate__api__identity__derive_trade_key_impl(port, ptr, rust_vec_len, data_len),
+        53 => wire__crate__api__nwc__disconnect_wallet_impl(port, ptr, rust_vec_len, data_len),
+        54 => {
             wire__crate__api__messages__download_attachment_impl(port, ptr, rust_vec_len, data_len)
         }
-        52 => wire__crate__api__bond__estimate_bond_sats_impl(port, ptr, rust_vec_len, data_len),
-        53 => wire__crate__api__identity__export_encrypted_backup_impl(
+        55 => wire__crate__api__bond__estimate_bond_sats_impl(port, ptr, rust_vec_len, data_len),
+        56 => wire__crate__api__identity__export_encrypted_backup_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        54 => wire__crate__api__nostr__fetch_exchange_rate_impl(port, ptr, rust_vec_len, data_len),
-        55 => wire__crate__api__nostr__fetch_mostro_instance_tags_impl(
+        57 => wire__crate__api__nostr__fetch_exchange_rate_impl(port, ptr, rust_vec_len, data_len),
+        58 => wire__crate__api__nostr__fetch_mostro_instance_tags_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        56 => wire__crate__api__node_stats__fetch_mostro_node_stats_impl(
+        59 => wire__crate__api__node_stats__fetch_mostro_node_stats_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        57 => wire__crate__api__nostr__flush_message_queue_impl(port, ptr, rust_vec_len, data_len),
-        58 => wire__crate__api__get_app_version_impl(port, ptr, rust_vec_len, data_len),
-        59 => wire__crate__api__messages__get_attachment_status_impl(
+        60 => wire__crate__api__nostr__flush_message_queue_impl(port, ptr, rust_vec_len, data_len),
+        61 => wire__crate__api__get_app_version_impl(port, ptr, rust_vec_len, data_len),
+        62 => wire__crate__api__messages__get_attachment_status_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        60 => wire__crate__api__nwc__get_balance_impl(port, ptr, rust_vec_len, data_len),
-        61 => wire__crate__api__bond__get_bond_policy_impl(port, ptr, rust_vec_len, data_len),
-        62 => wire__crate__api__nostr__get_connection_state_impl(port, ptr, rust_vec_len, data_len),
-        63 => wire__crate__api__disputes__get_dispute_impl(port, ptr, rust_vec_len, data_len),
-        64 => wire__crate__api__escrow__get_escrow_mode_impl(port, ptr, rust_vec_len, data_len),
-        65 => wire__crate__api__identity__get_identity_impl(port, ptr, rust_vec_len, data_len),
-        66 => wire__crate__api__messages__get_messages_impl(port, ptr, rust_vec_len, data_len),
-        67 => wire__crate__api__settings__get_mostro_pubkey_impl(port, ptr, rust_vec_len, data_len),
-        68 => wire__crate__api__identity__get_nym_identity_impl(port, ptr, rust_vec_len, data_len),
-        69 => wire__crate__api__orders__get_order_impl(port, ptr, rust_vec_len, data_len),
-        70 => wire__crate__api__orders__get_orders_impl(port, ptr, rust_vec_len, data_len),
-        71 => {
+        63 => wire__crate__api__nwc__get_balance_impl(port, ptr, rust_vec_len, data_len),
+        64 => wire__crate__api__bond__get_bond_policy_impl(port, ptr, rust_vec_len, data_len),
+        65 => wire__crate__api__nostr__get_connection_state_impl(port, ptr, rust_vec_len, data_len),
+        66 => wire__crate__api__disputes__get_dispute_impl(port, ptr, rust_vec_len, data_len),
+        67 => wire__crate__api__escrow__get_escrow_mode_impl(port, ptr, rust_vec_len, data_len),
+        68 => wire__crate__api__identity__get_identity_impl(port, ptr, rust_vec_len, data_len),
+        69 => wire__crate__api__messages__get_messages_impl(port, ptr, rust_vec_len, data_len),
+        70 => wire__crate__api__settings__get_mostro_pubkey_impl(port, ptr, rust_vec_len, data_len),
+        71 => wire__crate__api__identity__get_nym_identity_impl(port, ptr, rust_vec_len, data_len),
+        72 => wire__crate__api__orders__get_order_impl(port, ptr, rust_vec_len, data_len),
+        73 => wire__crate__api__orders__get_orders_impl(port, ptr, rust_vec_len, data_len),
+        74 => {
             wire__crate__api__reputation__get_privacy_mode_impl(port, ptr, rust_vec_len, data_len)
         }
-        72 => wire__crate__api__reputation__get_rating_for_trade_impl(
+        75 => wire__crate__api__reputation__get_rating_for_trade_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        73 => wire__crate__api__nostr__get_relays_impl(port, ptr, rust_vec_len, data_len),
-        74 => wire__crate__api__settings__get_settings_impl(port, ptr, rust_vec_len, data_len),
-        75 => wire__crate__api__identity__get_trade_key_impl(port, ptr, rust_vec_len, data_len),
-        76 => wire__crate__api__orders__get_trade_role_impl(port, ptr, rust_vec_len, data_len),
-        77 => wire__crate__api__messages__get_unread_count_impl(port, ptr, rust_vec_len, data_len),
-        78 => wire__crate__api__nwc__get_wallet_impl(port, ptr, rust_vec_len, data_len),
-        79 => wire__crate__api__disputes__handle_admin_canceled_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        80 => {
-            wire__crate__api__disputes__handle_admin_settled_impl(port, ptr, rust_vec_len, data_len)
-        }
-        81 => wire__crate__api__disputes__handle_admin_took_dispute_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        82 => wire__crate__api__reputation__handle_rating_received_impl(
+        76 => wire__crate__api__nostr__get_relays_impl(port, ptr, rust_vec_len, data_len),
+        77 => wire__crate__api__settings__get_settings_impl(port, ptr, rust_vec_len, data_len),
+        78 => wire__crate__api__identity__get_trade_key_impl(port, ptr, rust_vec_len, data_len),
+        79 => wire__crate__api__orders__get_trade_role_impl(port, ptr, rust_vec_len, data_len),
+        80 => wire__crate__api__messages__get_unread_count_impl(port, ptr, rust_vec_len, data_len),
+        81 => wire__crate__api__nwc__get_wallet_impl(port, ptr, rust_vec_len, data_len),
+        82 => wire__crate__api__disputes__handle_admin_canceled_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
         83 => {
+            wire__crate__api__disputes__handle_admin_settled_impl(port, ptr, rust_vec_len, data_len)
+        }
+        84 => wire__crate__api__disputes__handle_admin_took_dispute_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        85 => wire__crate__api__reputation__handle_rating_received_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        86 => {
             wire__crate__api__identity__import_from_mnemonic_impl(port, ptr, rust_vec_len, data_len)
         }
-        84 => wire__crate__api__identity__import_from_nsec_impl(port, ptr, rust_vec_len, data_len),
-        85 => wire__crate__api__init_db_impl(port, ptr, rust_vec_len, data_len),
-        86 => wire__crate__api__nostr__initialize_impl(port, ptr, rust_vec_len, data_len),
-        87 => wire__crate__api__logging__install_log_bridge_impl(port, ptr, rust_vec_len, data_len),
-        88 => wire__crate__api__nodes__list_mostro_nodes_impl(port, ptr, rust_vec_len, data_len),
-        89 => wire__crate__api__orders__list_trades_impl(port, ptr, rust_vec_len, data_len),
-        90 => wire__crate__api__identity__load_identity_from_mnemonic_impl(
+        87 => wire__crate__api__identity__import_from_nsec_impl(port, ptr, rust_vec_len, data_len),
+        88 => wire__crate__api__init_db_impl(port, ptr, rust_vec_len, data_len),
+        89 => wire__crate__api__nostr__initialize_impl(port, ptr, rust_vec_len, data_len),
+        90 => wire__crate__api__logging__install_log_bridge_impl(port, ptr, rust_vec_len, data_len),
+        91 => wire__crate__api__nodes__list_mostro_nodes_impl(port, ptr, rust_vec_len, data_len),
+        92 => wire__crate__api__orders__list_trades_impl(port, ptr, rust_vec_len, data_len),
+        93 => wire__crate__api__identity__load_identity_from_mnemonic_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        91 => wire__crate__api__nwc__make_invoice_impl(port, ptr, rust_vec_len, data_len),
-        92 => wire__crate__api__messages__mark_as_read_impl(port, ptr, rust_vec_len, data_len),
-        93 => {
+        94 => wire__crate__api__nwc__make_invoice_impl(port, ptr, rust_vec_len, data_len),
+        95 => wire__crate__api__messages__mark_as_read_impl(port, ptr, rust_vec_len, data_len),
+        96 => {
             wire__crate__api__nodes__node_metadata_default_impl(port, ptr, rust_vec_len, data_len)
         }
-        94 => wire__crate__api__messages__on_attachment_progress_impl(
+        97 => wire__crate__api__messages__on_attachment_progress_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        95 => wire__crate__api__bond__on_bond_slashed_impl(port, ptr, rust_vec_len, data_len),
-        96 => {
+        98 => wire__crate__api__bond__on_bond_slashed_impl(port, ptr, rust_vec_len, data_len),
+        99 => {
             wire__crate__api__cashu__on_cashu_wallet_changed_impl(port, ptr, rust_vec_len, data_len)
         }
-        97 => wire__crate__api__nostr__on_connection_state_changed_impl(
+        100 => wire__crate__api__nostr__on_connection_state_changed_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        98 => {
+        101 => {
             wire__crate__api__disputes__on_dispute_updated_impl(port, ptr, rust_vec_len, data_len)
         }
-        99 => {
+        102 => {
             wire__crate__api__escrow__on_escrow_mode_changed_impl(port, ptr, rust_vec_len, data_len)
         }
-        100 => wire__crate__api__logging__on_log_entry_impl(port, ptr, rust_vec_len, data_len),
-        101 => wire__crate__api__messages__on_new_message_impl(port, ptr, rust_vec_len, data_len),
-        102 => wire__crate__api__orders__on_orders_updated_impl(port, ptr, rust_vec_len, data_len),
-        103 => {
+        103 => wire__crate__api__logging__on_log_entry_impl(port, ptr, rust_vec_len, data_len),
+        104 => wire__crate__api__messages__on_new_message_impl(port, ptr, rust_vec_len, data_len),
+        105 => wire__crate__api__orders__on_orders_updated_impl(port, ptr, rust_vec_len, data_len),
+        106 => {
             wire__crate__api__reputation__on_rating_received_impl(port, ptr, rust_vec_len, data_len)
         }
-        104 => {
+        107 => {
             wire__crate__api__nostr__on_relay_auto_synced_impl(port, ptr, rust_vec_len, data_len)
         }
-        105 => {
+        108 => {
             wire__crate__api__nostr__on_relay_status_changed_impl(port, ptr, rust_vec_len, data_len)
         }
-        106 => {
+        109 => {
             wire__crate__api__settings__on_settings_changed_impl(port, ptr, rust_vec_len, data_len)
         }
-        107 => wire__crate__api__identity__on_trade_key_index_changed_impl(
+        110 => wire__crate__api__identity__on_trade_key_index_changed_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        108 => wire__crate__api__orders__on_trade_updated_impl(port, ptr, rust_vec_len, data_len),
-        109 => wire__crate__api__messages__on_unread_count_changed_impl(
+        111 => wire__crate__api__orders__on_trade_updated_impl(port, ptr, rust_vec_len, data_len),
+        112 => wire__crate__api__messages__on_unread_count_changed_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        110 => {
+        113 => {
             wire__crate__api__nwc__on_wallet_status_changed_impl(port, ptr, rust_vec_len, data_len)
         }
-        111 => wire__crate__api__disputes__open_dispute_impl(port, ptr, rust_vec_len, data_len),
-        112 => {
+        114 => wire__crate__api__disputes__open_dispute_impl(port, ptr, rust_vec_len, data_len),
+        115 => {
             wire__crate__api__orders__order_filters_default_impl(port, ptr, rust_vec_len, data_len)
         }
-        113 => wire__crate__api__nwc__pay_invoice_impl(port, ptr, rust_vec_len, data_len),
-        114 => wire__crate__api__logging__recent_logs_impl(port, ptr, rust_vec_len, data_len),
-        115 => wire__crate__api__nodes__refresh_mostro_node_metadata_impl(
+        116 => wire__crate__api__nwc__pay_invoice_impl(port, ptr, rust_vec_len, data_len),
+        117 => wire__crate__api__logging__recent_logs_impl(port, ptr, rust_vec_len, data_len),
+        118 => wire__crate__api__nodes__refresh_mostro_node_metadata_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        116 => wire__crate__api__settings__rehydrate_active_mostro_node_impl(
+        119 => wire__crate__api__settings__rehydrate_active_mostro_node_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        117 => wire__crate__api__escrow__rehydrate_escrow_overrides_impl(
+        120 => wire__crate__api__escrow__rehydrate_escrow_overrides_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        118 => wire__crate__api__orders__release_order_impl(port, ptr, rust_vec_len, data_len),
-        119 => wire__crate__api__nodes__remove_custom_mostro_node_impl(
+        121 => wire__crate__api__orders__release_order_impl(port, ptr, rust_vec_len, data_len),
+        122 => wire__crate__api__nodes__remove_custom_mostro_node_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        120 => wire__crate__api__nostr__remove_relay_impl(port, ptr, rust_vec_len, data_len),
-        121 => wire__crate__api__orders__request_bond_invoice_again_impl(
+        123 => wire__crate__api__nostr__remove_relay_impl(port, ptr, rust_vec_len, data_len),
+        124 => wire__crate__api__orders__request_bond_invoice_again_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        122 => wire__crate__api__orders__restart_orders_subscription_impl(
+        125 => wire__crate__api__orders__restart_orders_subscription_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        123 => wire__crate__api__orders__send_fiat_sent_impl(port, ptr, rust_vec_len, data_len),
-        124 => wire__crate__api__messages__send_file_impl(port, ptr, rust_vec_len, data_len),
-        125 => wire__crate__api__orders__send_invoice_impl(port, ptr, rust_vec_len, data_len),
-        126 => wire__crate__api__messages__send_message_impl(port, ptr, rust_vec_len, data_len),
-        127 => wire__crate__api__settings__set_active_mostro_node_impl(
+        126 => wire__crate__api__orders__send_fiat_sent_impl(port, ptr, rust_vec_len, data_len),
+        127 => wire__crate__api__messages__send_file_impl(port, ptr, rust_vec_len, data_len),
+        128 => wire__crate__api__orders__send_invoice_impl(port, ptr, rust_vec_len, data_len),
+        129 => wire__crate__api__messages__send_message_impl(port, ptr, rust_vec_len, data_len),
+        130 => wire__crate__api__settings__set_active_mostro_node_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        128 => wire__crate__api__escrow__set_cashu_mint_url_override_impl(
+        131 => wire__crate__api__escrow__set_cashu_mint_url_override_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        129 => wire__crate__api__settings__set_default_fiat_code_impl(
+        132 => wire__crate__api__settings__set_default_fiat_code_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        130 => wire__crate__api__settings__set_default_lightning_address_impl(
+        133 => wire__crate__api__settings__set_default_lightning_address_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        131 => wire__crate__api__escrow__set_escrow_mode_override_impl(
+        134 => wire__crate__api__escrow__set_escrow_mode_override_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        132 => wire__crate__api__settings__set_language_impl(port, ptr, rust_vec_len, data_len),
-        133 => {
+        135 => wire__crate__api__settings__set_language_impl(port, ptr, rust_vec_len, data_len),
+        136 => {
             wire__crate__api__settings__set_logging_enabled_impl(port, ptr, rust_vec_len, data_len)
         }
-        134 => {
+        137 => {
             wire__crate__api__reputation__set_privacy_mode_impl(port, ptr, rust_vec_len, data_len)
         }
-        135 => wire__crate__api__settings__set_test_order_expiry_impl(
+        138 => wire__crate__api__settings__set_test_order_expiry_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        136 => wire__crate__api__settings__set_theme_impl(port, ptr, rust_vec_len, data_len),
-        137 => wire__crate__api__disputes__submit_evidence_impl(port, ptr, rust_vec_len, data_len),
-        138 => wire__crate__api__reputation__submit_rating_impl(port, ptr, rust_vec_len, data_len),
-        139 => wire__crate__api__orders__subscribe_orders_impl(port, ptr, rust_vec_len, data_len),
-        140 => wire__crate__api__orders__take_order_impl(port, ptr, rust_vec_len, data_len),
-        141 => {
+        139 => wire__crate__api__settings__set_theme_impl(port, ptr, rust_vec_len, data_len),
+        140 => wire__crate__api__disputes__submit_evidence_impl(port, ptr, rust_vec_len, data_len),
+        141 => wire__crate__api__reputation__submit_rating_impl(port, ptr, rust_vec_len, data_len),
+        142 => wire__crate__api__orders__subscribe_orders_impl(port, ptr, rust_vec_len, data_len),
+        143 => wire__crate__api__orders__take_order_impl(port, ptr, rust_vec_len, data_len),
+        144 => {
             wire__crate__api__invoice__trade_step_started_at_impl(port, ptr, rust_vec_len, data_len)
         }
         _ => unreachable!(),
@@ -8534,6 +8695,57 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::types::BondApplyTo>
     for crate::api::types::BondApplyTo
 {
     fn into_into_dart(self) -> crate::api::types::BondApplyTo {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::types::BondClaim {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.order_id.into_into_dart().into_dart(),
+            self.node_pubkey.into_into_dart().into_dart(),
+            self.amount_sats.into_into_dart().into_dart(),
+            self.slashed_at.into_into_dart().into_dart(),
+            self.deadline_at.into_into_dart().into_dart(),
+            self.phase.into_into_dart().into_dart(),
+            self.submitted_invoice.into_into_dart().into_dart(),
+            self.fiat_code.into_into_dart().into_dart(),
+            self.fiat_amount.into_into_dart().into_dart(),
+            self.payment_method.into_into_dart().into_dart(),
+            self.updated_at.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for crate::api::types::BondClaim {}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::types::BondClaim>
+    for crate::api::types::BondClaim
+{
+    fn into_into_dart(self) -> crate::api::types::BondClaim {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::types::BondClaimPhase {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        match self {
+            Self::Pending => 0.into_dart(),
+            Self::Submitted => 1.into_dart(),
+            Self::Acknowledged => 2.into_dart(),
+            Self::Completed => 3.into_dart(),
+            Self::Expired => 4.into_dart(),
+            _ => unreachable!(),
+        }
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::types::BondClaimPhase
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::types::BondClaimPhase>
+    for crate::api::types::BondClaimPhase
+{
+    fn into_into_dart(self) -> crate::api::types::BondClaimPhase {
         self
     }
 }
@@ -10220,6 +10432,42 @@ impl SseEncode for crate::api::types::BondApplyTo {
                 crate::api::types::BondApplyTo::Take => 0,
                 crate::api::types::BondApplyTo::Make => 1,
                 crate::api::types::BondApplyTo::Both => 2,
+                _ => {
+                    unimplemented!("");
+                }
+            },
+            serializer,
+        );
+    }
+}
+
+impl SseEncode for crate::api::types::BondClaim {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.order_id, serializer);
+        <String>::sse_encode(self.node_pubkey, serializer);
+        <u64>::sse_encode(self.amount_sats, serializer);
+        <i64>::sse_encode(self.slashed_at, serializer);
+        <i64>::sse_encode(self.deadline_at, serializer);
+        <crate::api::types::BondClaimPhase>::sse_encode(self.phase, serializer);
+        <Option<String>>::sse_encode(self.submitted_invoice, serializer);
+        <String>::sse_encode(self.fiat_code, serializer);
+        <Option<f64>>::sse_encode(self.fiat_amount, serializer);
+        <String>::sse_encode(self.payment_method, serializer);
+        <i64>::sse_encode(self.updated_at, serializer);
+    }
+}
+
+impl SseEncode for crate::api::types::BondClaimPhase {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(
+            match self {
+                crate::api::types::BondClaimPhase::Pending => 0,
+                crate::api::types::BondClaimPhase::Submitted => 1,
+                crate::api::types::BondClaimPhase::Acknowledged => 2,
+                crate::api::types::BondClaimPhase::Completed => 3,
+                crate::api::types::BondClaimPhase::Expired => 4,
                 _ => {
                     unimplemented!("");
                 }


### PR DESCRIPTION
## Summary

`docs/ANTI_ABUSE_BOND.md` Phase 3, task **T3.1** — the storage for payout claims on slashed bonds. One task, one PR: it is the only Phase 3 change touching the DB layer on both platforms.

### What changes

- **Model** (`rust/src/api/types.rs`): `BondClaim { order_id, node_pubkey, amount_sats, slashed_at, deadline_at, phase, submitted_invoice, fiat_code, fiat_amount, payment_method, updated_at }`, `BondClaimPhase { Pending, Submitted, Acknowledged, Completed, Expired }` (with `is_terminal`), `BondClaimUpdate`. Keyed by `(node_pubkey, order_id)` — the user can switch nodes while a claim is open and the submission must address the issuing daemon; `deadline_at` is frozen at first receipt so a later policy change cannot move a deadline the user was shown. Independent of the trade row (the winner's trade may be completed, cancelled or wiped).
- **SQLite** (`schema.rs`, `sqlite.rs`): `bond_claims` table per §7.3 (`id = "<node_pubkey>:<order_id>"`, JSON `data`, `node_pubkey`, `phase`, `deadline_at`, `updated_at` columns, index on `(node_pubkey, phase)`), `SCHEMA_VERSION` 3 → 4. Idempotent `CREATE … IF NOT EXISTS`, so existing databases gain the table on next open.
- **IndexedDB** (`indexeddb.rs`): `bond_claims` object store, `ALL_STORES` 8 → 9, `DB_VERSION` 3 → 4 (the upgrade hook creates the missing store).
- **`Storage` trait**: `save_bond_claim` (insert-or-replace), `get_bond_claim(node_pubkey, order_id)`, `list_bond_claims` (most recently changed first, same order on both backends), `delete_bond_claim`. The test `FailingStore` stub gains the four methods.
- FRB bindings regenerated for the new types (`bond_claim_key` is the shared key helper; the method name had to differ from the free function for codegen).

### Not in this PR
- The dispatch arms, submission call and kind-14 filter (PR-3b), the claim screen (PR-3c), list/detail/notifications (PR-3d).

## Test plan

- [x] `cargo test`: 596 passed, incl. `bond_claims_round_trip_keyed_by_node_and_order` (round trip, two nodes on one order, newest-first listing, replace on same key, delete only the matching key, delete absent is a no-op).
- [x] `cargo check --target wasm32-unknown-unknown` and `cargo clippy -D warnings` clean; `flutter analyze` clean (pre-commit hook).
- [ ] Web: the `DB_VERSION` bump is exercised by the smoke test on CI (existing store still opens, new store created).

## Manual testing

This PR adds storage only; nothing user-visible changes yet. The checks are that existing installs keep working across the schema bump.

1. Install the previous build, create or take an order so the local database has trades, then update to this build and open the app: My Trades still lists the same trades, chat history is intact, settings (active node, relays) are kept.
2. On desktop/Android, open the SQLite file and confirm `bond_claims` exists with the columns `id, node_pubkey, data, phase, deadline_at, updated_at` and the index `idx_bond_claims_node`.
3. On web, open the site with a profile that already used the app (IndexedDB at version 3), reload: no blank page, DevTools → Application → IndexedDB shows the database at version 4 with the new `bond_claims` store alongside the eight existing ones.
4. A fresh install on any platform opens normally (the table/store is created on first open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016uNEjsgPcjXGgBLpVJRkHC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for tracking anti-abuse bond payout claims through their lifecycle, from pending submission to completion or expiration.
  - Added durable storage for bond claims, including lookup, listing, replacement, and deletion.
  - Claims can be kept separate for different nodes and orders, with recent updates shown first.
  - Added cross-platform support for bond claim data and status updates in the application interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->